### PR TITLE
dont segfault on exit

### DIFF
--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -1120,6 +1120,7 @@ namespace llarp
   Router::AfterStopLinks()
   {
     Close();
+    m_lmq.reset();
   }
 
   void
@@ -1128,7 +1129,6 @@ namespace llarp
     StopLinks();
     nodedb()->AsyncFlushToDisk();
     _logic->call_later(200ms, std::bind(&Router::AfterStopLinks, this));
-    m_lmq.reset();
   }
 
   void
@@ -1238,6 +1238,18 @@ namespace llarp
     _outboundSessionMaker.CreateSessionTo(rc, nullptr);
 
     return true;
+  }
+
+  void
+  Router::QueueWork(std::function<void(void)> func)
+  {
+    m_lmq->job(std::move(func));
+  }
+
+  void
+  Router::QueueDiskIO(std::function<void(void)> func)
+  {
+    m_lmq->job(std::move(func), m_DiskThread);
   }
 
   bool

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -283,6 +283,8 @@ namespace llarp
 
     _nodedb = nodedb;
 
+    m_isServiceNode = conf.router.m_isRelay;
+
     if (whitelistRouters)
     {
       m_lokidRpcClient->ConnectAsync(lokidRPCAddr);
@@ -454,8 +456,6 @@ namespace llarp
 
     if (usingSNSeed)
       ident_keyfile = conf.lokid.ident_keyfile;
-
-    m_isServiceNode = conf.router.m_isRelay;
 
     networkConfig = conf.network;
 

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -170,16 +170,10 @@ namespace llarp
     }
 
     void
-    QueueWork(std::function<void(void)> func) override
-    {
-      m_lmq->job(std::move(func));
-    }
+    QueueWork(std::function<void(void)> func) override;
 
     void
-    QueueDiskIO(std::function<void(void)> func) override
-    {
-      m_lmq->job(std::move(func), m_DiskThread);
-    }
+    QueueDiskIO(std::function<void(void)> func) override;
 
     IpAddress _ourAddress;
 


### PR DESCRIPTION
the `std::shared_ptr` for lmq was destroyed to early in the shutdown phase.