### PR TITLE
Fix broken assert :(

### DIFF
--- a/llarp/queue_manager.cpp
+++ b/llarp/queue_manager.cpp
@@ -335,7 +335,7 @@ namespace llarp
           // Queue is full.
           assert(state == ElementState::Reading);
           assert(
-              1 == (circularDifference(currGen, elemGen, m_maxGeneration) + 1));
+              1 == (circularDifference(currGen, elemGen, m_maxGeneration + 1)));
 
           return QueueReturn::QueueEmpty;
         }


### PR DESCRIPTION
This only happened under high contention (eg low cpu machines) which is why it wasn't caught under development.

Running in an ubunutu docker container dialed down (1 CPU + 1GB of RAM) to the max managed to reproduce this on almost every iteration.  

fixes #74