### PR TITLE
Config file improvements

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,7 +14,23 @@ AlwaysBreakAfterDefinitionReturnType: All
 AlwaysBreakAfterReturnType: All
 AlwaysBreakTemplateDeclarations: 'true'
 BreakBeforeBinaryOperators: NonAssignment
-BreakBeforeBraces: Allman
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
 BreakBeforeTernaryOperators: 'true'
 BreakConstructorInitializersBeforeComma: 'true'
 Cpp11BracedListStyle: 'true'

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -259,7 +259,8 @@ run_main_context(const fs::path confFile, const llarp::RuntimeOptions opts)
     llarp::LogInfo("Using config file: ", confFile);
 
     llarp::Config conf;
-    conf.Load(confFile, opts.isRouter, confFile.parent_path());
+    if (!conf.Load(confFile, opts.isRouter, confFile.parent_path()))
+      throw std::runtime_error{"Config file parsing failed"};
 
     ctx = std::make_shared<llarp::Context>();
     ctx->Configure(conf);

--- a/jni/lokinet_jni_vpnio.hpp
+++ b/jni/lokinet_jni_vpnio.hpp
@@ -133,18 +133,15 @@ struct lokinet_jni_vpnio : public lokinet::VPNIO
 {
   void
   InjectSuccess() override
-  {
-  }
+  {}
 
   void
   InjectFail() override
-  {
-  }
+  {}
 
   void
   Tick() override
-  {
-  }
+  {}
 };
 
 #endif

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -570,7 +570,16 @@ namespace llarp
 
     // TODO: support SRV records for routers, but for now client only
     conf.defineOption<std::string>(
-        "network", "srv", ClientOnly, MultiValue, [this](std::string arg) {
+        "network",
+        "srv",
+        ClientOnly,
+        MultiValue,
+        Comment{
+            "Specify SRV Records for services hosted on the SNApp",
+            "for more info see https://docs.loki.network/Lokinet/Guides/HostingSNApps/",
+            "srv=_service._protocol priority weight port target.loki",
+        },
+        [this](std::string arg) {
           llarp::dns::SRVData newSRV;
           if (not newSRV.fromString(arg))
             throw std::invalid_argument(stringify("Invalid SRV Record string: ", arg));

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -17,6 +17,7 @@
 #include <fstream>
 #include <ios>
 #include <iostream>
+#include "constants/version.hpp"
 
 namespace llarp
 {
@@ -29,51 +30,81 @@ namespace llarp
 
   constexpr int DefaultPublicPort = 1090;
 
+  using namespace config;
+
   void
   RouterConfig::defineConfigOptions(ConfigDefinition& conf, const ConfigGenParameters& params)
   {
-    constexpr int DefaultJobQueueSize = 1024 * 8;
-    constexpr auto DefaultNetId = "lokinet";
-    constexpr int DefaultWorkerThreads = 1;
-    constexpr int DefaultNetThreads = 1;
-    constexpr bool DefaultBlockBogons = true;
+    constexpr Default DefaultJobQueueSize{1024 * 8};
+    constexpr Default DefaultWorkerThreads{0};
+    constexpr Default DefaultBlockBogons{true};
 
-    conf.defineOption<int>("router", "job-queue-size", false, DefaultJobQueueSize, [this](int arg) {
-      if (arg < 1024)
-        throw std::invalid_argument("job-queue-size must be 1024 or greater");
+    conf.defineOption<int>(
+        "router", "job-queue-size", DefaultJobQueueSize, Hidden, [this](int arg) {
+          if (arg < 1024)
+            throw std::invalid_argument("job-queue-size must be 1024 or greater");
 
-      m_JobQueueSize = arg;
-    });
+          m_JobQueueSize = arg;
+        });
 
-    conf.defineOption<std::string>("router", "netid", false, DefaultNetId, [this](std::string arg) {
-      if (arg.size() > NetID::size())
-        throw std::invalid_argument(stringify("netid is too long, max length is ", NetID::size()));
+    conf.defineOption<std::string>(
+        "router",
+        "netid",
+        Default{llarp::DEFAULT_NETID},
+        Comment{
+            "Network ID; this is '"s + llarp::DEFAULT_NETID + "' for mainnet, 'gamma' for testnet.",
+        },
+        [this](std::string arg) {
+          if (arg.size() > NetID::size())
+            throw std::invalid_argument(
+                stringify("netid is too long, max length is ", NetID::size()));
 
-      m_netId = std::move(arg);
-    });
+          m_netId = std::move(arg);
+        });
 
     int minConnections =
         (params.isRelay ? DefaultMinConnectionsForRouter : DefaultMinConnectionsForClient);
-    conf.defineOption<int>("router", "min-connections", false, minConnections, [=](int arg) {
-      if (arg < minConnections)
-        throw std::invalid_argument(stringify("min-connections must be >= ", minConnections));
+    conf.defineOption<int>(
+        "router",
+        "min-connections",
+        Default{minConnections},
+        Comment{
+            "Minimum number of routers lokinet will attempt to maintain connections to.",
+        },
+        [=](int arg) {
+          if (arg < minConnections)
+            throw std::invalid_argument(stringify("min-connections must be >= ", minConnections));
 
-      m_minConnectedRouters = arg;
-    });
+          m_minConnectedRouters = arg;
+        });
 
     int maxConnections =
         (params.isRelay ? DefaultMaxConnectionsForRouter : DefaultMaxConnectionsForClient);
-    conf.defineOption<int>("router", "max-connections", false, maxConnections, [=](int arg) {
-      if (arg < maxConnections)
-        throw std::invalid_argument(stringify("max-connections must be >= ", maxConnections));
+    conf.defineOption<int>(
+        "router",
+        "max-connections",
+        Default{maxConnections},
+        Comment{
+            "Maximum number (hard limit) of routers lokinet will be connected to at any time.",
+        },
+        [=](int arg) {
+          if (arg < maxConnections)
+            throw std::invalid_argument(stringify("max-connections must be >= ", maxConnections));
 
-      m_maxConnectedRouters = arg;
-    });
+          m_maxConnectedRouters = arg;
+        });
 
-    conf.defineOption<std::string>("router", "nickname", false, "", AssignmentAcceptor(m_nickname));
+    conf.defineOption<std::string>("router", "nickname", Hidden, AssignmentAcceptor(m_nickname));
 
     conf.defineOption<fs::path>(
-        "router", "data-dir", false, params.defaultDataDir, [this](fs::path arg) {
+        "router",
+        "data-dir",
+        Default{params.defaultDataDir},
+        Comment{
+            "Optional directory for containing lokinet runtime data. This includes generated",
+            "private keys.",
+        },
+        [this](fs::path arg) {
           if (not fs::exists(arg))
             throw std::runtime_error(
                 stringify("Specified [router]:data-dir ", arg, " does not exist"));
@@ -81,19 +112,28 @@ namespace llarp
           m_dataDir = std::move(arg);
         });
 
-    conf.defineOption<std::string>("router", "public-ip", false, "", [this](std::string arg) {
-      if (not arg.empty())
-      {
-        llarp::LogInfo("public ip ", arg, " size ", arg.size());
+    conf.defineOption<std::string>(
+        "router",
+        "public-ip",
+        RelayOnly,
+        Comment{
+            "For complex network configurations where the detected IP is incorrect or non-public",
+            "this setting specifies the public IP at which this router is reachable. When",
+            "provided the public-port option must also be specified.",
+        },
+        [this](std::string arg) {
+          if (not arg.empty())
+          {
+            llarp::LogInfo("public ip ", arg, " size ", arg.size());
 
-        if (arg.size() > 15)
-          throw std::invalid_argument(stringify("Not a valid IPv4 addr: ", arg));
+            if (arg.size() > 15)
+              throw std::invalid_argument(stringify("Not a valid IPv4 addr: ", arg));
 
-        m_publicAddress.setAddress(arg);
-      }
-    });
+            m_publicAddress.setAddress(arg);
+          }
+        });
 
-    conf.defineOption<std::string>("router", "public-address", false, "", [this](std::string arg) {
+    conf.defineOption<std::string>("router", "public-address", Hidden, [this](std::string arg) {
       if (not arg.empty())
       {
         llarp::LogWarn(
@@ -101,7 +141,7 @@ namespace llarp
             arg,
             " is deprecated, use public-ip=",
             arg,
-            " instead.");
+            " instead to avoid this warning and avoid future configuration problems.");
 
         if (arg.size() > 15)
           throw std::invalid_argument(stringify("Not a valid IPv4 addr: ", arg));
@@ -110,49 +150,91 @@ namespace llarp
       }
     });
 
-    conf.defineOption<int>("router", "public-port", false, DefaultPublicPort, [this](int arg) {
-      if (arg <= 0 || arg > std::numeric_limits<uint16_t>::max())
-        throw std::invalid_argument("public-port must be >= 0 and <= 65536");
+    conf.defineOption<int>(
+        "router",
+        "public-port",
+        RelayOnly,
+        Default{DefaultPublicPort},
+        Comment{
+            "When specifying public-ip=, this specifies the public UDP port at which this lokinet",
+            "router is reachable. Required when public-ip is used.",
+        },
+        [this](int arg) {
+          if (arg <= 0 || arg > std::numeric_limits<uint16_t>::max())
+            throw std::invalid_argument("public-port must be >= 0 and <= 65536");
 
-      m_publicAddress.setPort(arg);
-    });
+          m_publicAddress.setPort(arg);
+        });
 
     conf.defineOption<int>(
-        "router", "worker-threads", false, DefaultWorkerThreads, [this](int arg) {
-          if (arg <= 0)
-            throw std::invalid_argument("worker-threads must be > 0");
+        "router",
+        "worker-threads",
+        DefaultWorkerThreads,
+        Comment{
+            "The number of threads available for performing cryptographic functions.",
+            "The minimum is one thread, but network performance may increase with more.",
+            "threads. Should not exceed the number of logical CPU cores.",
+            "0 means use the number of logical CPU cores detected at startup.",
+        },
+        [this](int arg) {
+          if (arg < 0)
+            throw std::invalid_argument("worker-threads must be >= 0");
 
           m_workerThreads = arg;
         });
 
-    conf.defineOption<int>("router", "net-threads", false, DefaultNetThreads, [this](int arg) {
-      if (arg <= 0)
-        throw std::invalid_argument("net-threads must be > 0");
-
-      m_numNetThreads = arg;
-    });
-
+    // Hidden option because this isn't something that should ever be turned off occasionally when
+    // doing dev/testing work.
     conf.defineOption<bool>(
-        "router", "block-bogons", false, DefaultBlockBogons, AssignmentAcceptor(m_blockBogons));
+        "router", "block-bogons", DefaultBlockBogons, Hidden, AssignmentAcceptor(m_blockBogons));
+
+    constexpr auto relative_to_datadir =
+        "An absolute path is used as-is, otherwise relative to 'data-dir'.";
 
     conf.defineOption<std::string>(
-        "router", "contact-file", false, "", AssignmentAcceptor(m_routerContactFile));
-
-    conf.defineOption<std::string>(
-        "router", "encryption-privkey", false, "", AssignmentAcceptor(m_encryptionKeyFile));
-
-    conf.defineOption<std::string>(
-        "router", "ident-privkey", false, "", AssignmentAcceptor(m_identityKeyFile));
-
-    conf.defineOption<std::string>(
-        "router", "transport-privkey", false, "", AssignmentAcceptor(m_transportKeyFile));
-
-    conf.defineOption<bool>(
         "router",
-        "enable-peer-stats",
-        false,
-        params.isRelay,
-        AssignmentAcceptor(m_enablePeerStats));
+        "contact-file",
+        RelayOnly,
+        Default{llarp::our_rc_filename},
+        AssignmentAcceptor(m_routerContactFile),
+        Comment{
+            "Filename in which to store the router contact file",
+            relative_to_datadir,
+        });
+
+    conf.defineOption<std::string>(
+        "router",
+        "encryption-privkey",
+        RelayOnly,
+        Default{llarp::our_enc_key_filename},
+        AssignmentAcceptor(m_encryptionKeyFile),
+        Comment{
+            "Filename in which to store the encryption private key",
+            relative_to_datadir,
+        });
+
+    conf.defineOption<std::string>(
+        "router",
+        "ident-privkey",
+        RelayOnly,
+        Default{llarp::our_identity_filename},
+        AssignmentAcceptor(m_identityKeyFile),
+        Comment{
+            "Filename in which to store the identity private key",
+            relative_to_datadir,
+        });
+
+    conf.defineOption<std::string>(
+        "router",
+        "transport-privkey",
+        RelayOnly,
+        Default{llarp::our_transport_key_filename},
+        AssignmentAcceptor(m_transportKeyFile),
+        Comment{
+            "Filename in which to store the transport private key.",
+            relative_to_datadir,
+        });
+
     m_isRelay = params.isRelay;
   }
 
@@ -161,53 +243,91 @@ namespace llarp
   {
     (void)params;
 
-    constexpr bool DefaultProfilingValue = true;
-    static constexpr bool ReachableDefault = true;
-    static constexpr int HopsDefault = 4;
-    static constexpr int PathsDefault = 6;
+    static constexpr Default ProfilingValueDefault{false};
+    static constexpr Default ReachableDefault{true};
+    static constexpr Default HopsDefault{4};
+    static constexpr Default PathsDefault{6};
 
     conf.defineOption<std::string>(
-        "network", "type", false, "tun", AssignmentAcceptor(m_endpointType));
-
-    conf.defineOption<bool>("network", "exit", false, false, AssignmentAcceptor(m_AllowExit));
+        "network", "type", Default{"tun"}, Hidden, AssignmentAcceptor(m_endpointType));
 
     conf.defineOption<bool>(
         "network",
         "profiling",
-        false,
-        DefaultProfilingValue,
+        ProfilingValueDefault,
+        Hidden,
         AssignmentAcceptor(m_enableProfiling));
 
-    // TODO: this should be implied from [router]:data-dir
     conf.defineOption<std::string>(
         "network",
-        "profiles",
-        false,
-        m_routerProfilesFile,
-        AssignmentAcceptor(m_routerProfilesFile));
+        "strict-connect",
+        ClientOnly,
+        AssignmentAcceptor(m_strictConnect),
+        Comment{
+            "Public key of a router which will act as sole first-hop. This may be used to",
+            "provide a trusted router (consider that you are not fully anonymous with your",
+            "first hop).",
+        });
 
     conf.defineOption<std::string>(
-        "network", "strict-connect", false, "", AssignmentAcceptor(m_strictConnect));
-
-    conf.defineOption<std::string>("network", "keyfile", false, "", AssignmentAcceptor(m_keyfile));
-
-    conf.defineOption<std::string>("network", "auth", false, "", [this](std::string arg) {
-      if (arg.empty())
-        return;
-      m_AuthType = service::ParseAuthType(arg);
-    });
-
-    conf.defineOption<std::string>("network", "auth-lmq", false, "", AssignmentAcceptor(m_AuthUrl));
+        "network",
+        "keyfile",
+        ClientOnly,
+        AssignmentAcceptor(m_keyfile),
+        Comment{
+            "The private key to persist address with. If not specified the address will be",
+            "ephemeral.",
+        });
 
     conf.defineOption<std::string>(
-        "network", "auth-lmq-method", false, "llarp.auth", [this](std::string arg) {
+        "network",
+        "auth",
+        ClientOnly,
+        Comment{
+            "Set the endpoint authentication mechanism.",
+            "none/whitelist/lmq",
+        },
+        [this](std::string arg) {
+          if (arg.empty())
+            return;
+          m_AuthType = service::ParseAuthType(arg);
+        });
+
+    conf.defineOption<std::string>(
+        "network",
+        "auth-lmq",
+        ClientOnly,
+        AssignmentAcceptor(m_AuthUrl),
+        Comment{
+            "lmq endpoint to talk to for authenticating new sessions",
+            "ipc:///var/lib/lokinet/auth.socket",
+            "tcp://127.0.0.1:5555",
+        });
+
+    conf.defineOption<std::string>(
+        "network",
+        "auth-lmq-method",
+        ClientOnly,
+        Default{"llarp.auth"},
+        Comment{
+            "lmq function to call for authenticating new sessions",
+            "llarp.auth",
+        },
+        [this](std::string arg) {
           if (arg.empty())
             return;
           m_AuthMethod = std::move(arg);
         });
 
     conf.defineOption<std::string>(
-        "network", "auth-whitelist", false, true, "", [this](std::string arg) {
+        "network",
+        "auth-whitelist",
+        ClientOnly,
+        MultiValue,
+        Comment{
+            "manually add a remote endpoint by .loki address to the access whitelist",
+        },
+        [this](std::string arg) {
           service::Address addr;
           if (not addr.FromString(arg))
             throw std::invalid_argument(stringify("bad loki address: ", arg));
@@ -215,125 +335,230 @@ namespace llarp
         });
 
     conf.defineOption<bool>(
-        "network", "reachable", false, ReachableDefault, AssignmentAcceptor(m_reachable));
+        "network",
+        "reachable",
+        ClientOnly,
+        ReachableDefault,
+        AssignmentAcceptor(m_reachable),
+        Comment{
+            "Determines whether we will publish our snapp's introset to the DHT.",
+        });
 
-    conf.defineOption<int>("network", "hops", false, HopsDefault, [this](int arg) {
-      if (arg < 1 or arg > 8)
-        throw std::invalid_argument("[endpoint]:hops must be >= 1 and <= 8");
-      m_Hops = arg;
-    });
+    conf.defineOption<int>(
+        "network",
+        "hops",
+        HopsDefault,
+        Comment{
+            "Number of hops in a path. Min 1, max 8.",
+        },
+        [this](int arg) {
+          if (arg < 1 or arg > 8)
+            throw std::invalid_argument("[endpoint]:hops must be >= 1 and <= 8");
+          m_Hops = arg;
+        });
 
-    conf.defineOption<int>("network", "paths", false, PathsDefault, [this](int arg) {
-      if (arg < 2 or arg > 8)
-        throw std::invalid_argument("[endpoint]:paths must be >= 2 and <= 8");
-      m_Paths = arg;
-    });
+    conf.defineOption<int>(
+        "network",
+        "paths",
+        ClientOnly,
+        PathsDefault,
+        Comment{
+            "Number of paths to maintain at any given time.",
+        },
+        [this](int arg) {
+          if (arg < 2 or arg > 8)
+            throw std::invalid_argument("[endpoint]:paths must be >= 2 and <= 8");
+          m_Paths = arg;
+        });
 
-    conf.defineOption<std::string>("network", "exit-auth", false, "", [this](std::string arg) {
-      if (arg.empty())
-        return;
-      service::Address exit;
-      service::AuthInfo auth;
-      const auto pos = arg.find(":");
-      if (pos == std::string::npos)
-      {
-        throw std::invalid_argument(
-            "[network]:exit-auth invalid format, expects exit-address.loki:auth-code-goes-here");
-      }
-      const auto exit_str = arg.substr(0, pos);
-      auth.token = arg.substr(pos + 1);
-      if (not exit.FromString(exit_str))
-      {
-        throw std::invalid_argument("[network]:exit-auth invalid exit address");
-      }
-      m_ExitAuths.emplace(exit, auth);
-    });
+    conf.defineOption<bool>(
+        "network",
+        "exit",
+        ClientOnly,
+        Default{false},
+        AssignmentAcceptor(m_AllowExit),
+        Comment{
+            "Whether or not we should act as an exit node. Beware that this increases demand",
+            "on the server and may pose liability concerns. Enable at your own risk.",
+        });
 
-    conf.defineOption<std::string>("network", "exit-node", false, "", [this](std::string arg) {
-      if (arg.empty())
-        return;
-      service::Address exit;
-      IPRange range;
-      const auto pos = arg.find(":");
-      if (pos == std::string::npos)
-      {
-        range.FromString("0.0.0.0/0");
-      }
-      else if (not range.FromString(arg.substr(pos + 1)))
-      {
-        throw std::invalid_argument("[network]:exit-node invalid ip range for exit provided");
-      }
-      if (pos != std::string::npos)
-      {
-        arg = arg.substr(0, pos);
-      }
-      if (not exit.FromString(arg))
-      {
-        throw std::invalid_argument(stringify("[network]:exit-node bad address: ", arg));
-      }
-      m_ExitMap.Insert(range, exit);
-    });
+    // TODO: not implemented yet!
+    // TODO: define the order of precedence (e.g. is whitelist applied before blacklist?)
+    //       additionally, what's default? What if I don't whitelist anything?
+    /*
+    conf.defineOption<std::string>("network", "exit-whitelist", MultiValue, Comment{
+            "List of destination protocol:port pairs to whitelist, example: udp:*",
+            "or tcp:80. Multiple values supported.",
+        }, FIXME-acceptor);
 
-    conf.defineOption<std::string>("network", "mapaddr", false, true, "", [this](std::string arg) {
-      if (arg.empty())
-        return;
-      huint128_t ip;
-      service::Address addr;
-      const auto pos = arg.find(":");
-      if (pos == std::string::npos)
-      {
-        throw std::invalid_argument(stringify("[endpoint]:mapaddr invalid entry: ", arg));
-      }
-      std::string addrstr = arg.substr(0, pos);
-      std::string ipstr = arg.substr(pos + 1);
-      if (not ip.FromString(ipstr))
-      {
-        huint32_t ipv4;
-        if (not ipv4.FromString(ipstr))
-        {
-          throw std::invalid_argument(stringify("[endpoint]:mapaddr invalid ip: ", ipstr));
-        }
-        ip = net::ExpandV4(ipv4);
-      }
-      if (not addr.FromString(addrstr))
-      {
-        throw std::invalid_argument(stringify("[endpoint]:mapaddr invalid addresss: ", addrstr));
-      }
-      if (m_mapAddrs.find(ip) != m_mapAddrs.end())
-      {
-        throw std::invalid_argument(stringify("[endpoint]:mapaddr ip already mapped: ", ipstr));
-      }
-      m_mapAddrs[ip] = addr;
-    });
-
-    conf.defineOption<std::string>("network", "ifaddr", false, "", [this](std::string arg) {
-      if (arg.empty())
-      {
-        const auto maybe = llarp::FindFreeRange();
-        if (not maybe)
-          throw std::invalid_argument("cannot determine free ip range");
-        m_ifaddr = *maybe;
-        return;
-      }
-      if (not m_ifaddr.FromString(arg))
-      {
-        throw std::invalid_argument(stringify("[network]:ifaddr invalid value: ", arg));
-      }
-    });
-
-    conf.defineOption<std::string>("network", "ifname", false, "", [this](std::string arg) {
-      if (arg.empty())
-      {
-        const auto maybe = llarp::FindFreeTun();
-        if (not maybe)
-          throw std::invalid_argument("cannot determine free interface name");
-        arg = *maybe;
-      }
-      m_ifname = arg;
-    });
+    conf.defineOption<std::string>("network", "exit-blacklist", MultiValue, Comment{
+            "Blacklist of destinations (same format as whitelist).",
+        }, FIXME-acceptor);
+    */
 
     conf.defineOption<std::string>(
-        "network", "blacklist-snode", false, true, "", [this](std::string arg) {
+        "network",
+        "exit-node",
+        ClientOnly,
+        Comment{
+            "Specify a `.loki` address and an optional ip range to use as an exit broker.",
+            "Example:",
+            "exit-node=whatever.loki # maps all exit traffic to whatever.loki",
+            "exit-node=stuff.loki:100.0.0.0/24 # maps 100.0.0.0/24 to stuff.loki",
+        },
+        [this](std::string arg) {
+          if (arg.empty())
+            return;
+          service::Address exit;
+          IPRange range;
+          const auto pos = arg.find(":");
+          if (pos == std::string::npos)
+          {
+            range.FromString("0.0.0.0/0");
+          }
+          else if (not range.FromString(arg.substr(pos + 1)))
+          {
+            throw std::invalid_argument("[network]:exit-node invalid ip range for exit provided");
+          }
+          if (pos != std::string::npos)
+          {
+            arg = arg.substr(0, pos);
+          }
+          if (not exit.FromString(arg))
+          {
+            throw std::invalid_argument(stringify("[network]:exit-node bad address: ", arg));
+          }
+          m_ExitMap.Insert(range, exit);
+        });
+
+    conf.defineOption<std::string>(
+        "network",
+        "exit-auth",
+        ClientOnly,
+        Comment{
+            "Specify an optional authentication code required to use a non-public exit node.",
+            "For example:",
+            "    exit-auth=myfavouriteexit.loki:abc",
+            "uses the authentication code `abc` whenever myfavouriteexit.loki is accessed.",
+            "Can be specified multiple time to store codes for different exit nodes.",
+        },
+        [this](std::string arg) {
+          if (arg.empty())
+            return;
+          service::Address exit;
+          service::AuthInfo auth;
+          const auto pos = arg.find(":");
+          if (pos == std::string::npos)
+          {
+            throw std::invalid_argument(
+                "[network]:exit-auth invalid format, expects "
+                "exit-address.loki:auth-code-goes-here");
+          }
+          const auto exit_str = arg.substr(0, pos);
+          auth.token = arg.substr(pos + 1);
+          if (not exit.FromString(exit_str))
+          {
+            throw std::invalid_argument("[network]:exit-auth invalid exit address");
+          }
+          m_ExitAuths.emplace(exit, auth);
+        });
+
+    conf.defineOption<std::string>(
+        "network",
+        "ifname",
+        Comment{
+            "Interface name for lokinet traffic. If unset lokinet will look for a free name",
+            "lokinetN, starting at 0 (e.g. lokinet0, lokinet1, ...).",
+        },
+        [this](std::string arg) {
+          if (arg.empty())
+          {
+            const auto maybe = llarp::FindFreeTun();
+            if (not maybe)
+              throw std::invalid_argument("cannot determine free interface name");
+            arg = *maybe;
+          }
+          m_ifname = arg;
+        });
+
+    conf.defineOption<std::string>(
+        "network",
+        "ifaddr",
+        Comment{
+            "Local IP and range for lokinet traffic. For example, 172.16.0.1/16 to use",
+            "172.16.0.1 for this machine and 172.16.x.y for remote peers. If omitted then",
+            "lokinet will attempt to find an unused private range.",
+        },
+        [this](std::string arg) {
+          if (arg.empty())
+          {
+            const auto maybe = llarp::FindFreeRange();
+            if (not maybe)
+              throw std::invalid_argument("cannot determine free ip range");
+            m_ifaddr = *maybe;
+            return;
+          }
+          if (not m_ifaddr.FromString(arg))
+          {
+            throw std::invalid_argument(stringify("[network]:ifaddr invalid value: ", arg));
+          }
+        });
+
+    // TODO: could be useful for snodes in the future, but currently only implemented for clients:
+    conf.defineOption<std::string>(
+        "network",
+        "mapaddr",
+        ClientOnly,
+        MultiValue,
+        Comment{
+            "Map a remote `.loki` address to always use a fixed local IP. For example:",
+            "    mapaddr=whatever.loki:172.16.0.10",
+            "maps `whatever.loki` to `172.16.0.10` instead of using the next available IP.",
+            "The given IP address must be inside the range configured by ifaddr=",
+        },
+        [this](std::string arg) {
+          if (arg.empty())
+            return;
+          huint128_t ip;
+          service::Address addr;
+          const auto pos = arg.find(":");
+          if (pos == std::string::npos)
+          {
+            throw std::invalid_argument(stringify("[endpoint]:mapaddr invalid entry: ", arg));
+          }
+          std::string addrstr = arg.substr(0, pos);
+          std::string ipstr = arg.substr(pos + 1);
+          if (not ip.FromString(ipstr))
+          {
+            huint32_t ipv4;
+            if (not ipv4.FromString(ipstr))
+            {
+              throw std::invalid_argument(stringify("[endpoint]:mapaddr invalid ip: ", ipstr));
+            }
+            ip = net::ExpandV4(ipv4);
+          }
+          if (not addr.FromString(addrstr))
+          {
+            throw std::invalid_argument(
+                stringify("[endpoint]:mapaddr invalid addresss: ", addrstr));
+          }
+          if (m_mapAddrs.find(ip) != m_mapAddrs.end())
+          {
+            throw std::invalid_argument(stringify("[endpoint]:mapaddr ip already mapped: ", ipstr));
+          }
+          m_mapAddrs[ip] = addr;
+        });
+
+    conf.defineOption<std::string>(
+        "network",
+        "blacklist-snode",
+        ClientOnly,
+        MultiValue,
+        Comment{
+            "Adds a lokinet relay `.snode` address to the list of relays to avoid when",
+            "building paths. Can be specified multiple times.",
+        },
+        [this](std::string arg) {
           RouterID id;
           if (not id.FromString(arg))
             throw std::invalid_argument(stringify("Invalid RouterID: ", arg));
@@ -343,13 +568,15 @@ namespace llarp
             throw std::invalid_argument(stringify("Duplicate blacklist-snode: ", arg));
         });
 
-    conf.defineOption<std::string>("network", "srv", false, true, "", [this](std::string arg) {
-      llarp::dns::SRVData newSRV;
-      if (not newSRV.fromString(arg))
-        throw std::invalid_argument(stringify("Invalid SRV Record string: ", arg));
+    // TODO: support SRV records for routers, but for now client only
+    conf.defineOption<std::string>(
+        "network", "srv", ClientOnly, MultiValue, [this](std::string arg) {
+          llarp::dns::SRVData newSRV;
+          if (not newSRV.fromString(arg))
+            throw std::invalid_argument(stringify("Invalid SRV Record string: ", arg));
 
-      m_SRVRecords.push_back(std::move(newSRV));
-    });
+          m_SRVRecords.push_back(std::move(newSRV));
+        });
   }
 
   void
@@ -357,16 +584,20 @@ namespace llarp
   {
     (void)params;
 
+    constexpr Default DefaultDNSBind{"127.3.2.1:53"};
     // Default, but if we get any upstream (including upstream=, i.e. empty string) we clear it
-    constexpr auto DefaultUpstreamDNS = "1.1.1.1";
-    m_upstreamDNS.emplace_back(DefaultUpstreamDNS);
+    constexpr Default DefaultUpstreamDNS{"1.1.1.1"};
+    m_upstreamDNS.emplace_back(DefaultUpstreamDNS.val);
 
     conf.defineOption<std::string>(
         "dns",
         "upstream",
-        false,
-        true,
         DefaultUpstreamDNS,
+        MultiValue,
+        Comment{
+            "Upstream resolver(s) to use as fallback for non-loki addresses.",
+            "Multiple values accepted.",
+        },
         [=, first = true](std::string arg) mutable {
           if (first)
           {
@@ -384,14 +615,29 @@ namespace llarp
           }
         });
 
-    conf.defineOption<std::string>("dns", "bind", false, "127.3.2.1:53", [=](std::string arg) {
-      m_bind = IpAddress{std::move(arg)};
-      if (!m_bind.getPort())
-        m_bind.setPort(53);
-    });
+    conf.defineOption<std::string>(
+        "dns",
+        "bind",
+        DefaultDNSBind,
+        Comment{
+            "Address to bind to for handling DNS requests.",
+        },
+        [=](std::string arg) {
+          m_bind = IpAddress{std::move(arg)};
+          if (!m_bind.getPort())
+            m_bind.setPort(53);
+        });
 
     // Ignored option (used by the systemd service file to disable resolvconf configuration).
-    conf.defineOption<bool>("dns", "no-resolvconf", false, false);
+    conf.defineOption<bool>(
+        "dns",
+        "no-resolvconf",
+        ClientOnly,
+        Comment{
+            "Can be uncommented and set to 1 to disable resolvconf configuration of lokinet DNS.",
+            "(This is not used directly by lokinet itself, but by the lokinet init scripts",
+            "on systems which use resolveconf)",
+        });
   }
 
   LinksConfig::LinkInfo
@@ -437,12 +683,45 @@ namespace llarp
   {
     (void)params;
 
-    constexpr auto DefaultOutboundLinkValue = "0";
+    constexpr Default DefaultOutboundLinkValue{"0"};
+
+    conf.addSectionComments(
+        "bind",
+        {
+            "This section specifies network interface names and/or IPs as keys, and",
+            "ports as values to control the address(es) on which Lokinet listens for",
+            "incoming data.",
+            "",
+            "Examples:",
+            "",
+            "    eth0=1090",
+            "    0.0.0.0=1090",
+            "    1.2.3.4=1090",
+            "",
+            "The first bind to port 1090 on the network interface 'eth0'; the second binds",
+            "to port 1090 on all local network interfaces; and the third example binds to",
+            "port 1090 on the given IP address.",
+            "",
+            "If a private range IP address (or an interface with a private IP) is given, or",
+            "if the 0.0.0.0 all-address IP is given then you must also specify the",
+            "public-ip= and public-port= settings in the [router] section with a public",
+            "address at which this router can be reached.",
+            ""
+            "Typically this section can be left blank: if no inbound bind addresses are",
+            "configured then lokinet will search for a local network interface with a public",
+            "IP address and use that (with port 1090).",
+        });
 
     conf.defineOption<std::string>(
-        "bind", "*", false, false, DefaultOutboundLinkValue, [this](std::string arg) {
-          m_OutboundLink = LinkInfoFromINIValues("*", arg);
-        });
+        "bind",
+        "*",
+        DefaultOutboundLinkValue,
+        Comment{
+            "Specify a source port for **outgoing** Lokinet traffic, for example if you want to",
+            "set up custom firewall rules based on the originating port. Typically this should",
+            "be left unset to automatically choose random source ports.",
+        },
+        [this](std::string arg) { m_OutboundLink = LinkInfoFromINIValues("*", arg); });
 
     if (std::string best_if; GetBestNetIF(best_if))
       m_InboundLinks.push_back(LinkInfoFromINIValues(best_if, std::to_string(DefaultPublicPort)));
@@ -495,22 +774,35 @@ namespace llarp
   void
   ApiConfig::defineConfigOptions(ConfigDefinition& conf, const ConfigGenParameters& params)
   {
-    constexpr auto DefaultRPCBindAddr = "tcp://127.0.0.1:1190";
+    constexpr Default DefaultRPCBindAddr{"tcp://127.0.0.1:1190"};
 
     conf.defineOption<bool>(
-        "api", "enabled", false, not params.isRelay, AssignmentAcceptor(m_enableRPCServer));
+        "api",
+        "enabled",
+        Default{not params.isRelay},
+        AssignmentAcceptor(m_enableRPCServer),
+        Comment{
+            "Determines whether or not the LMQ JSON API is enabled. Defaults ",
+        });
 
     conf.defineOption<std::string>(
-        "api", "bind", false, DefaultRPCBindAddr, [this](std::string arg) {
+        "api",
+        "bind",
+        DefaultRPCBindAddr,
+        [this](std::string arg) {
           if (arg.empty())
           {
-            arg = DefaultRPCBindAddr;
+            arg = DefaultRPCBindAddr.val;
           }
           if (arg.find("://") == std::string::npos)
           {
             arg = "tcp://" + arg;
           }
           m_rpcBindAddr = std::move(arg);
+        },
+        Comment{
+            "IP address and port to bind to.",
+            "Recommend localhost-only for security purposes.",
         });
 
     // TODO: this was from pre-refactor:
@@ -522,33 +814,39 @@ namespace llarp
   {
     (void)params;
 
-    constexpr auto DefaultLokidRPCAddr = "tcp://127.0.0.1:22023";
-
-    conf.defineOption<std::string>(
-        "lokid", "service-node-seed", false, our_identity_filename, [this](std::string arg) {
-          if (not arg.empty())
-          {
-            usingSNSeed = true;
-            ident_keyfile = std::move(arg);
-          }
-        });
-
     conf.defineOption<bool>(
-        "lokid", "enabled", false, params.isRelay, AssignmentAcceptor(whitelistRouters));
+        "lokid",
+        "enabled",
+        RelayOnly,
+        Default{true},
+        Comment{
+            "Whether or not we should talk to lokid. Must be enabled for staked routers.",
+        },
+        AssignmentAcceptor(whitelistRouters));
 
-    conf.defineOption<std::string>("lokid", "jsonrpc", false, "", [](std::string arg) {
+    conf.defineOption<std::string>("lokid", "jsonrpc", RelayOnly, [](std::string arg) {
       if (arg.empty())
         return;
       throw std::invalid_argument(
-          "the [lokid]::jsonrpc option is deprecated please use the "
-          "[lokid]::rpc "
-          "config option instead");
+          "the [lokid]:jsonrpc option is no longer supported; please use the [lokid]:rpc config "
+          "option instead with lokid's lmq-local-control address -- typically a value such as "
+          "rpc=ipc:///var/lib/loki/lokid.sock or rpc=ipc:///home/snode/.loki/lokid.sock");
     });
 
     conf.defineOption<std::string>(
-        "lokid", "rpc", false, DefaultLokidRPCAddr, [this](std::string arg) {
-          lokidRPCAddr = lokimq::address(arg);
-        });
+        "lokid",
+        "rpc",
+        RelayOnly,
+        Comment{
+            "lokimq control address for for communicating with lokid. Depends on lokid's",
+            "lmq-local-control configuration option. By default this value should be",
+            "ipc://LOKID-DATA-DIRECTORY/lokid.sock, such as:",
+            "    rpc=ipc:///var/lib/loki/lokid.sock",
+            "    rpc=ipc:///home/USER/.loki/lokid.sock",
+            "but can use (non-default) TCP if lokid is configured that way:",
+            "    rpc=tcp://127.0.0.1:5678",
+        },
+        [this](std::string arg) { lokidRPCAddr = lokimq::address(arg); });
   }
 
   void
@@ -557,7 +855,14 @@ namespace llarp
     (void)params;
 
     conf.defineOption<std::string>(
-        "bootstrap", "add-node", false, true, "", [this](std::string arg) {
+        "bootstrap",
+        "add-node",
+        MultiValue,
+        Comment{
+            "Specify a bootstrap file containing a signed RouterContact of a service node",
+            "which can act as a bootstrap. Can be specified multiple times.",
+        },
+        [this](std::string arg) {
           if (arg.empty())
           {
             throw std::invalid_argument("cannot use empty filename as bootstrap");
@@ -575,30 +880,59 @@ namespace llarp
   {
     (void)params;
 
-    constexpr auto DefaultLogType = "file";
-    constexpr auto DefaultLogFile = "stdout";
-    constexpr auto DefaultLogLevel = "info";
+    constexpr Default DefaultLogType{"file"};
+    constexpr Default DefaultLogFile{""};
+    constexpr Default DefaultLogLevel{"info"};
 
     conf.defineOption<std::string>(
-        "logging", "type", false, DefaultLogType, [this](std::string arg) {
+        "logging",
+        "type",
+        DefaultLogType,
+        [this](std::string arg) {
           LogType type = LogTypeFromString(arg);
           if (type == LogType::Unknown)
             throw std::invalid_argument(stringify("invalid log type: ", arg));
 
           m_logType = type;
+        },
+        Comment{
+            "Log type (format). Valid options are:",
+            "  file - plaintext formatting",
+            "  json - json-formatted log statements",
+            "  syslog - logs directed to syslog",
         });
 
     conf.defineOption<std::string>(
-        "logging", "level", false, DefaultLogLevel, [this](std::string arg) {
+        "logging",
+        "level",
+        DefaultLogLevel,
+        [this](std::string arg) {
           std::optional<LogLevel> level = LogLevelFromString(arg);
           if (not level)
             throw std::invalid_argument(stringify("invalid log level value: ", arg));
 
           m_logLevel = *level;
+        },
+        Comment{
+            "Minimum log level to print. Logging below this level will be ignored.",
+            "Valid log levels, in ascending order, are:",
+            "  trace",
+            "  debug",
+            "  info",
+            "  warn",
+            "  error",
         });
 
     conf.defineOption<std::string>(
-        "logging", "file", false, DefaultLogFile, AssignmentAcceptor(m_logFile));
+        "logging",
+        "file",
+        DefaultLogFile,
+        AssignmentAcceptor(m_logFile),
+        Comment{
+            "When using type=file this is the output filename. If given the value 'stdout' or",
+            "left empty then logging is printed as standard output rather than written to a",
+            "file.",
+        });
   }
 
   void
@@ -622,7 +956,7 @@ namespace llarp
       params.isRelay = isRelay;
       params.defaultDataDir = std::move(defaultDataDir);
 
-      ConfigDefinition conf;
+      ConfigDefinition conf{isRelay};
       initializeConfig(conf, params);
       addBackwardsCompatibleConfigOptions(conf);
       m_Parser.Clear();
@@ -662,7 +996,7 @@ namespace llarp
       params.isRelay = isRelay;
       params.defaultDataDir = std::move(dataDir);
 
-      ConfigDefinition conf;
+      ConfigDefinition conf{isRelay};
       initializeConfig(conf, params);
 
       conf.acceptAllOptions();
@@ -694,7 +1028,7 @@ namespace llarp
   Config::addBackwardsCompatibleConfigOptions(ConfigDefinition& conf)
   {
     auto addIgnoreOption = [&](const std::string& section, const std::string& name) {
-      conf.defineOption<std::string>(section, name, false, true, "", [=](std::string arg) {
+      conf.defineOption<std::string>(section, name, MultiValue, Hidden, [=](std::string arg) {
         (void)arg;
         LogWarn("*** WARNING: The config option [", section, "]:", name, " is deprecated");
       });
@@ -714,6 +1048,7 @@ namespace llarp
 
     // TODO: this may have been a synonym for [router]worker-threads
     addIgnoreOption("router", "threads");
+    addIgnoreOption("router", "net-threads");
 
     addIgnoreOption("metrics", "json-metrics-path");
 
@@ -721,6 +1056,7 @@ namespace llarp
 
     addIgnoreOption("lokid", "username");
     addIgnoreOption("lokid", "password");
+    addIgnoreOption("lokid", "service-node-seed");
   }
 
   void
@@ -778,85 +1114,11 @@ namespace llarp
             "Configuration for routing activity.",
         });
 
-    def.addOptionComments(
-        "router",
-        "threads",
-        {
-            "The number of threads available for performing cryptographic functions.",
-            "The minimum is one thread, but network performance may increase with more.",
-            "threads. Should not exceed the number of logical CPU cores.",
-        });
-
-    def.addOptionComments(
-        "router",
-        "data-dir",
-        {
-            "Optional directory for containing lokinet runtime data. This includes generated",
-            "private keys.",
-        });
-
-    // TODO: why did Kee want this, and/or what does it really do? Something about logs?
-    def.addOptionComments("router", "nickname", {"Router nickname. Kee wanted it."});
-
-    def.addOptionComments(
-        "router",
-        "min-connections",
-        {
-            "Minimum number of routers lokinet will attempt to maintain connections to.",
-        });
-
-    def.addOptionComments(
-        "router",
-        "max-connections",
-        {
-            "Maximum number (hard limit) of routers lokinet will be connected to at any time.",
-        });
-
-    def.addOptionComments(
-        "router",
-        "public-ip",
-        {
-            "For complex network configurations where the detected IP is incorrect or non-public",
-            "this setting specifies the public IP at which this router is reachable. When",
-            "provided the public-port option must also be specified.",
-        });
-
-    def.addOptionComments(
-        "router",
-        "public-port",
-        {
-            "When specifying public-ip=, this specifies the public UDP port at which this lokinet",
-            "router is reachable. Required when public-ip is used.",
-        });
-
     // logging
     def.addSectionComments(
         "logging",
         {
             "logging settings",
-        });
-
-    def.addOptionComments(
-        "logging",
-        "level",
-        {
-            "Minimum log level to print. Logging below this level will be ignored.",
-            "Valid log levels, in ascending order, are:",
-            "  trace",
-            "  debug",
-            "  info",
-            "  warn",
-            "  error",
-        });
-
-    def.addOptionComments(
-        "logging",
-        "type",
-        {
-            "Log type (format). Valid options are:",
-            "  file - plaintext formatting",
-            "  json - json-formatted log statements",
-            "  syslog - logs directed to syslog",
         });
 
     // api
@@ -866,51 +1128,11 @@ namespace llarp
             "JSON API settings",
         });
 
-    def.addOptionComments(
-        "api",
-        "enabled",
-        {
-            "Determines whether or not the JSON API is enabled.",
-        });
-
-    def.addOptionComments(
-        "api",
-        "bind",
-        {
-            "IP address and port to bind to.",
-            "Recommend localhost-only for security purposes.",
-        });
-
     // dns
     def.addSectionComments(
         "dns",
         {
             "DNS configuration",
-        });
-
-    def.addOptionComments(
-        "dns",
-        "upstream",
-        {
-            "Upstream resolver(s) to use as fallback for non-loki addresses.",
-            "Multiple values accepted.",
-        });
-
-    def.addOptionComments(
-        "dns",
-        "bind",
-        {
-            "Address to bind to for handling DNS requests.",
-            "Multiple values accepted.",
-        });
-
-    def.addOptionComments(
-        "dns",
-        "no-resolvconf",
-        {
-            "Can be uncommented and set to 1 to disable resolvconf configuration of lokinet DNS.",
-            "(This is not used directly by lokinet itself, but by the lokinet init scripts",
-            "on systems which use resolveconf)",
         });
 
     // bootstrap
@@ -920,56 +1142,11 @@ namespace llarp
             "Configure nodes that will bootstrap us onto the network",
         });
 
-    def.addOptionComments(
-        "bootstrap",
-        "add-node",
-        {
-            "Specify a bootstrap file containing a signed RouterContact of a service node",
-            "which can act as a bootstrap. Accepts multiple values.",
-        });
-
     // network
     def.addSectionComments(
         "network",
         {
             "Network settings",
-        });
-
-    def.addOptionComments(
-        "network",
-        "profiles",
-        {
-            "File to contain router profiles.",
-        });
-
-    def.addOptionComments(
-        "network",
-        "strict-connect",
-        {
-            "Public key of a router which will act as sole first-hop. This may be used to",
-            "provide a trusted router (consider that you are not fully anonymous with your",
-            "first hop).",
-        });
-
-    def.addOptionComments(
-        "network",
-        "exit-node",
-        {
-            "Public key of an exit-node.",
-        });
-
-    def.addOptionComments(
-        "network",
-        "ifname",
-        {
-            "Interface name for lokinet traffic.",
-        });
-
-    def.addOptionComments(
-        "network",
-        "ifaddr",
-        {
-            "Local IP address for lokinet traffic.",
         });
   }
 
@@ -980,7 +1157,7 @@ namespace llarp
     params.isRelay = false;
     params.defaultDataDir = std::move(defaultDataDir);
 
-    llarp::ConfigDefinition def;
+    llarp::ConfigDefinition def{false};
     initializeConfig(def, params);
     generateCommonConfigComments(def);
 
@@ -988,102 +1165,6 @@ namespace llarp
         "network",
         {
             "Snapp settings",
-        });
-
-    def.addOptionComments(
-        "network",
-        "keyfile",
-        {
-            "The private key to persist address with. If not specified the address will be",
-            "ephemeral.",
-        });
-
-    // TODO: is this redundant with / should be merged with basic client config?
-    def.addOptionComments(
-        "network",
-        "reachable",
-        {
-            "Determines whether we will publish our snapp's introset to the DHT.",
-        });
-
-    def.addOptionComments(
-        "network",
-        "hops",
-        {
-            "Number of hops in a path. Min 1, max 8.",
-        });
-
-    def.addOptionComments(
-        "network",
-        "paths",
-        {
-            "Number of paths to maintain at any given time.",
-        });
-
-    def.addOptionComments(
-        "network",
-        "blacklist-snode",
-        {
-            "Adds a `.snode` address to the blacklist.",
-        });
-
-    def.addOptionComments(
-        "network",
-        "exit-node",
-        {
-            "Specify a `.loki` address and an optional ip range to use as an exit broker.",
-            "Example:",
-            "exit-node=whatever.loki # maps all exit traffic to whatever.loki",
-            "exit-node=stuff.loki:100.0.0.0/24 # maps 100.0.0.0/24 to stuff.loki",
-        });
-
-    def.addOptionComments(
-        "network",
-        "mapaddr",
-        {
-            "Permanently map a `.loki` address to an IP owned by the snapp. Example:",
-            "mapaddr=whatever.loki:10.0.10.10 # maps `whatever.loki` to `10.0.10.10`.",
-        });
-    // extra [network] options
-    // TODO: probably better to create an [exit] section and only allow it for routers
-    def.addOptionComments(
-        "network",
-        "exit",
-        {
-            "Whether or not we should act as an exit node. Beware that this increases demand",
-            "on the server and may pose liability concerns. Enable at your own risk.",
-        });
-
-    def.addOptionComments(
-        "network",
-        "auth",
-        {
-            "Set the endpoint authentication mechanism.",
-            "none/whitelist/lmq",
-        });
-
-    def.addOptionComments(
-        "network",
-        "auth-lmq",
-        {
-            "lmq endpoint to talk to for authenticating new sessions",
-            "ipc:///var/lib/lokinet/auth.socket",
-            "tcp://127.0.0.1:5555",
-        });
-
-    def.addOptionComments(
-        "network",
-        "auth-lmq-method",
-        {
-            "lmq function to call for authenticating new sessions",
-            "llarp.auth",
-        });
-
-    def.addOptionComments(
-        "network",
-        "auth-whitelist",
-        {
-            "manually add a remote endpoint by .loki address to the access whitelist",
         });
 
     return def.generateINIConfig(true);
@@ -1096,7 +1177,7 @@ namespace llarp
     params.isRelay = true;
     params.defaultDataDir = std::move(defaultDataDir);
 
-    llarp::ConfigDefinition def;
+    llarp::ConfigDefinition def{true};
     initializeConfig(def, params);
     generateCommonConfigComments(def);
 
@@ -1104,63 +1185,7 @@ namespace llarp
     def.addSectionComments(
         "lokid",
         {
-            "Lokid configuration (settings for talking to lokid",
-        });
-
-    def.addOptionComments(
-        "lokid",
-        "enabled",
-        {
-            "Whether or not we should talk to lokid. Must be enabled for staked routers.",
-        });
-
-    def.addOptionComments(
-        "lokid",
-        "rpc",
-        {
-            "Host and port of running lokid's rpc that we should talk to.",
-        });
-
-    // TODO: doesn't appear to be used in the codebase
-    def.addOptionComments(
-        "lokid",
-        "service-node-seed",
-        {
-            "File containing service node's seed.",
-        });
-
-    // extra [network] options
-    // TODO: probably better to create an [exit] section and only allow it for routers
-    def.addOptionComments(
-        "network",
-        "exit",
-        {
-            "Whether or not we should act as an exit node. Beware that this increases demand",
-            "on the server and may pose liability concerns. Enable at your own risk.",
-        });
-
-    // TODO: define the order of precedence (e.g. is whitelist applied before blacklist?)
-    //       additionally, what's default? What if I don't whitelist anything?
-    def.addOptionComments(
-        "network",
-        "exit-whitelist",
-        {
-            "List of destination protocol:port pairs to whitelist, example: udp:*",
-            "or tcp:80. Multiple values supported.",
-        });
-
-    def.addOptionComments(
-        "network",
-        "exit-blacklist",
-        {
-            "Blacklist of destinations (same format as whitelist).",
-        });
-
-    def.addOptionComments(
-        "router",
-        "enable-peer-stats",
-        {
-            "Enable collection of SNode peer stats",
+            "Settings for communicating with lokid",
         });
 
     return def.generateINIConfig(true);

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -235,6 +235,16 @@ namespace llarp
             relative_to_datadir,
         });
 
+    // Deprecated options:
+
+    // these weren't even ever used!
+    conf.defineOption<std::string>("router", "max-routers", Deprecated);
+    conf.defineOption<std::string>("router", "min-routers", Deprecated);
+
+    // TODO: this may have been a synonym for [router]worker-threads
+    conf.defineOption<std::string>("router", "threads", Deprecated);
+    conf.defineOption<std::string>("router", "net-threads", Deprecated);
+
     m_isRelay = params.isRelay;
   }
 
@@ -586,6 +596,9 @@ namespace llarp
 
           m_SRVRecords.push_back(std::move(newSRV));
         });
+
+    // Deprecated options:
+    conf.defineOption<std::string>("network", "enabled", Deprecated);
   }
 
   void
@@ -814,6 +827,8 @@ namespace llarp
             "Recommend localhost-only for security purposes.",
         });
 
+    conf.defineOption<std::string>("api", "authkey", Deprecated);
+
     // TODO: this was from pre-refactor:
     // TODO: add pubkey to whitelist
   }
@@ -856,6 +871,11 @@ namespace llarp
             "    rpc=tcp://127.0.0.1:5678",
         },
         [this](std::string arg) { lokidRPCAddr = lokimq::address(arg); });
+
+    // Deprecated options:
+    conf.defineOption<std::string>("lokid", "username", Deprecated);
+    conf.defineOption<std::string>("lokid", "password", Deprecated);
+    conf.defineOption<std::string>("lokid", "service-node-seed", Deprecated);
   }
 
   void
@@ -1036,29 +1056,15 @@ namespace llarp
   void
   Config::addBackwardsCompatibleConfigOptions(ConfigDefinition& conf)
   {
+    // These config sections don't exist anymore:
+
     conf.defineOption<std::string>("system", "user", Deprecated);
     conf.defineOption<std::string>("system", "group", Deprecated);
     conf.defineOption<std::string>("system", "pidfile", Deprecated);
 
-    conf.defineOption<std::string>("api", "authkey", Deprecated);
-
     conf.defineOption<std::string>("netdb", "dir", Deprecated);
 
-    // these weren't even ever used!
-    conf.defineOption<std::string>("router", "max-routers", Deprecated);
-    conf.defineOption<std::string>("router", "min-routers", Deprecated);
-
-    // TODO: this may have been a synonym for [router]worker-threads
-    conf.defineOption<std::string>("router", "threads", Deprecated);
-    conf.defineOption<std::string>("router", "net-threads", Deprecated);
-
     conf.defineOption<std::string>("metrics", "json-metrics-path", Deprecated);
-
-    conf.defineOption<std::string>("network", "enabled", Deprecated);
-
-    conf.defineOption<std::string>("lokid", "username", Deprecated);
-    conf.defineOption<std::string>("lokid", "password", Deprecated);
-    conf.defineOption<std::string>("lokid", "service-node-seed", Deprecated);
   }
 
   void

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -606,7 +606,15 @@ namespace llarp
   {
     (void)params;
 
+    // Most non-linux platforms have loopback as 127.0.0.1/32, but linux uses 127.0.0.1/8 so that we
+    // can bind to other 127.* IPs to avoid conflicting with something else that may be listening on
+    // 127.0.0.1:53.
+#ifdef __linux__
     constexpr Default DefaultDNSBind{"127.3.2.1:53"};
+#else
+    constexpr Default DefaultDNSBind{"127.0.0.1:53"};
+#endif
+
     // Default, but if we get any upstream (including upstream=, i.e. empty string) we clear it
     constexpr Default DefaultUpstreamDNS{"1.1.1.1"};
     m_upstreamDNS.emplace_back(DefaultUpstreamDNS.val);

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -1036,36 +1036,29 @@ namespace llarp
   void
   Config::addBackwardsCompatibleConfigOptions(ConfigDefinition& conf)
   {
-    auto addIgnoreOption = [&](const std::string& section, const std::string& name) {
-      conf.defineOption<std::string>(section, name, MultiValue, Hidden, [=](std::string arg) {
-        (void)arg;
-        LogWarn("*** WARNING: The config option [", section, "]:", name, " is deprecated");
-      });
-    };
+    conf.defineOption<std::string>("system", "user", Deprecated);
+    conf.defineOption<std::string>("system", "group", Deprecated);
+    conf.defineOption<std::string>("system", "pidfile", Deprecated);
 
-    addIgnoreOption("system", "user");
-    addIgnoreOption("system", "group");
-    addIgnoreOption("system", "pidfile");
+    conf.defineOption<std::string>("api", "authkey", Deprecated);
 
-    addIgnoreOption("api", "authkey");
-
-    addIgnoreOption("netdb", "dir");
+    conf.defineOption<std::string>("netdb", "dir", Deprecated);
 
     // these weren't even ever used!
-    addIgnoreOption("router", "max-routers");
-    addIgnoreOption("router", "min-routers");
+    conf.defineOption<std::string>("router", "max-routers", Deprecated);
+    conf.defineOption<std::string>("router", "min-routers", Deprecated);
 
     // TODO: this may have been a synonym for [router]worker-threads
-    addIgnoreOption("router", "threads");
-    addIgnoreOption("router", "net-threads");
+    conf.defineOption<std::string>("router", "threads", Deprecated);
+    conf.defineOption<std::string>("router", "net-threads", Deprecated);
 
-    addIgnoreOption("metrics", "json-metrics-path");
+    conf.defineOption<std::string>("metrics", "json-metrics-path", Deprecated);
 
-    addIgnoreOption("network", "enabled");
+    conf.defineOption<std::string>("network", "enabled", Deprecated);
 
-    addIgnoreOption("lokid", "username");
-    addIgnoreOption("lokid", "password");
-    addIgnoreOption("lokid", "service-node-seed");
+    conf.defineOption<std::string>("lokid", "username", Deprecated);
+    conf.defineOption<std::string>("lokid", "password", Deprecated);
+    conf.defineOption<std::string>("lokid", "service-node-seed", Deprecated);
   }
 
   void

--- a/llarp/config/config.hpp
+++ b/llarp/config/config.hpp
@@ -63,7 +63,6 @@ namespace llarp
     std::string m_identityKeyFile;
     std::string m_transportKeyFile;
 
-    bool m_enablePeerStats = false;
     bool m_isRelay = false;
 
     void
@@ -73,7 +72,6 @@ namespace llarp
   struct NetworkConfig
   {
     std::optional<bool> m_enableProfiling;
-    std::string m_routerProfilesFile;
     std::string m_strictConnect;
     std::string m_ifname;
     IPRange m_ifaddr;
@@ -153,7 +151,6 @@ namespace llarp
 
   struct LokidConfig
   {
-    bool usingSNSeed = false;
     bool whitelistRouters = false;
     fs::path ident_keyfile;
     lokimq::address lokidRPCAddr;

--- a/llarp/config/definition.cpp
+++ b/llarp/config/definition.cpp
@@ -28,14 +28,22 @@ namespace llarp
     // dummy, warning option instead of this one.
     if (def->deprecated || (relay ? def->clientOnly : def->relayOnly))
     {
-      return defineOption<std::string>(def->section, def->name, MultiValue, Hidden,
-          [deprecated=def->deprecated, relay=relay, opt="[" + def->section + "]:" + def->name](std::string_view) {
-        LogWarn("*** WARNING: The config option ", opt, (
-              deprecated ? " is deprecated" :
-              relay ? " is not valid in service node configuration files" :
-              " is not valid in client configuration files"),
-            " and has been ignored.");
-      });
+      return defineOption<std::string>(
+          def->section,
+          def->name,
+          MultiValue,
+          Hidden,
+          [deprecated = def->deprecated,
+           relay = relay,
+           opt = "[" + def->section + "]:" + def->name](std::string_view) {
+            LogWarn(
+                "*** WARNING: The config option ",
+                opt,
+                (deprecated ? " is deprecated"
+                            : relay ? " is not valid in service node configuration files"
+                                    : " is not valid in client configuration files"),
+                " and has been ignored.");
+          });
     }
 
     auto [sectionItr, newSect] = m_definitions.try_emplace(def->section);

--- a/llarp/config/definition.cpp
+++ b/llarp/config/definition.cpp
@@ -1,22 +1,12 @@
 #include <config/definition.hpp>
 
+#include <iterator>
 #include <sstream>
 #include <stdexcept>
 #include <cassert>
 
 namespace llarp
 {
-  OptionDefinitionBase::OptionDefinitionBase(
-      std::string section_, std::string name_, bool required_)
-      : section(section_), name(name_), required(required_)
-  {
-  }
-  OptionDefinitionBase::OptionDefinitionBase(
-      std::string section_, std::string name_, bool required_, bool multiValued_)
-      : section(section_), name(name_), required(required_), multiValued(multiValued_)
-  {
-  }
-
   template <>
   bool
   OptionDefinition<bool>::fromString(const std::string& input)
@@ -32,17 +22,23 @@ namespace llarp
   ConfigDefinition&
   ConfigDefinition::defineOption(OptionDefinition_ptr def)
   {
-    auto sectionItr = m_definitions.find(def->section);
-    if (sectionItr == m_definitions.end())
-      m_sectionOrdering.push_back(def->section);
+    if (relay ? def->clientOnly : def->relayOnly)
+      return *this;
 
-    auto& sectionDefinitions = m_definitions[def->section];
-    if (sectionDefinitions.find(def->name) != sectionDefinitions.end())
+    auto [sectionItr, newSect] = m_definitions.try_emplace(def->section);
+    if (newSect)
+      m_sectionOrdering.push_back(def->section);
+    auto& section = sectionItr->first;
+
+    auto [it, added] = m_definitions[section].try_emplace(std::string{def->name}, std::move(def));
+    if (!added)
       throw std::invalid_argument(
           stringify("definition for [", def->section, "]:", def->name, " already exists"));
 
-    m_definitionOrdering[def->section].push_back(def->name);
-    sectionDefinitions[def->name] = std::move(def);
+    m_definitionOrdering[section].push_back(it->first);
+
+    if (!it->second->comments.empty())
+      addOptionComments(section, it->first, std::move(it->second->comments));
 
     return *this;
   }
@@ -153,10 +149,13 @@ namespace llarp
       const std::string& section, const std::string& name, std::vector<std::string> comments)
   {
     auto& defComments = m_definitionComments[section][name];
-    for (size_t i = 0; i < comments.size(); ++i)
-    {
-      defComments.emplace_back(std::move(comments[i]));
-    }
+    if (defComments.empty())
+      defComments = std::move(comments);
+    else
+      defComments.insert(
+          defComments.end(),
+          std::make_move_iterator(comments.begin()),
+          std::make_move_iterator(comments.end()));
   }
 
   std::string
@@ -170,6 +169,8 @@ namespace llarp
       if (sectionsVisited > 0)
         oss << "\n\n";
 
+      oss << "[" << section << "]\n";
+
       // TODO: this will create empty objects as a side effect of map's operator[]
       // TODO: this also won't handle sections which have no definition
       for (const std::string& comment : m_sectionComments[section])
@@ -177,25 +178,24 @@ namespace llarp
         oss << "# " << comment << "\n";
       }
 
-      oss << "[" << section << "]\n";
-
       visitDefinitions(section, [&](const std::string& name, const OptionDefinition_ptr& def) {
-        oss << "\n";
-
+        bool has_comment = false;
         // TODO: as above, this will create empty objects
         // TODO: as above (but more important): this won't handle definitions with no entries
         //       (i.e. those handled by UndeclaredValueHandler's)
         for (const std::string& comment : m_definitionComments[section][name])
         {
-          oss << "# " << comment << "\n";
+          oss << "\n# " << comment;
+          has_comment = true;
         }
 
         if (useValues and def->getNumberFound() > 0)
         {
-          oss << name << "=" << def->valueAsString(false) << "\n";
+          oss << "\n" << name << "=" << def->valueAsString(false) << "\n";
         }
-        else
+        else if (not(def->hidden and not has_comment))
         {
+          oss << "\n";
           if (not def->required)
             oss << "#";
           oss << name << "=" << def->defaultValueAsString() << "\n";

--- a/llarp/config/definition.cpp
+++ b/llarp/config/definition.cpp
@@ -177,6 +177,7 @@ namespace llarp
       {
         oss << "# " << comment << "\n";
       }
+      oss << "\n";
 
       visitDefinitions(section, [&](const std::string& name, const OptionDefinition_ptr& def) {
         bool has_comment = false;

--- a/llarp/config/definition.hpp
+++ b/llarp/config/definition.hpp
@@ -22,25 +22,20 @@ namespace llarp
   {
     // Base class for the following option flag types
     struct option_flag
-    {
-    };
+    {};
 
     struct Required_t : option_flag
-    {
-    };
+    {};
     struct Hidden_t : option_flag
-    {
-    };
+    {};
     struct MultiValue_t : option_flag
-    {
-    };
+    {};
     struct RelayOnly_t : option_flag
-    {
-    };
+    {};
     struct ClientOnly_t : option_flag
-    {
-    };
-    struct Deprecated_t : option_flag {};
+    {};
+    struct Deprecated_t : option_flag
+    {};
 
     /// Value to pass for an OptionDefinition to indicate that the option is required
     inline constexpr Required_t Required{};
@@ -68,8 +63,7 @@ namespace llarp
     {
       T val;
       constexpr explicit Default(T val) : val{std::move(val)}
-      {
-      }
+      {}
     };
 
     /// Adds one or more comment lines to the option definition.
@@ -77,8 +71,7 @@ namespace llarp
     {
       std::vector<std::string> comments;
       explicit Comment(std::initializer_list<std::string> comments) : comments{std::move(comments)}
-      {
-      }
+      {}
     };
 
     /// A convenience function that returns an acceptor which assigns to a reference.
@@ -127,8 +120,7 @@ namespace llarp
         , hidden{deprecated || (std::is_same_v<T, config::Hidden_t> || ...)}
         , relayOnly{(std::is_same_v<T, config::RelayOnly_t> || ...)}
         , clientOnly{(std::is_same_v<T, config::ClientOnly_t> || ...)}
-    {
-    }
+    {}
 
     virtual ~OptionDefinitionBase() = default;
 
@@ -424,8 +416,7 @@ namespace llarp
   struct ConfigDefinition
   {
     explicit ConfigDefinition(bool relay) : relay{relay}
-    {
-    }
+    {}
 
     /// Specify the parameters and type of a configuration option. The parameters are members of
     /// OptionDefinitionBase; the type is inferred from OptionDefinition's template parameter T.

--- a/llarp/config/definition.hpp
+++ b/llarp/config/definition.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <initializer_list>
+#include <type_traits>
 #include <util/str.hpp>
+#include <util/fs.hpp>
 
 #include <iostream>
 #include <memory>
@@ -15,19 +18,108 @@
 
 namespace llarp
 {
+  namespace config
+  {
+    // Base class for the following option flag types
+    struct option_flag
+    {
+    };
+
+    struct Required_t : option_flag
+    {
+    };
+    struct Hidden_t : option_flag
+    {
+    };
+    struct MultiValue_t : option_flag
+    {
+    };
+    struct RelayOnly_t : option_flag
+    {
+    };
+    struct ClientOnly_t : option_flag
+    {
+    };
+    /// Value to pass for an OptionDefinition to indicate that the option is required
+    inline constexpr Required_t Required{};
+    /// Value to pass for an OptionDefinition to indicate that the option should be hidden from the
+    /// generate config file if it is unset (and has no comment).  Typically for deprecated options.
+    inline constexpr Hidden_t Hidden{};
+    /// Value to pass for an OptionDefinition to indicate that the option takes multiple values
+    inline constexpr MultiValue_t MultiValue{};
+    /// Value to pass for an option that should only be set for relay configs.
+    inline constexpr RelayOnly_t RelayOnly{};
+    /// Value to pass for an option that should only be set for client configs.
+    inline constexpr ClientOnly_t ClientOnly{};
+
+    /// Wrapper to specify a default value to an OptionDefinition
+    template <typename T>
+    struct Default
+    {
+      T val;
+      constexpr explicit Default(T val) : val{std::move(val)}
+      {
+      }
+    };
+
+    /// Adds one or more comment lines to the option definition.
+    struct Comment
+    {
+      std::vector<std::string> comments;
+      explicit Comment(std::initializer_list<std::string> comments) : comments{std::move(comments)}
+      {
+      }
+    };
+
+    /// A convenience function that returns an acceptor which assigns to a reference.
+    ///
+    /// Note that this holds on to the reference; it must only be used when this is safe to do. In
+    /// particular, a reference to a local variable may be problematic.
+    template <typename T>
+    auto
+    AssignmentAcceptor(T& ref)
+    {
+      return [&ref](T arg) { ref = std::move(arg); };
+    }
+
+    // C++20 backport:
+    template <typename T>
+    using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
+
+    template <typename T>
+    constexpr bool is_default = false;
+    template <typename T>
+    constexpr bool is_default<Default<T>> = true;
+    template <typename U>
+    constexpr bool is_default<U&> = is_default<remove_cvref_t<U>>;
+
+    template <typename T, typename Option>
+    constexpr bool is_option =
+        std::is_base_of_v<
+            option_flag,
+            remove_cvref_t<
+                Option>> or std::is_same_v<Comment, Option> or is_default<Option> or std::is_invocable_v<remove_cvref_t<Option>, T>;
+  }  // namespace config
+
   /// A base class for specifying config options and their constraints. The basic to/from string
   /// type functions are provided pure-virtual. The type-aware implementations which implement these
   /// functions are templated classes. One reason for providing a non-templated base class is so
   /// that they can all be mixed into the same containers (albiet as pointers).
   struct OptionDefinitionBase
   {
-    OptionDefinitionBase(std::string section_, std::string name_, bool required_);
-    OptionDefinitionBase(
-        std::string section_, std::string name_, bool required_, bool multiValued_);
-
-    virtual ~OptionDefinitionBase()
+    template <typename... T>
+    OptionDefinitionBase(std::string section_, std::string name_, const T&...)
+        : section(std::move(section_))
+        , name(std::move(name_))
+        , required{(std::is_same_v<T, config::Required_t> || ...)}
+        , multiValued{(std::is_same_v<T, config::MultiValue_t> || ...)}
+        , hidden{(std::is_same_v<T, config::Hidden_t> || ...)}
+        , relayOnly{(std::is_same_v<T, config::RelayOnly_t> || ...)}
+        , clientOnly{(std::is_same_v<T, config::ClientOnly_t> || ...)}
     {
     }
+
+    virtual ~OptionDefinitionBase() = default;
 
     /// Subclasses should provide their default value as a string
     ///
@@ -65,6 +157,12 @@ namespace llarp
     std::string name;
     bool required = false;
     bool multiValued = false;
+    bool hidden = false;
+    bool relayOnly = false;
+    bool clientOnly = false;
+    // Temporarily holds comments given during construction until the option is actually added to
+    // the owning ConfigDefinition.
+    std::vector<std::string> comments;
   };
 
   /// The primary type-aware implementation of OptionDefinitionBase, this templated class allows
@@ -84,33 +182,53 @@ namespace llarp
     /// 2) as the output in defaultValueAsString(), used to generate config files
     /// 3) as the output in valueAsString(), used to generate config files
     ///
-    /// @param acceptor_ is an optional function whose purpose is to both validate the parsed
-    ///        input and internalize it (e.g. copy it for runtime use). The acceptor should throw
-    ///        an exception with a useful message if it is not acceptable.
-    OptionDefinition(
-        std::string section_,
-        std::string name_,
-        bool required_,
-        std::optional<T> defaultValue_,
-        std::function<void(T)> acceptor_ = nullptr)
-        : OptionDefinitionBase(section_, name_, required_)
-        , defaultValue(defaultValue_)
-        , acceptor(acceptor_)
+    /// @param opts - 0 or more of config::Required, config::Hidden, config::Default{...}, etc.
+    /// tagged options or an invocable acceptor validate and internalize input (e.g. copy it for
+    /// runtime use). The acceptor should throw an exception with a useful message if it is not
+    /// acceptable.  Parameters may be passed in any order.
+    template <
+        typename... Options,
+        std::enable_if_t<(config::is_option<T, Options> && ...), int> = 0>
+    OptionDefinition(std::string section_, std::string name_, Options&&... opts)
+        : OptionDefinitionBase(section_, name_, opts...)
     {
+      (extractDefault(std::forward<Options>(opts)), ...);
+      (extractAcceptor(std::forward<Options>(opts)), ...);
+      (extractComments(std::forward<Options>(opts)), ...);
     }
 
-    /// As above, but also takes a bool value for multiValued.
-    OptionDefinition(
-        std::string section_,
-        std::string name_,
-        bool required_,
-        bool multiValued_,
-        std::optional<T> defaultValue_,
-        std::function<void(T)> acceptor_ = nullptr)
-        : OptionDefinitionBase(section_, name_, required_, multiValued_)
-        , defaultValue(defaultValue_)
-        , acceptor(acceptor_)
+    /// Extracts a default value from an config::Default<U>; ignores anything that isn't an
+    /// config::Default<U>.
+    template <typename U>
+    void
+    extractDefault(U&& defaultValue_)
     {
+      if constexpr (config::is_default<U>)
+      {
+        static_assert(
+            std::is_convertible_v<decltype(std::forward<U>(defaultValue_).val), T>,
+            "Cannot convert given llarp::config::Default to the required value type");
+        defaultValue = std::forward<U>(defaultValue_).val;
+      }
+    }
+
+    /// Extracts an acceptor (i.e. something callable with a `T`) from options; ignores anything
+    /// that isn't callable.
+    template <typename U>
+    void
+    extractAcceptor(U&& acceptor_)
+    {
+      if constexpr (std::is_invocable_v<U, T>)
+        acceptor = std::forward<U>(acceptor_);
+    }
+
+    /// Extracts option Comments and forwards them addOptionComments.
+    template <typename U>
+    void
+    extractComments(U&& comment)
+    {
+      if constexpr (std::is_same_v<config::remove_cvref_t<U>, config::Comment>)
+        comments = std::forward<U>(comment).comments;
     }
 
     /// Returns the first parsed value, if available. Otherwise, provides the default value if the
@@ -155,10 +273,14 @@ namespace llarp
     std::string
     defaultValueAsString() override
     {
-      std::ostringstream oss;
-      if (defaultValue)
-        oss << *defaultValue;
+      if (!defaultValue)
+        return "";
 
+      if constexpr (std::is_same_v<fs::path, T>)
+        return defaultValue->string();
+
+      std::ostringstream oss;
+      oss << *defaultValue;
       return oss.str();
     }
 
@@ -224,7 +346,7 @@ namespace llarp
       }
 
       // don't use default value if we are multi-valued and have no value
-      if (multiValued && parsedValues.size() == 0)
+      if (multiValued and parsedValues.size() == 0)
         return;
 
       if (acceptor)
@@ -289,11 +411,15 @@ namespace llarp
   /// calls to addConfigValue()).
   struct ConfigDefinition
   {
-    /// Spefify the parameters and type of a configuration option. The parameters are members of
+    explicit ConfigDefinition(bool relay) : relay{relay}
+    {
+    }
+
+    /// Specify the parameters and type of a configuration option. The parameters are members of
     /// OptionDefinitionBase; the type is inferred from OptionDefinition's template parameter T.
     ///
     /// This function should be called for every option that this Configuration supports, and should
-    /// be done before any other interractions involving that option.
+    /// be done before any other interactions involving that option.
     ///
     /// @param def should be a unique_ptr to a valid subclass of OptionDefinitionBase
     /// @return `*this` for chaining calls
@@ -307,7 +433,7 @@ namespace llarp
     ConfigDefinition&
     defineOption(Params&&... args)
     {
-      return defineOption(std::make_unique<OptionDefinition<T>>(args...));
+      return defineOption(std::make_unique<OptionDefinition<T>>(std::forward<Params>(args)...));
     }
 
     /// Specify a config value for the given section and name. The value should be a valid string
@@ -416,6 +542,9 @@ namespace llarp
     generateINIConfig(bool useValues = false);
 
    private:
+    // If true skip client-only options; if false skip relay-only options.
+    bool relay;
+
     OptionDefinition_ptr&
     lookupDefinitionOrThrow(std::string_view section, std::string_view name);
     const OptionDefinition_ptr&
@@ -443,16 +572,5 @@ namespace llarp
     CommentsMap m_sectionComments;
     std::unordered_map<std::string, CommentsMap> m_definitionComments;
   };
-
-  /// A convenience acceptor which takes a reference and later assigns it in its acceptor call.
-  ///
-  /// Note that this holds on to a reference; it must only be used when this is safe to do. In
-  /// particular, a reference to a local variable may be problematic.
-  template <typename T>
-  std::function<void(T)>
-  AssignmentAcceptor(T& ref)
-  {
-    return [&](T arg) mutable { ref = std::move(arg); };
-  }
 
 }  // namespace llarp

--- a/llarp/config/key_manager.cpp
+++ b/llarp/config/key_manager.cpp
@@ -9,8 +9,7 @@
 namespace llarp
 {
   KeyManager::KeyManager() : m_initialized(false), m_needBackup(false)
-  {
-  }
+  {}
 
   bool
   KeyManager::initialize(const llarp::Config& config, bool genIfAbsent, bool isRouter)

--- a/llarp/context.cpp
+++ b/llarp/context.cpp
@@ -167,8 +167,7 @@ namespace llarp
 
   void
   Context::Reload()
-  {
-  }
+  {}
 
   void
   Context::SigINT()

--- a/llarp/crypto/encrypted.hpp
+++ b/llarp/crypto/encrypted.hpp
@@ -56,8 +56,7 @@ namespace llarp
     }
 
     Encrypted(size_t sz) : Encrypted(nullptr, sz)
-    {
-    }
+    {}
 
     bool
     BEncode(llarp_buffer_t* buf) const

--- a/llarp/crypto/encrypted_frame.hpp
+++ b/llarp/crypto/encrypted_frame.hpp
@@ -16,14 +16,12 @@ namespace llarp
   struct EncryptedFrame : public Encrypted<EncryptedFrameSize>
   {
     EncryptedFrame() : EncryptedFrame(EncryptedFrameBodySize)
-    {
-    }
+    {}
 
     EncryptedFrame(size_t sz)
         : Encrypted<EncryptedFrameSize>(
             std::min(sz, EncryptedFrameBodySize) + EncryptedFrameOverheadSize)
-    {
-    }
+    {}
 
     void
     Resize(size_t sz)
@@ -70,8 +68,7 @@ namespace llarp
 
     AsyncFrameDecrypter(const SecretKey& secretkey, DecryptHandler h)
         : result(std::move(h)), seckey(secretkey)
-    {
-    }
+    {}
 
     DecryptHandler result;
     const SecretKey& seckey;

--- a/llarp/crypto/types.hpp
+++ b/llarp/crypto/types.hpp
@@ -20,16 +20,13 @@ namespace llarp
     PubKey() = default;
 
     explicit PubKey(const byte_t* ptr) : AlignedBuffer<SIZE>(ptr)
-    {
-    }
+    {}
 
     explicit PubKey(const Data& data) : AlignedBuffer<SIZE>(data)
-    {
-    }
+    {}
 
     explicit PubKey(const AlignedBuffer<SIZE>& other) : AlignedBuffer<SIZE>(other)
-    {
-    }
+    {}
 
     std::string
     ToString() const;
@@ -84,13 +81,11 @@ namespace llarp
     SecretKey() = default;
 
     explicit SecretKey(const byte_t* ptr) : AlignedBuffer<SECKEYSIZE>(ptr)
-    {
-    }
+    {}
 
     // The full data
     explicit SecretKey(const AlignedBuffer<SECKEYSIZE>& seed) : AlignedBuffer<SECKEYSIZE>(seed)
-    {
-    }
+    {}
 
     // Just the seed, we recalculate the pubkey
     explicit SecretKey(const AlignedBuffer<32>& seed)
@@ -147,12 +142,10 @@ namespace llarp
     PrivateKey() = default;
 
     explicit PrivateKey(const byte_t* ptr) : AlignedBuffer<64>(ptr)
-    {
-    }
+    {}
 
     explicit PrivateKey(const AlignedBuffer<64>& key_and_hash) : AlignedBuffer<64>(key_and_hash)
-    {
-    }
+    {}
 
     /// Returns a pointer to the beginning of the 32-byte hash which is used for
     /// pseudorandomness when signing with this private key.
@@ -195,8 +188,7 @@ namespace llarp
   struct IdentitySecret final : public AlignedBuffer<32>
   {
     IdentitySecret() : AlignedBuffer<32>()
-    {
-    }
+    {}
 
     /// no copy constructor
     explicit IdentitySecret(const IdentitySecret&) = delete;

--- a/llarp/dht/bucket.hpp
+++ b/llarp/dht/bucket.hpp
@@ -20,8 +20,7 @@ namespace llarp
       using Random_t = std::function<uint64_t()>;
 
       Bucket(const Key_t& us, Random_t r) : nodes(XorMetric(us)), random(std::move(r))
-      {
-      }
+      {}
 
       util::StatusObject
       ExtractStatus() const

--- a/llarp/dht/explorenetworkjob.hpp
+++ b/llarp/dht/explorenetworkjob.hpp
@@ -12,8 +12,7 @@ namespace llarp
     {
       ExploreNetworkJob(const RouterID& peer, AbstractContext* ctx)
           : TX<RouterID, RouterID>(TXOwner{}, peer, ctx)
-      {
-      }
+      {}
 
       bool
       Validate(const RouterID&) const override

--- a/llarp/dht/kademlia.hpp
+++ b/llarp/dht/kademlia.hpp
@@ -13,8 +13,7 @@ namespace llarp
       const Key_t us;
 
       XorMetric(const Key_t& ourKey) : us(ourKey)
-      {
-      }
+      {}
 
       bool
       operator()(const Key_t& left, const Key_t& right) const

--- a/llarp/dht/key.hpp
+++ b/llarp/dht/key.hpp
@@ -13,20 +13,16 @@ namespace llarp
     struct Key_t : public AlignedBuffer<32>
     {
       explicit Key_t(const byte_t* buf) : AlignedBuffer<SIZE>(buf)
-      {
-      }
+      {}
 
       explicit Key_t(const Data& data) : AlignedBuffer<SIZE>(data)
-      {
-      }
+      {}
 
       explicit Key_t(const AlignedBuffer<SIZE>& data) : AlignedBuffer<SIZE>(data)
-      {
-      }
+      {}
 
       Key_t() : AlignedBuffer<SIZE>()
-      {
-      }
+      {}
 
       /// get snode address string
       std::string

--- a/llarp/dht/localrouterlookup.cpp
+++ b/llarp/dht/localrouterlookup.cpp
@@ -16,8 +16,7 @@ namespace llarp
         const PathID_t& path, uint64_t txid, const RouterID& _target, AbstractContext* ctx)
         : RecursiveRouterLookup(TXOwner{ctx->OurKey(), txid}, _target, ctx, nullptr)
         , localPath(path)
-    {
-    }
+    {}
 
     void
     LocalRouterLookup::SendReply()

--- a/llarp/dht/localserviceaddresslookup.cpp
+++ b/llarp/dht/localserviceaddresslookup.cpp
@@ -20,8 +20,7 @@ namespace llarp
         __attribute__((unused)) const Key_t& askpeer)
         : ServiceAddressLookup(TXOwner{ctx->OurKey(), txid}, addr, ctx, relayOrder, nullptr)
         , localPath(pathid)
-    {
-    }
+    {}
 
     void
     LocalServiceAddressLookup::SendReply()

--- a/llarp/dht/localtaglookup.cpp
+++ b/llarp/dht/localtaglookup.cpp
@@ -13,8 +13,7 @@ namespace llarp
     LocalTagLookup::LocalTagLookup(
         const PathID_t& path, uint64_t txid, const service::Tag& _target, AbstractContext* ctx)
         : TagLookup(TXOwner{ctx->OurKey(), txid}, _target, ctx, 0), localPath(path)
-    {
-    }
+    {}
 
     void
     LocalTagLookup::SendReply()

--- a/llarp/dht/message.cpp
+++ b/llarp/dht/message.cpp
@@ -22,8 +22,7 @@ namespace llarp
       bool relayed = false;
 
       MessageDecoder(const Key_t& from, bool wasRelayed) : From(from), relayed(wasRelayed)
-      {
-      }
+      {}
 
       bool
       operator()(llarp_buffer_t* buffer, llarp_buffer_t* key)
@@ -105,8 +104,7 @@ namespace llarp
     {
       ListDecoder(bool hasRelayed, const Key_t& from, std::vector<IMessage::Ptr_t>& list)
           : relayed(hasRelayed), From(from), l(list)
-      {
-      }
+      {}
 
       bool relayed;
       const Key_t& From;

--- a/llarp/dht/message.hpp
+++ b/llarp/dht/message.hpp
@@ -20,8 +20,7 @@ namespace llarp
 
       /// construct
       IMessage(const Key_t& from) : From(from)
-      {
-      }
+      {}
 
       using Ptr_t = std::unique_ptr<IMessage>;
 

--- a/llarp/dht/messages/findintro.hpp
+++ b/llarp/dht/messages/findintro.hpp
@@ -26,8 +26,7 @@ namespace llarp
 
       FindIntroMessage(const llarp::service::Tag& tag, uint64_t txid)
           : IMessage({}), tagName(tag), txID(txid)
-      {
-      }
+      {}
 
       explicit FindIntroMessage(uint64_t txid, const Key_t& addr, uint64_t order)
           : IMessage({}), location(addr), txID(txid), relayOrder(order)

--- a/llarp/dht/messages/findname.cpp
+++ b/llarp/dht/messages/findname.cpp
@@ -11,8 +11,7 @@ namespace llarp::dht
 {
   FindNameMessage::FindNameMessage(const Key_t& from, Key_t namehash, uint64_t txid)
       : IMessage(from), NameHash(std::move(namehash)), TxID(txid)
-  {
-  }
+  {}
 
   bool
   FindNameMessage::BEncode(llarp_buffer_t* buf) const

--- a/llarp/dht/messages/findrouter.hpp
+++ b/llarp/dht/messages/findrouter.hpp
@@ -10,14 +10,12 @@ namespace llarp
     {
       // inbound parsing
       FindRouterMessage(const Key_t& from) : IMessage(from)
-      {
-      }
+      {}
 
       // find by routerid
       FindRouterMessage(uint64_t id, const RouterID& target)
           : IMessage({}), targetKey(target), txid(id)
-      {
-      }
+      {}
 
       // exploritory
       FindRouterMessage(uint64_t id) : IMessage({}), exploritory(true), txid(id)
@@ -48,8 +46,7 @@ namespace llarp
     struct RelayedFindRouterMessage final : public FindRouterMessage
     {
       RelayedFindRouterMessage(const Key_t& from) : FindRouterMessage(from)
-      {
-      }
+      {}
 
       /// handle a relayed FindRouterMessage, do a lookup on the dht and inform
       /// the path of the result

--- a/llarp/dht/messages/gotintro.cpp
+++ b/llarp/dht/messages/gotintro.cpp
@@ -15,8 +15,7 @@ namespace llarp
   {
     GotIntroMessage::GotIntroMessage(std::vector<service::EncryptedIntroSet> results, uint64_t tx)
         : IMessage({}), found(std::move(results)), txid(tx)
-    {
-    }
+    {}
 
     bool
     GotIntroMessage::HandleMessage(

--- a/llarp/dht/messages/gotintro.hpp
+++ b/llarp/dht/messages/gotintro.hpp
@@ -23,8 +23,7 @@ namespace llarp
       std::optional<Key_t> closer;
 
       GotIntroMessage(const Key_t& from) : IMessage(from)
-      {
-      }
+      {}
 
       GotIntroMessage(const GotIntroMessage& other)
           : IMessage(other.From), found(other.found), txid(other.txid), closer(other.closer)
@@ -35,8 +34,7 @@ namespace llarp
       /// for iterative reply
       GotIntroMessage(const Key_t& from, const Key_t& _closer, uint64_t _txid)
           : IMessage(from), txid(_txid), closer(_closer)
-      {
-      }
+      {}
 
       /// for recursive reply
       GotIntroMessage(std::vector<service::EncryptedIntroSet> results, uint64_t txid);
@@ -56,8 +54,7 @@ namespace llarp
     struct RelayedGotIntroMessage final : public GotIntroMessage
     {
       RelayedGotIntroMessage() : GotIntroMessage({})
-      {
-      }
+      {}
 
       bool
       HandleMessage(llarp_dht_context* ctx, std::vector<IMessage::Ptr_t>& replies) const override;

--- a/llarp/dht/messages/gotrouter.hpp
+++ b/llarp/dht/messages/gotrouter.hpp
@@ -14,23 +14,19 @@ namespace llarp
     struct GotRouterMessage final : public IMessage
     {
       GotRouterMessage(const Key_t& from, bool tunneled) : IMessage(from), relayed(tunneled)
-      {
-      }
+      {}
       GotRouterMessage(
           const Key_t& from, uint64_t id, const std::vector<RouterContact>& results, bool tunneled)
           : IMessage(from), foundRCs(results), txid(id), relayed(tunneled)
-      {
-      }
+      {}
 
       GotRouterMessage(const Key_t& from, const Key_t& closer, uint64_t id, bool tunneled)
           : IMessage(from), closerTarget(new Key_t(closer)), txid(id), relayed(tunneled)
-      {
-      }
+      {}
 
       GotRouterMessage(uint64_t id, std::vector<RouterID> _near, bool tunneled)
           : IMessage({}), nearKeys(std::move(_near)), txid(id), relayed(tunneled)
-      {
-      }
+      {}
 
       /// gossip message
       GotRouterMessage(const RouterContact rc) : IMessage({}), foundRCs({rc}), txid(0)

--- a/llarp/dht/messages/pubintro.hpp
+++ b/llarp/dht/messages/pubintro.hpp
@@ -18,8 +18,7 @@ namespace llarp
       uint64_t relayOrder = 0;
       uint64_t txID = 0;
       PublishIntroMessage(const Key_t& from, bool relayed_) : IMessage(from), relayed(relayed_)
-      {
-      }
+      {}
 
       PublishIntroMessage(
           const llarp::service::EncryptedIntroSet& introset_,
@@ -27,8 +26,7 @@ namespace llarp
           bool relayed_,
           uint64_t relayOrder_)
           : IMessage({}), introset(introset_), relayed(relayed_), relayOrder(relayOrder_), txID(tx)
-      {
-      }
+      {}
 
       ~PublishIntroMessage() override;
 

--- a/llarp/dht/node.hpp
+++ b/llarp/dht/node.hpp
@@ -21,8 +21,7 @@ namespace llarp
       }
 
       RCNode(const RouterContact& other) : rc(other), ID(other.pubkey)
-      {
-      }
+      {}
 
       util::StatusObject
       ExtractStatus() const

--- a/llarp/dht/publishservicejob.cpp
+++ b/llarp/dht/publishservicejob.cpp
@@ -20,8 +20,7 @@ namespace llarp
         : TX<TXOwner, service::EncryptedIntroSet>(asker, asker, ctx)
         , relayOrder(relayOrder_)
         , introset(introset_)
-    {
-    }
+    {}
 
     bool
     PublishServiceJob::Validate(const service::EncryptedIntroSet& value) const
@@ -56,8 +55,7 @@ namespace llarp
         AbstractContext* ctx,
         uint64_t relayOrder)
         : PublishServiceJob(peer, introset, ctx, relayOrder), localPath(fromID), txid(_txid)
-    {
-    }
+    {}
 
     void
     LocalPublishServiceJob::SendReply()

--- a/llarp/dht/taglookup.hpp
+++ b/llarp/dht/taglookup.hpp
@@ -15,8 +15,7 @@ namespace llarp
       TagLookup(
           const TXOwner& asker, const service::Tag& tag, AbstractContext* ctx, uint64_t recursion)
           : TX<service::Tag, service::EncryptedIntroSet>(asker, tag, ctx), recursionDepth(recursion)
-      {
-      }
+      {}
 
       bool
       Validate(const service::EncryptedIntroSet& introset) const override;

--- a/llarp/dht/tx.hpp
+++ b/llarp/dht/tx.hpp
@@ -26,8 +26,7 @@ namespace llarp
 
       TX(const TXOwner& asker, const K& k, AbstractContext* p)
           : target(k), parent(p), whoasked(asker)
-      {
-      }
+      {}
 
       virtual ~TX() = default;
 

--- a/llarp/dht/txowner.hpp
+++ b/llarp/dht/txowner.hpp
@@ -22,8 +22,7 @@ namespace llarp
       operator=(const TXOwner&) = default;
 
       TXOwner(const Key_t& k, uint64_t id) : node(k), txid(id)
-      {
-      }
+      {}
 
       util::StatusObject
       ExtractStatus() const

--- a/llarp/dns/message.cpp
+++ b/llarp/dns/message.cpp
@@ -55,8 +55,7 @@ namespace llarp
         , answers(std::move(other.answers))
         , authorities(std::move(other.authorities))
         , additional(std::move(other.additional))
-    {
-    }
+    {}
 
     Message::Message(const Message& other)
         : hdr_id(other.hdr_id)
@@ -65,8 +64,7 @@ namespace llarp
         , answers(other.answers)
         , authorities(other.authorities)
         , additional(other.additional)
-    {
-    }
+    {}
 
     Message::Message(const MessageHeader& hdr) : hdr_id(hdr.id), hdr_fields(hdr.fields)
     {

--- a/llarp/dns/question.cpp
+++ b/llarp/dns/question.cpp
@@ -12,12 +12,10 @@ namespace llarp
         : qname(std::move(other.qname))
         , qtype(std::move(other.qtype))
         , qclass(std::move(other.qclass))
-    {
-    }
+    {}
     Question::Question(const Question& other)
         : qname(other.qname), qtype(other.qtype), qclass(other.qclass)
-    {
-    }
+    {}
 
     bool
     Question::Encode(llarp_buffer_t* buf) const

--- a/llarp/dns/rr.cpp
+++ b/llarp/dns/rr.cpp
@@ -14,8 +14,7 @@ namespace llarp
         , rr_class(other.rr_class)
         , ttl(other.ttl)
         , rData(other.rData)
-    {
-    }
+    {}
 
     ResourceRecord::ResourceRecord(ResourceRecord&& other)
         : rr_name(std::move(other.rr_name))
@@ -23,8 +22,7 @@ namespace llarp
         , rr_class(std::move(other.rr_class))
         , ttl(std::move(other.ttl))
         , rData(std::move(other.rData))
-    {
-    }
+    {}
 
     bool
     ResourceRecord::Encode(llarp_buffer_t* buf) const

--- a/llarp/dns/server.cpp
+++ b/llarp/dns/server.cpp
@@ -31,8 +31,7 @@ namespace llarp
 
     void
     Proxy::Stop()
-    {
-    }
+    {}
 
     bool
     Proxy::Start(const IpAddress& addr, const std::vector<IpAddress>& resolvers)
@@ -137,8 +136,7 @@ namespace llarp
 
     void
     Proxy::HandleTick(llarp_udp_io*)
-    {
-    }
+    {}
 
     void
     Proxy::SendServerMessageBufferTo(const SockAddr& to, const llarp_buffer_t& buf)

--- a/llarp/dns/unbound_resolver.cpp
+++ b/llarp/dns/unbound_resolver.cpp
@@ -66,8 +66,7 @@ namespace llarp::dns
       , replyFunc(reply)
       , failFunc(fail)
 #endif
-  {
-  }
+  {}
 
   // static callback
   void

--- a/llarp/ev/ev.hpp
+++ b/llarp/ev/ev.hpp
@@ -101,8 +101,7 @@ namespace llarp
       {
         llarp_ev_loop_ptr loop;
         GetNow(llarp_ev_loop_ptr l) : loop(l)
-        {
-        }
+        {}
 
         llarp_time_t
         operator()() const
@@ -115,8 +114,7 @@ namespace llarp
       {
         llarp_ev_loop_ptr loop;
         PutTime(llarp_ev_loop_ptr l) : loop(l)
-        {
-        }
+        {}
         void
         operator()(WriteBuffer& buf)
         {
@@ -143,8 +141,7 @@ namespace llarp
 
     /// for tcp
     win32_ev_io(intptr_t f, LosslessWriteQueue_t* q) : fd(f), m_BlockingWriteQueue(q)
-    {
-    }
+    {}
 
     virtual void
     error()
@@ -304,8 +301,7 @@ namespace llarp
       {
         llarp_ev_loop_ptr loop;
         GetNow(llarp_ev_loop_ptr l) : loop(std::move(l))
-        {
-        }
+        {}
 
         llarp_time_t
         operator()() const
@@ -318,8 +314,7 @@ namespace llarp
       {
         llarp_ev_loop_ptr loop;
         PutTime(llarp_ev_loop_ptr l) : loop(std::move(l))
-        {
-        }
+        {}
         void
         operator()(WriteBuffer& writebuf)
         {
@@ -355,18 +350,15 @@ namespace llarp
 #endif
 
     posix_ev_io(int f) : fd(f)
-    {
-    }
+    {}
 
     /// for tun
     posix_ev_io(int f, LossyWriteQueue_t* q) : fd(f), m_LossyWriteQueue(q)
-    {
-    }
+    {}
 
     /// for tcp
     posix_ev_io(int f, LosslessWriteQueue_t* q) : fd(f), m_BlockingWriteQueue(q)
-    {
-    }
+    {}
 
     virtual void
     error()
@@ -425,8 +417,7 @@ namespace llarp
 
     virtual void
     before_flush_write()
-    {
-    }
+    {}
 
     /// called in event loop when fd is ready for writing
     /// requeues anything not written
@@ -659,8 +650,7 @@ namespace llarp
 struct llarp_fd_promise
 {
   void Set(std::pair<int, int>)
-  {
-  }
+  {}
 
   int
   Get()
@@ -673,8 +663,7 @@ struct llarp_fd_promise
 {
   using promise_val_t = std::pair<int, int>;
   llarp_fd_promise(std::promise<promise_val_t>* p) : _impl(p)
-  {
-  }
+  {}
   std::promise<promise_val_t>* _impl;
 
   void
@@ -710,8 +699,7 @@ struct llarp_ev_loop
 
   virtual void
   update_time()
-  {
-  }
+  {}
 
   virtual llarp_time_t
   time_now() const

--- a/llarp/ev/ev_libuv.cpp
+++ b/llarp/ev/ev_libuv.cpp
@@ -762,8 +762,7 @@ namespace libuv
 
   Loop::Loop(size_t queue_size)
       : llarp_ev_loop(), m_LogicCalls(queue_size), m_timerQueue(20), m_timerCancelQueue(20)
-  {
-  }
+  {}
 
   bool
   Loop::init()

--- a/llarp/ev/ev_win32.hpp
+++ b/llarp/ev/ev_win32.hpp
@@ -40,8 +40,7 @@ namespace llarp
     udp_listener(int fd, llarp_udp_io* u) : ev_io(fd), udp(u){};
 
     ~udp_listener()
-    {
-    }
+    {}
 
     bool
     tick();

--- a/llarp/ev/pipe.cpp
+++ b/llarp/ev/pipe.cpp
@@ -8,8 +8,7 @@
 
 llarp_ev_pkt_pipe::llarp_ev_pkt_pipe(llarp_ev_loop_ptr loop)
     : llarp::ev_io(-1, new LosslessWriteQueue_t()), m_Loop(std::move(loop))
-{
-}
+{}
 
 bool
 llarp_ev_pkt_pipe::StartPipe()

--- a/llarp/ev/vpnio.hpp
+++ b/llarp/ev/vpnio.hpp
@@ -18,18 +18,15 @@ struct llarp_vpn_pkt_queue
 };
 
 struct llarp_vpn_pkt_writer : public llarp_vpn_pkt_queue
-{
-};
+{};
 
 struct llarp_vpn_pkt_reader : public llarp_vpn_pkt_queue
-{
-};
+{};
 
 struct llarp_vpn_io_impl
 {
   llarp_vpn_io_impl(llarp::Context* c, llarp_vpn_io* io) : ctx(c), parent(io)
-  {
-  }
+  {}
   ~llarp_vpn_io_impl() = default;
 
   llarp::Context* ctx;

--- a/llarp/exit/context.cpp
+++ b/llarp/exit/context.cpp
@@ -7,8 +7,7 @@ namespace llarp
   namespace exit
   {
     Context::Context(AbstractRouter* r) : m_Router(r)
-    {
-    }
+    {}
     Context::~Context() = default;
 
     void

--- a/llarp/exit/endpoint.hpp
+++ b/llarp/exit/endpoint.hpp
@@ -124,8 +124,7 @@ namespace llarp
       struct UpstreamBuffer
       {
         UpstreamBuffer(const llarp::net::IPPacket& p, uint64_t c) : pkt(p), counter(c)
-        {
-        }
+        {}
 
         llarp::net::IPPacket pkt;
         uint64_t counter;

--- a/llarp/exit/exit_messages.hpp
+++ b/llarp/exit/exit_messages.hpp
@@ -22,8 +22,7 @@ namespace llarp
       llarp::Signature Z;
 
       ObtainExitMessage() : IMessage()
-      {
-      }
+      {}
 
       ~ObtainExitMessage() override = default;
 

--- a/llarp/exit/session.hpp
+++ b/llarp/exit/session.hpp
@@ -179,8 +179,7 @@ namespace llarp
           size_t hoplen,
           bool bundleRC)
           : BaseSession(snodeRouter, writepkt, r, numpaths, hoplen, bundleRC)
-      {
-      }
+      {}
 
       ~ExitSession() override = default;
 

--- a/llarp/handlers/null.hpp
+++ b/llarp/handlers/null.hpp
@@ -12,8 +12,7 @@ namespace llarp
     {
       NullEndpoint(AbstractRouter* r, llarp::service::Context* parent)
           : llarp::service::Endpoint(r, parent)
-      {
-      }
+      {}
 
       virtual bool
       HandleInboundPacket(

--- a/llarp/iwp/linklayer.cpp
+++ b/llarp/iwp/linklayer.cpp
@@ -24,8 +24,7 @@ namespace llarp
         : ILinkLayer(
             keyManager, getrc, h, sign, before, est, reneg, timeout, closed, pumpDone, worker)
         , permitInbound{allowInbound}
-    {
-    }
+    {}
 
     LinkLayer::~LinkLayer() = default;
 

--- a/llarp/iwp/message_buffer.cpp
+++ b/llarp/iwp/message_buffer.cpp
@@ -115,8 +115,7 @@ namespace llarp
 
     InboundMessage::InboundMessage(uint64_t msgid, uint16_t sz, ShortHash h, llarp_time_t now)
         : m_Data(size_t{sz}), m_Digset{std::move(h)}, m_MsgID(msgid), m_LastActiveAt{now}
-    {
-    }
+    {}
 
     void
     InboundMessage::HandleData(uint16_t idx, const llarp_buffer_t& buf, llarp_time_t now)

--- a/llarp/link/server.cpp
+++ b/llarp/link/server.cpp
@@ -37,8 +37,7 @@ namespace llarp
       , QueueWork(std::move(work))
       , m_RouterEncSecret(keyManager->encryptionKey)
       , m_SecretKey(keyManager->transportKey)
-  {
-  }
+  {}
 
   ILinkLayer::~ILinkLayer() = default;
 

--- a/llarp/messages/discard.hpp
+++ b/llarp/messages/discard.hpp
@@ -11,8 +11,7 @@ namespace llarp
   struct DiscardMessage final : public ILinkMessage
   {
     DiscardMessage() : ILinkMessage()
-    {
-    }
+    {}
 
     bool
     BEncode(llarp_buffer_t* buf) const override

--- a/llarp/messages/link_intro.hpp
+++ b/llarp/messages/link_intro.hpp
@@ -14,8 +14,7 @@ namespace llarp
     static constexpr size_t MaxSize = MAX_RC_SIZE + 256;
 
     LinkIntroMessage() : ILinkMessage()
-    {
-    }
+    {}
 
     RouterContact rc;
     KeyExchangeNonce N;

--- a/llarp/messages/link_message_parser.cpp
+++ b/llarp/messages/link_message_parser.cpp
@@ -30,8 +30,7 @@ namespace llarp
 
   LinkMessageParser::LinkMessageParser(AbstractRouter* _router)
       : router(_router), from(nullptr), msg(nullptr), holder(std::make_unique<msg_holder_t>())
-  {
-  }
+  {}
 
   LinkMessageParser::~LinkMessageParser() = default;
 

--- a/llarp/messages/relay_commit.hpp
+++ b/llarp/messages/relay_commit.hpp
@@ -52,8 +52,7 @@ namespace llarp
 
     LR_CommitMessage(std::array<EncryptedFrame, 8> _frames)
         : ILinkMessage(), frames(std::move(_frames))
-    {
-    }
+    {}
 
     LR_CommitMessage() = default;
 

--- a/llarp/messages/relay_status.cpp
+++ b/llarp/messages/relay_status.cpp
@@ -38,8 +38,7 @@ namespace llarp
         , path(std::move(_path))
         , router(_router)
         , pathid(pathid)
-    {
-    }
+    {}
 
     ~LRSM_AsyncHandler() = default;
 

--- a/llarp/messages/relay_status.hpp
+++ b/llarp/messages/relay_status.hpp
@@ -60,8 +60,7 @@ namespace llarp
 
     LR_StatusMessage(std::array<EncryptedFrame, 8> _frames)
         : ILinkMessage(), frames(std::move(_frames))
-    {
-    }
+    {}
 
     LR_StatusMessage() = default;
 

--- a/llarp/net/exit_info.hpp
+++ b/llarp/net/exit_info.hpp
@@ -26,8 +26,7 @@ namespace llarp
     ExitInfo() = default;
 
     ExitInfo(const PubKey& pk, const IpAddress& address) : ipAddress(address), pubkey(pk)
-    {
-    }
+    {}
 
     bool
     BEncode(llarp_buffer_t* buf) const;

--- a/llarp/net/ip_address.cpp
+++ b/llarp/net/ip_address.cpp
@@ -11,8 +11,7 @@ namespace llarp
 
   IpAddress::IpAddress(const IpAddress& other)
       : m_empty(other.m_empty), m_ipAddress(other.m_ipAddress), m_port(other.m_port)
-  {
-  }
+  {}
 
   IpAddress::IpAddress(std::string_view str, std::optional<uint16_t> port)
   {

--- a/llarp/net/ip_packet.hpp
+++ b/llarp/net/ip_packet.hpp
@@ -84,7 +84,8 @@ struct ipv6_header_preamble
 
 struct ipv6_header
 {
-  union {
+  union
+  {
     ipv6_header_preamble preamble;
     uint32_t flowlabel;
   } preamble;
@@ -144,8 +145,7 @@ namespace llarp
       {
         llarp_ev_loop_ptr loop;
         PutTime(llarp_ev_loop_ptr evloop) : loop(std::move(evloop))
-        {
-        }
+        {}
         void
         operator()(IPPacket& pkt) const
         {
@@ -157,8 +157,7 @@ namespace llarp
       {
         llarp_ev_loop_ptr loop;
         GetNow(llarp_ev_loop_ptr evloop) : loop(std::move(evloop))
-        {
-        }
+        {}
         llarp_time_t
         operator()() const
         {

--- a/llarp/net/uint128.hpp
+++ b/llarp/net/uint128.hpp
@@ -24,13 +24,11 @@ namespace llarp
 
     // Initializes with 0s
     constexpr uint128_t() : uint128_t{0, 0}
-    {
-    }
+    {}
 
     // Initializes with least-significant value
     constexpr uint128_t(uint64_t lower) : uint128_t{0, lower}
-    {
-    }
+    {}
 
     // Initializes with upper and lower values
     constexpr uint128_t(uint64_t upper, uint64_t lower)
@@ -41,8 +39,7 @@ namespace llarp
         : lower{lower}, upper{upper}
 #endif
     // clang-format on
-    {
-    }
+    {}
 
     constexpr uint128_t(const uint128_t&) = default;
     constexpr uint128_t(uint128_t&&) = default;

--- a/llarp/nodedb.cpp
+++ b/llarp/nodedb.cpp
@@ -21,8 +21,7 @@ static const std::string RC_FILE_EXT = ".signed";
 
 llarp_nodedb::NetDBEntry::NetDBEntry(llarp::RouterContact value)
     : rc(std::move(value)), inserted(llarp::time_now_ms())
-{
-}
+{}
 
 bool
 llarp_nodedb::Remove(const llarp::RouterID& pk)

--- a/llarp/nodedb.hpp
+++ b/llarp/nodedb.hpp
@@ -32,8 +32,7 @@ struct llarp_nodedb
   explicit llarp_nodedb(const std::string rootdir, DiskCaller_t diskCaller)
       : disk(std::move(diskCaller)), nodePath(rootdir)
 
-  {
-  }
+  {}
 
   ~llarp_nodedb()
   {

--- a/llarp/path/path_context.cpp
+++ b/llarp/path/path_context.cpp
@@ -13,8 +13,7 @@ namespace llarp
 
     PathContext::PathContext(AbstractRouter* router)
         : m_Router(router), m_AllowTransit(false), m_PathLimits(DefaultPathBuildLimit)
-    {
-    }
+    {}
 
     void
     PathContext::AllowTransit()
@@ -358,7 +357,6 @@ namespace llarp
     }
 
     void PathContext::RemovePathSet(PathSet_ptr)
-    {
-    }
+    {}
   }  // namespace path
 }  // namespace llarp

--- a/llarp/path/pathset.cpp
+++ b/llarp/path/pathset.cpp
@@ -12,8 +12,7 @@ namespace llarp
   namespace path
   {
     PathSet::PathSet(size_t num) : numPaths(num)
-    {
-    }
+    {}
 
     bool
     PathSet::ShouldBuildMore(llarp_time_t now) const

--- a/llarp/path/transit_hop.cpp
+++ b/llarp/path/transit_hop.cpp
@@ -85,8 +85,7 @@ namespace llarp
 
     TransitHopInfo::TransitHopInfo(const RouterID& down, const LR_CommitRecord& record)
         : txID(record.txid), rxID(record.rxid), upstream(record.nextHop), downstream(down)
-    {
-    }
+    {}
 
     bool
     TransitHop::SendRoutingMessage(const routing::IMessage& msg, AbstractRouter* r)

--- a/llarp/peerstats/orm.hpp
+++ b/llarp/peerstats/orm.hpp
@@ -44,8 +44,7 @@ namespace sqlite_orm
   /// llarp_time_t serialization
   template <>
   struct type_printer<llarp_time_t> : public integer_printer
-  {
-  };
+  {};
 
   template <>
   struct statement_binder<llarp_time_t>
@@ -90,8 +89,7 @@ namespace sqlite_orm
   /// RouterID serialization
   template <>
   struct type_printer<llarp::RouterID> : public text_printer
-  {
-  };
+  {};
 
   template <>
   struct statement_binder<llarp::RouterID>

--- a/llarp/peerstats/peer_db.cpp
+++ b/llarp/peerstats/peer_db.cpp
@@ -259,9 +259,6 @@ namespace llarp
   void
   PeerDb::configure(const RouterConfig& routerConfig)
   {
-    if (not routerConfig.m_enablePeerStats)
-      throw std::runtime_error("[router]:enable-peer-stats is not enabled");
-
     fs::path dbPath = routerConfig.m_dataDir / "peerstats.sqlite";
 
     loadDatabase(dbPath);

--- a/llarp/peerstats/types.cpp
+++ b/llarp/peerstats/types.cpp
@@ -26,8 +26,7 @@ namespace llarp
   PeerStats::PeerStats() = default;
 
   PeerStats::PeerStats(const RouterID& routerId_) : routerId(routerId_)
-  {
-  }
+  {}
 
   PeerStats&
   PeerStats::operator+=(const PeerStats& other)

--- a/llarp/profiling.cpp
+++ b/llarp/profiling.cpp
@@ -96,8 +96,7 @@ namespace llarp
   }
 
   Profiling::Profiling() : m_DisableProfiling(false)
-  {
-  }
+  {}
 
   void
   Profiling::Disable()

--- a/llarp/router/outbound_message_handler.cpp
+++ b/llarp/router/outbound_message_handler.cpp
@@ -16,8 +16,7 @@ namespace llarp
 
   OutboundMessageHandler::OutboundMessageHandler(size_t maxQueueSize)
       : outboundQueue(maxQueueSize), removedPaths(20), removedSomePaths(false)
-  {
-  }
+  {}
 
   bool
   OutboundMessageHandler::QueueMessage(

--- a/llarp/router/outbound_session_maker.cpp
+++ b/llarp/router/outbound_session_maker.cpp
@@ -27,8 +27,7 @@ namespace llarp
 
     PendingSession(RouterContact _rc, LinkLayer_ptr _link)
         : rc(std::move(_rc)), link(std::move(_link))
-    {
-    }
+    {}
   };
 
   bool

--- a/llarp/router/rc_gossiper.cpp
+++ b/llarp/router/rc_gossiper.cpp
@@ -14,8 +14,7 @@ namespace llarp
 
   RCGossiper::RCGossiper()
       : I_RCGossiper(), m_Filter(std::chrono::duration_cast<Time_t>(RCGossipFilterDecayInterval))
-  {
-  }
+  {}
 
   void
   RCGossiper::Init(ILinkManager* l, const RouterID& ourID, AbstractRouter* router)

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -71,9 +71,6 @@ namespace llarp
     // our router contact
     RouterContact _rc;
 
-    /// are we using the lokid service node seed ?
-    bool usingSNSeed = false;
-
     /// should we obey the service node whitelist?
     bool whitelistRouters = false;
 

--- a/llarp/router_contact.cpp
+++ b/llarp/router_contact.cpp
@@ -45,8 +45,7 @@ namespace llarp
   }
 
   NetID::NetID() : NetID(DefaultValue().data())
-  {
-  }
+  {}
 
   bool
   NetID::operator==(const NetID& other) const

--- a/llarp/router_id.hpp
+++ b/llarp/router_id.hpp
@@ -13,16 +13,13 @@ namespace llarp
     using Data = std::array<byte_t, SIZE>;
 
     RouterID()
-    {
-    }
+    {}
 
     RouterID(const byte_t* buf) : AlignedBuffer<SIZE>(buf)
-    {
-    }
+    {}
 
     RouterID(const Data& data) : AlignedBuffer<SIZE>(data)
-    {
-    }
+    {}
 
     util::StatusObject
     ExtractStatus() const;

--- a/llarp/router_version.cpp
+++ b/llarp/router_version.cpp
@@ -9,8 +9,7 @@ namespace llarp
 {
   RouterVersion::RouterVersion(const Version_t& router, uint64_t proto)
       : m_Version(router), m_ProtoVersion(proto)
-  {
-  }
+  {}
 
   bool
   RouterVersion::IsCompatableWith(const RouterVersion& other) const

--- a/llarp/routing/message_parser.cpp
+++ b/llarp/routing/message_parser.cpp
@@ -31,8 +31,7 @@ namespace llarp
     };
 
     InboundMessageParser::InboundMessageParser() : m_Holder(std::make_unique<MessageHolder>())
-    {
-    }
+    {}
 
     InboundMessageParser::~InboundMessageParser() = default;
 

--- a/llarp/routing/path_confirm_message.cpp
+++ b/llarp/routing/path_confirm_message.cpp
@@ -10,8 +10,7 @@ namespace llarp
   {
     PathConfirmMessage::PathConfirmMessage(llarp_time_t lifetime)
         : pathLifetime(lifetime), pathCreated(time_now_ms())
-    {
-    }
+    {}
 
     bool
     PathConfirmMessage::DecodeKey(const llarp_buffer_t& key, llarp_buffer_t* val)

--- a/llarp/rpc/endpoint_rpc.cpp
+++ b/llarp/rpc/endpoint_rpc.cpp
@@ -14,8 +14,7 @@ namespace llarp::rpc
       , m_AuthWhitelist(std::move(whitelist))
       , m_LMQ(std::move(lmq))
       , m_Endpoint(std::move(endpoint))
-  {
-  }
+  {}
 
   void
   EndpointAuthRPC::Start()

--- a/llarp/rpc/rpc_server.cpp
+++ b/llarp/rpc/rpc_server.cpp
@@ -11,8 +11,7 @@
 namespace llarp::rpc
 {
   RpcServer::RpcServer(LMQ_ptr lmq, AbstractRouter* r) : m_LMQ(std::move(lmq)), m_Router(r)
-  {
-  }
+  {}
 
   /// maybe parse json from message paramter at index
   std::optional<nlohmann::json>

--- a/llarp/service/address.hpp
+++ b/llarp/service/address.hpp
@@ -37,8 +37,7 @@ namespace llarp
       FromString(std::string_view str, const char* tld = ".loki");
 
       Address() : AlignedBuffer<32>()
-      {
-      }
+      {}
 
       explicit Address(const std::string& str) : AlignedBuffer<32>()
       {
@@ -47,17 +46,14 @@ namespace llarp
       }
 
       explicit Address(const Data& buf) : AlignedBuffer<32>(buf)
-      {
-      }
+      {}
 
       Address(const Address& other)
           : AlignedBuffer<32>(other.as_array()), subdomain(other.subdomain)
-      {
-      }
+      {}
 
       explicit Address(const AlignedBuffer<32>& other) : AlignedBuffer<32>(other)
-      {
-      }
+      {}
 
       bool
       operator<(const Address& other) const

--- a/llarp/service/context.cpp
+++ b/llarp/service/context.cpp
@@ -36,8 +36,7 @@ namespace llarp
 
     }  // namespace
     Context::Context(AbstractRouter* r) : m_Router(r)
-    {
-    }
+    {}
 
     Context::~Context() = default;
 

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -505,8 +505,7 @@ namespace llarp
           , m_IntroSet(std::move(introset))
           , m_Endpoint(parent)
           , m_relayOrder(relayOrder)
-      {
-      }
+      {}
 
       std::shared_ptr<routing::IMessage>
       BuildRequestMessage() override

--- a/llarp/service/hidden_service_address_lookup.cpp
+++ b/llarp/service/hidden_service_address_lookup.cpp
@@ -20,8 +20,7 @@ namespace llarp
         , relayOrder(order)
         , location(l)
         , handle(std::move(h))
-    {
-    }
+    {}
 
     bool
     HiddenServiceAddressLookup::HandleIntrosetResponse(const std::set<EncryptedIntroSet>& results)

--- a/llarp/service/protocol.cpp
+++ b/llarp/service/protocol.cpp
@@ -19,8 +19,7 @@ namespace llarp
     }
 
     ProtocolMessage::ProtocolMessage(const ConvoTag& t) : tag(t)
-    {
-    }
+    {}
 
     ProtocolMessage::~ProtocolMessage() = default;
 
@@ -292,8 +291,7 @@ namespace llarp
           , handler(h)
           , frame(f)
           , fromIntro(recvIntro)
-      {
-      }
+      {}
 
       static void
       Work(std::shared_ptr<AsyncFrameDecrypt> self)

--- a/llarp/service/router_lookup_job.cpp
+++ b/llarp/service/router_lookup_job.cpp
@@ -9,8 +9,7 @@ namespace llarp
   {
     RouterLookupJob::RouterLookupJob(Endpoint* p, RouterLookupHandler h)
         : handler(std::move(h)), txid(p->GenTXID()), started(p->Now())
-    {
-    }
+    {}
 
   }  // namespace service
 }  // namespace llarp

--- a/llarp/service/sendcontext.cpp
+++ b/llarp/service/sendcontext.cpp
@@ -22,8 +22,7 @@ namespace llarp
         , m_Endpoint(ep)
         , createdAt(ep->Now())
         , m_SendQueue(SendContextQueueSize)
-    {
-    }
+    {}
 
     bool
     SendContext::Send(std::shared_ptr<ProtocolFrame> msg, path::Path_ptr path)

--- a/llarp/service/tag.hpp
+++ b/llarp/service/tag.hpp
@@ -18,12 +18,10 @@ namespace llarp
     struct Tag : public AlignedBuffer<16>
     {
       Tag() : AlignedBuffer<SIZE>()
-      {
-      }
+      {}
 
       Tag(const byte_t* d) : AlignedBuffer<SIZE>(d)
-      {
-      }
+      {}
 
       Tag(const std::string& str) : Tag()
       {

--- a/llarp/simulation/sim_context.cpp
+++ b/llarp/simulation/sim_context.cpp
@@ -6,13 +6,11 @@ namespace llarp
   namespace simulate
   {
     Simulation::Simulation() : m_CryptoManager(new sodium::CryptoLibSodium())
-    {
-    }
+    {}
 
     void
     Simulation::NodeUp(llarp::Context*)
-    {
-    }
+    {}
 
     Node_ptr
     Simulation::AddNode(const std::string& name)

--- a/llarp/tooling/dht_event.hpp
+++ b/llarp/tooling/dht_event.hpp
@@ -22,8 +22,7 @@ namespace tooling
         , introsetPubkey(introsetPubkey_)
         , relay(relay_)
         , relayIndex(relayIndex_)
-    {
-    }
+    {}
 
     std::string
     ToString() const
@@ -51,8 +50,7 @@ namespace tooling
         , location(location_)
         , txid(txid_)
         , relayOrder(relayOrder_)
-    {
-    }
+    {}
 
     std::string
     ToString() const override
@@ -79,8 +77,7 @@ namespace tooling
         , From(from_)
         , Introset(introset_)
         , TxID(txid_)
-    {
-    }
+    {}
 
     std::string
     ToString() const override
@@ -108,8 +105,7 @@ namespace tooling
         , exploritory(msg.exploritory)
         , txid(msg.txid)
         , version(msg.version)
-    {
-    }
+    {}
 
     std::string
     ToString() const override

--- a/llarp/tooling/hive_context.cpp
+++ b/llarp/tooling/hive_context.cpp
@@ -5,8 +5,7 @@
 namespace tooling
 {
   HiveContext::HiveContext(RouterHive* hive) : m_hive(hive)
-  {
-  }
+  {}
 
   std::unique_ptr<llarp::AbstractRouter>
   HiveContext::makeRouter(llarp_ev_loop_ptr netloop, std::shared_ptr<llarp::Logic> logic)

--- a/llarp/tooling/hive_router.cpp
+++ b/llarp/tooling/hive_router.cpp
@@ -7,8 +7,7 @@ namespace tooling
   HiveRouter::HiveRouter(
       llarp_ev_loop_ptr netloop, std::shared_ptr<llarp::Logic> logic, RouterHive* hive)
       : Router(netloop, logic), m_hive(hive)
-  {
-  }
+  {}
 
   bool
   HiveRouter::disableGossipingRC_TestingOnly()

--- a/llarp/tooling/path_event.hpp
+++ b/llarp/tooling/path_event.hpp
@@ -15,8 +15,7 @@ namespace tooling
         : RouterEvent("PathAttemptEvent", routerID, false)
         , hops(path->hops)
         , pathid(path->hops[0].rxID)
-    {
-    }
+    {}
 
     std::string
     ToString() const
@@ -58,8 +57,7 @@ namespace tooling
         , txid(hop->info.txID)
         , rxid(hop->info.rxID)
         , isEndpoint(routerID == nextHop ? true : false)
-    {
-    }
+    {}
 
     std::string
     ToString() const
@@ -93,8 +91,7 @@ namespace tooling
     PathStatusReceivedEvent(
         const llarp::RouterID& routerID, const llarp::PathID_t rxid_, uint64_t status_)
         : RouterEvent("PathStatusReceivedEvent", routerID, true), rxid(rxid_), status(status_)
-    {
-    }
+    {}
 
     std::string
     ToString() const
@@ -119,8 +116,7 @@ namespace tooling
         : RouterEvent("PathBuildRejectedEvent", routerID, false)
         , rxid(rxid_)
         , rejectedBy(rejectedBy_)
-    {
-    }
+    {}
 
     std::string
     ToString() const

--- a/llarp/tooling/peer_stats_event.hpp
+++ b/llarp/tooling/peer_stats_event.hpp
@@ -14,8 +14,7 @@ namespace tooling
         : RouterEvent("Link: LinkSessionEstablishedEvent", ourRouterId, false)
         , remoteId(remoteId_)
         , inbound(inbound_)
-    {
-    }
+    {}
 
     std::string
     ToString() const
@@ -31,8 +30,7 @@ namespace tooling
 
     ConnectionAttemptEvent(const llarp::RouterID& ourRouterId, const llarp::RouterID& remoteId_)
         : RouterEvent("Link: ConnectionAttemptEvent", ourRouterId, false), remoteId(remoteId_)
-    {
-    }
+    {}
 
     std::string
     ToString() const

--- a/llarp/tooling/rc_event.hpp
+++ b/llarp/tooling/rc_event.hpp
@@ -10,8 +10,7 @@ namespace tooling
   {
     RCGossipReceivedEvent(const llarp::RouterID& routerID, const llarp::RouterContact& rc_)
         : RouterEvent("RCGossipReceivedEvent", routerID, true), rc(rc_)
-    {
-    }
+    {}
 
     std::string
     ToString() const override
@@ -33,8 +32,7 @@ namespace tooling
   {
     RCGossipSentEvent(const llarp::RouterID& routerID, const llarp::RouterContact& rc_)
         : RouterEvent("RCGossipSentEvent", routerID, true), rc(rc_)
-    {
-    }
+    {}
 
     std::string
     ToString() const override

--- a/llarp/tooling/router_event.hpp
+++ b/llarp/tooling/router_event.hpp
@@ -29,8 +29,7 @@ namespace tooling
   {
     RouterEvent(std::string eventType, llarp::RouterID routerID, bool triggered)
         : eventType(eventType), routerID(routerID), triggered(triggered)
-    {
-    }
+    {}
 
     virtual ~RouterEvent() = default;
 

--- a/llarp/util/buffer.hpp
+++ b/llarp/util/buffer.hpp
@@ -78,22 +78,19 @@ struct llarp_buffer_t
   llarp_buffer_t() = default;
 
   llarp_buffer_t(byte_t* b, byte_t* c, size_t s) : base(b), cur(c), sz(s)
-  {
-  }
+  {}
 
   llarp_buffer_t(const ManagedBuffer&) = delete;
   llarp_buffer_t(ManagedBuffer&&) = delete;
 
   template <typename T>
   llarp_buffer_t(T* buf, size_t _sz) : base(reinterpret_cast<byte_t*>(buf)), cur(base), sz(_sz)
-  {
-  }
+  {}
 
   template <typename T>
   llarp_buffer_t(const T* buf, size_t _sz)
       : base(reinterpret_cast<byte_t*>(const_cast<T*>(buf))), cur(base), sz(_sz)
-  {
-  }
+  {}
 
   /** initialize llarp_buffer_t from container */
   template <typename T>
@@ -106,8 +103,7 @@ struct llarp_buffer_t
 
   template <typename T>
   llarp_buffer_t(const T& t) : llarp_buffer_t(t.data(), t.size())
-  {
-  }
+  {}
 
   // clang-format off
   byte_t * begin()       { return base; }
@@ -204,8 +200,7 @@ struct ManagedBuffer
   ManagedBuffer() = delete;
 
   explicit ManagedBuffer(const llarp_buffer_t& b) : underlying(b)
-  {
-  }
+  {}
 
   ManagedBuffer(ManagedBuffer&&) = default;
   ManagedBuffer(const ManagedBuffer&) = default;

--- a/llarp/util/codel.hpp
+++ b/llarp/util/codel.hpp
@@ -42,8 +42,7 @@ namespace llarp
           , m_name(std::move(name))
           , _putTime(std::move(put))
           , _getNow(std::move(now))
-      {
-      }
+      {}
 
       size_t
       Size() EXCLUDES(m_QueueMutex)

--- a/llarp/util/decaying_hashset.hpp
+++ b/llarp/util/decaying_hashset.hpp
@@ -14,8 +14,7 @@ namespace llarp
       using Time_t = std::chrono::milliseconds;
 
       DecayingHashSet(Time_t cacheInterval = 5s) : m_CacheInterval(cacheInterval)
-      {
-      }
+      {}
       /// determine if we have v contained in our decaying hashset
       bool
       Contains(const Val_t& v) const

--- a/llarp/util/decaying_hashtable.hpp
+++ b/llarp/util/decaying_hashtable.hpp
@@ -9,8 +9,7 @@ namespace llarp::util
   struct DecayingHashTable
   {
     DecayingHashTable(std::chrono::milliseconds cacheInterval = 1h) : m_CacheInterval(cacheInterval)
-    {
-    }
+    {}
 
     void
     Decay(llarp_time_t now)

--- a/llarp/util/logging/android_logger.cpp
+++ b/llarp/util/logging/android_logger.cpp
@@ -37,12 +37,10 @@ namespace llarp
 
   void
   AndroidLogStream::PostLog(std::stringstream&) const
-  {
-  }
+  {}
 
   void AndroidLogStream::Tick(llarp_time_t)
-  {
-  }
+  {}
 
   void
   AndroidLogStream::Print(LogLevel lvl, const char* tag, const std::string& msg)

--- a/llarp/util/logging/json_logger.hpp
+++ b/llarp/util/logging/json_logger.hpp
@@ -13,8 +13,7 @@ namespace llarp
         llarp_time_t flushInterval,
         bool closeFile)
         : FileLogStream(std::move(disk), f, flushInterval, closeFile)
-    {
-    }
+    {}
 
     void
     AppendLog(

--- a/llarp/util/logging/logger.cpp
+++ b/llarp/util/logging/logger.cpp
@@ -46,8 +46,7 @@ namespace llarp
 
   LogContext::LogContext()
       : logStream(std::make_unique<Stream_t>(_LOGSTREAM_INIT)), started(llarp::time_now_ms())
-  {
-  }
+  {}
 
   LogContext&
   LogContext::Instance()
@@ -69,15 +68,13 @@ namespace llarp
   }
 
   log_timestamp::log_timestamp() : log_timestamp("%c %Z")
-  {
-  }
+  {}
 
   log_timestamp::log_timestamp(const char* fmt)
       : format(fmt)
       , now(llarp::time_now_ms())
       , delta(llarp::time_now_ms() - LogContext::Instance().started)
-  {
-  }
+  {}
 
   void
   SetLogLevel(LogLevel lvl)
@@ -174,12 +171,10 @@ namespace llarp
   }
 
   LogSilencer::LogSilencer() : LogSilencer(LogContext::Instance())
-  {
-  }
+  {}
 
   LogSilencer::LogSilencer(LogContext& ctx) : parent(ctx), stream(std::move(ctx.logStream))
-  {
-  }
+  {}
 
   LogSilencer::~LogSilencer()
   {

--- a/llarp/util/logging/logger.cpp
+++ b/llarp/util/logging/logger.cpp
@@ -113,7 +113,7 @@ namespace llarp
     nodeName = nickname;
 
     FILE* logfile = nullptr;
-    if (file == "stdout" or file.empty())
+    if (file == "stdout" or file == "-" or file.empty())
     {
       logfile = stdout;
     }

--- a/llarp/util/logging/logger_internal.hpp
+++ b/llarp/util/logging/logger_internal.hpp
@@ -12,8 +12,7 @@ namespace llarp
   /** internal, recursion terminator */
   constexpr void
   LogAppend(std::stringstream&) noexcept
-  {
-  }
+  {}
   /** internal */
   template <typename TArg, typename... TArgs>
   void

--- a/llarp/util/logging/logger_syslog.hpp
+++ b/llarp/util/logging/logger_syslog.hpp
@@ -24,12 +24,10 @@ namespace llarp
 
     virtual void
     ImmediateFlush() override
-    {
-    }
+    {}
 
     void Tick(llarp_time_t) override
-    {
-    }
+    {}
   };
 }  // namespace llarp
 #endif

--- a/llarp/util/logging/ostream_logger.cpp
+++ b/llarp/util/logging/ostream_logger.cpp
@@ -5,8 +5,7 @@ namespace llarp
 {
   OStreamLogStream::OStreamLogStream(bool withColours, std::ostream& out)
       : m_withColours(withColours), m_Out(out)
-  {
-  }
+  {}
 
   void
   OStreamLogStream::PreLog(

--- a/llarp/util/logging/ostream_logger.hpp
+++ b/llarp/util/logging/ostream_logger.hpp
@@ -30,8 +30,7 @@ namespace llarp
     ImmediateFlush() override;
 
     void Tick(llarp_time_t) override
-    {
-    }
+    {}
 
    private:
     bool m_withColours;

--- a/llarp/util/logging/syslog_logger.cpp
+++ b/llarp/util/logging/syslog_logger.cpp
@@ -45,8 +45,7 @@ namespace llarp
 
   void
   SysLogStream::PostLog(std::stringstream&) const
-  {
-  }
+  {}
 
 }  // namespace llarp
 #endif

--- a/llarp/util/meta/traits.hpp
+++ b/llarp/util/meta/traits.hpp
@@ -12,8 +12,7 @@ namespace llarp
   {
     /// Represents the empty type
     struct Bottom
-    {
-    };
+    {};
 
     /// Int tag
     template <size_t N>
@@ -25,8 +24,7 @@ namespace llarp
     /// Type trait representing whether a type is pointer-like
     template <typename T, typename _ = void>
     struct is_pointy : public std::false_type
-    {
-    };
+    {};
 
     // We take the following things:
     // - has element_type typedef
@@ -35,14 +33,12 @@ namespace llarp
     template <typename T>
     struct is_pointy<T, std::conditional_t<false, std::void_t<decltype(*std::declval<T>())>, void>>
         : public std::true_type
-    {
-    };
+    {};
 
     /// Type trait representing whether a type is an STL-style container
     template <typename T, typename _ = void>
     struct is_container : public std::false_type
-    {
-    };
+    {};
 
     // We take that the container has begin, end and size methods to be a
     // container.
@@ -95,8 +91,7 @@ namespace llarp
       /// meta function which always returns false
       template <typename>
       class False : public std::false_type
-      {
-      };
+      {};
 
       /// a case in the selection
       template <template <typename...> class Trait = False>
@@ -105,8 +100,7 @@ namespace llarp
        public:
         template <typename Type>
         struct Selector : public Trait<Type>::type
-        {
-        };
+        {};
 
         using Type = Case;
       };

--- a/llarp/util/printer.hpp
+++ b/llarp/util/printer.hpp
@@ -18,8 +18,7 @@ namespace llarp
     std::ios_base::fmtflags m_flags;
 
     FormatFlagsGuard(std::ios_base& base) : m_base(base), m_flags(base.flags())
-    {
-    }
+    {}
 
     ~FormatFlagsGuard()
     {

--- a/llarp/util/thread/barrier.hpp
+++ b/llarp/util/thread/barrier.hpp
@@ -16,8 +16,7 @@ namespace llarp
 
      public:
       Barrier(unsigned threads) : pending{threads}
-      {
-      }
+      {}
 
       /// Returns true if *this* Block call is the one that releases all of
       /// them; returns false (i.e. after unblocking) if some other thread

--- a/llarp/util/thread/queue.hpp
+++ b/llarp/util/thread/queue.hpp
@@ -127,8 +127,7 @@ namespace llarp
      public:
       QueuePushGuard(Queue<Type>& queue, uint32_t generation, uint32_t index)
           : m_queue(&queue), m_generation(generation), m_index(index)
-      {
-      }
+      {}
 
       ~QueuePushGuard();
 
@@ -150,8 +149,7 @@ namespace llarp
      public:
       QueuePopGuard(Queue<Type>& queue, uint32_t generation, uint32_t index)
           : m_queue(queue), m_generation(generation), m_index(index)
-      {
-      }
+      {}
 
       ~QueuePopGuard();
     };

--- a/llarp/util/thread/threading.hpp
+++ b/llarp/util/thread/threading.hpp
@@ -67,14 +67,12 @@ namespace llarp
 #else
       void
       lock() const
-      {
-      }
+      {}
 #endif
       // Does nothing; once locked the mutex belongs to that thread forever
       void
       unlock() const
-      {
-      }
+      {}
     };
 
     /// a lock that does nothing
@@ -116,8 +114,7 @@ namespace llarp
 
      public:
       Semaphore(size_t count) : m_count(count)
-      {
-      }
+      {}
 
       void
       notify() EXCLUDES(m_mutex)

--- a/llarp/win32/win32_intrnl.c
+++ b/llarp/win32/win32_intrnl.c
@@ -58,8 +58,7 @@ SetThreadName(DWORD dwThreadID, LPCSTR szThreadName)
       RaiseException(EXCEPTION_SET_THREAD_NAME, 0, infosize, (DWORD*)&info);
     }
     __except (EXCEPTION_EXECUTE_HANDLER)
-    {
-    }
+    {}
   }
   /* clean up */
   if (hThread)

--- a/pybind/llarp/config.cpp
+++ b/pybind/llarp/config.cpp
@@ -48,13 +48,11 @@ namespace llarp
             })
         .def_readwrite("workerThreads", &RouterConfig::m_workerThreads)
         .def_readwrite("numNetThreads", &RouterConfig::m_numNetThreads)
-        .def_readwrite("JobQueueSize", &RouterConfig::m_JobQueueSize)
-        .def_readwrite("enablePeerStats", &RouterConfig::m_enablePeerStats);
+        .def_readwrite("JobQueueSize", &RouterConfig::m_JobQueueSize);
 
     py::class_<NetworkConfig>(mod, "NetworkConfig")
         .def(py::init<>())
         .def_readwrite("enableProfiling", &NetworkConfig::m_enableProfiling)
-        .def_readwrite("routerProfilesFile", &NetworkConfig::m_routerProfilesFile)
         .def_readwrite("endpointType", &NetworkConfig::m_endpointType)
         .def_readwrite("keyfile", &NetworkConfig::m_keyfile)
         .def_readwrite("endpointType", &NetworkConfig::m_endpointType)
@@ -99,7 +97,6 @@ namespace llarp
 
     py::class_<LokidConfig>(mod, "LokidConfig")
         .def(py::init<>())
-        .def_readwrite("usingSNSeed", &LokidConfig::usingSNSeed)
         .def_readwrite("whitelistRouters", &LokidConfig::whitelistRouters)
         .def_readwrite("ident_keyfile", &LokidConfig::ident_keyfile)
         .def_property(

--- a/pybind/llarp/handlers/pyhandler.hpp
+++ b/pybind/llarp/handlers/pyhandler.hpp
@@ -18,8 +18,7 @@ namespace llarp
           : llarp::service::Endpoint(
               routerContext->router.get(), &routerContext->router->hiddenServiceContext())
           , OurName(std::move(name))
-      {
-      }
+      {}
       const std::string OurName;
 
       bool

--- a/pybind/llarp/tooling/peer_stats_event.hpp
+++ b/pybind/llarp/tooling/peer_stats_event.hpp
@@ -14,8 +14,7 @@ namespace tooling
         : RouterEvent("Link: LinkSessionEstablishedEvent", ourRouterId, false)
         , remoteId(remoteId_)
         , inbound(inbound_)
-    {
-    }
+    {}
 
     std::string
     ToString() const

--- a/test/config/test_llarp_config_output.cpp
+++ b/test/config/test_llarp_config_output.cpp
@@ -23,6 +23,7 @@ TEST_CASE("ConfigDefinition simple generate test", "[config]")
 
   CHECK(output == R"raw([foo]
 
+
 bar=1
 
 #baz=2
@@ -31,6 +32,7 @@ quux=hello
 
 
 [argle]
+
 
 bar=3
 
@@ -46,14 +48,14 @@ TEST_CASE("ConfigDefinition useValue test", "[config]")
 
   config.defineOption<int>("foo", "bar", Required, Default{1});
 
-  constexpr auto expected = "[foo]\n\nbar=1\n";
+  constexpr auto expected = "[foo]\n\n\nbar=1\n";
 
   CHECK(config.generateINIConfig(false) == expected);
   CHECK(config.generateINIConfig(true) == expected);
 
   config.addConfigValue("foo", "bar", "2");
 
-  constexpr auto expectedWhenValueProvided = "[foo]\n\nbar=2\n";
+  constexpr auto expectedWhenValueProvided = "[foo]\n\n\nbar=2\n";
 
   CHECK(config.generateINIConfig(false) == expected);
   CHECK(config.generateINIConfig(true) == expectedWhenValueProvided);
@@ -74,6 +76,7 @@ TEST_CASE("ConfigDefinition section comments test")
 # test comment
 # test comment 2
 
+
 bar=1
 )raw");
 }
@@ -92,6 +95,9 @@ TEST_CASE("ConfigDefinition option comments test")
         "___defg",
       });
 
+  config.defineOption<int>("client", "omg", ClientOnly, Default{1}, Comment{"hi"});
+  config.defineOption<int>("relay", "ftw", RelayOnly, Default{1}, Comment{"bye"});
+
   // has comment, so still gets shown.
   config.defineOption<int>("foo", "old-bar", Hidden, Default{456});
   config.addOptionComments("foo", "old-bar", {"old bar option"});
@@ -103,6 +109,7 @@ TEST_CASE("ConfigDefinition option comments test")
 
   CHECK(output == R"raw([foo]
 
+
 # test comment 1
 # test comment 2
 bar=1
@@ -113,6 +120,13 @@ bar=1
 
 # old bar option
 #old-bar=456
+
+
+[relay]
+
+
+# bye
+#ftw=1
 )raw");
 }
 
@@ -132,6 +146,7 @@ TEST_CASE("ConfigDefinition empty comments test")
   CHECK(output == R"raw([foo]
 # section comment
 # 
+
 
 # option comment
 # 
@@ -155,6 +170,7 @@ TEST_CASE("ConfigDefinition multi option comments")
 
   CHECK(output == R"raw([foo]
 # foo section comment
+
 
 # foo bar option comment
 bar=1

--- a/test/exit/test_llarp_exit_context.cpp
+++ b/test/exit/test_llarp_exit_context.cpp
@@ -18,7 +18,6 @@ make_context()
   conf.network.m_endpointType = "null";
   conf.bootstrap.skipBootstrap = true;
   conf.api.m_enableRPCServer = false;
-  conf.router.m_enablePeerStats = true;
   conf.lokid.whitelistRouters = false;
   conf.router.m_publicAddress = llarp::IpAddress("1.1.1.1");
   // make a fake inbound link


### PR DESCRIPTION
API improvements:
=================

Make the config API use position-independent tag parameters (Required,
Default{123}, MultiValue) rather than a sequence of bools with
overloads.  For example, instead of:

    conf.defineOption<int>("a", "b", false, true, 123, [] { ... });

you now write:

    conf.defineOption<int>("a", "b", MultiValue, Default{123}, [] { ... });

The tags are:
- Required
- MultiValue
- Default{value}
plus new abilities (see below):
- Hidden
- RelayOnly
- ClientOnly
- Comment{"line1", "line2", "line3"}

Made option definition more powerful:
=====================================

- `Hidden` allows you to define an option that won't show up in the
  generated config file if it isn't set.

- `RelayOnly`/`ClientOnly` sets up an option that is only accepted and
  only shows up for relay or client configs.  (If neither is specified
  the option shows up in both modes).

- `Comment{...}` lets the option comments be specified as part of the
  defineOption.

Comment improvements
====================

- Rewrote comments for various options to expand on details.
- Inlined all the comments with the option definitions.
- Several options that were missing comments got comments added.
- Made various options for deprecated and or internal options hidden by
  default so that they don't show up in a default config file.
- show the section comment (but not option comments) *after* the
  [section] tag instead of before it as it makes more sense that way
  (particularly for the [bind] section which has a new long comment to
  describe how it works).

Disable profiling by default
============================

We had this weird state where we use and store profiling by default but
never *load* it when starting up.  This commit makes us just not use
profiling at all unless explicitly enabled.

Other misc changes:
===================

- change default worker threads to 0 (= num cpus) instead of 1, and fix
  it to allow 0.
- fixed default data-dir value erroneously having quotes around it
- reordered ifname/ifaddr/mapaddr (was previously mapaddr/ifaddr/ifname)
  as mapaddr is a sort of specialization of ifaddr and so makes more
  sense to come after it (particularly because it now references ifaddr
  in its help message).
- removed peer-stats option (since we always require it for relays and
  never use it for clients)
- removed router profiles filename option (this doesn't need to be
  configurable)
- removed defunct `service-node-seed` option
- Change default logging output file to "" (which means stdout), and
  also made "-" work for stdout.