### PR TITLE
macos package fixes for 0.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)  # bionic's cmake version
 
 # Has to be set before `project()`, and ignored on non-macos:
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14 CACHE STRING "macOS deployment target (Apple clang only)")
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "macOS deployment target (Apple clang only)")
 
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
@@ -376,10 +376,6 @@ if(NOT TARGET uninstall)
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 endif()
 
-
-if(BUILD_PACKAGE)
-    include(cmake/installer.cmake)
-endif()
 
 if(BUILD_PACKAGE)
     include(cmake/installer.cmake)

--- a/cmake/macos_installer_deps.cmake
+++ b/cmake/macos_installer_deps.cmake
@@ -26,7 +26,7 @@ ExternalProject_Add(lokinet-gui
     GIT_REPOSITORY "${LOKINET_GUI_REPO}"
     GIT_TAG "${LOKINET_GUI_CHECKOUT}"
     CMAKE_ARGS -DMACOS_APP=ON -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR} -DMACOS_SIGN=${MACOS_SIGN_APP}
-        -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+        -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH} -DBUILD_STATIC_DEPS=ON -DBUILD_SHARED_LIBS=OFF
     )
 
 
@@ -60,16 +60,15 @@ set(CPACK_GENERATOR "productbuild")
 set(CPACK_PACKAGING_INSTALL_PREFIX "/opt/lokinet")
 set(CPACK_POSTFLIGHT_LOKINET_SCRIPT ${CMAKE_SOURCE_DIR}/contrib/macos/postinstall)
 
-# The GUI is GPLv3, and so the bundled core+GUI must be as well:
-set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/contrib/gpl-3.0.txt")
+set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE.txt")
 
 set(CPACK_PRODUCTBUILD_IDENTITY_NAME "${MACOS_SIGN_PKG}")
 
 if(MACOS_SIGN_APP)
     add_custom_target(sign ALL
-        echo "Signing lokinet and lokinetctl binaries"
-        COMMAND codesign -s "${MACOS_SIGN_APP}" --strict --options runtime --force -vvv $<TARGET_FILE:lokinet> $<TARGET_FILE:lokinetctl>
-        DEPENDS lokinet lokinetctl
+        echo "Signing lokinet and lokinet-vpn binaries"
+        COMMAND codesign -s "${MACOS_SIGN_APP}" --strict --options runtime --force -vvv $<TARGET_FILE:lokinet> $<TARGET_FILE:lokinet-vpn>
+        DEPENDS lokinet lokinet-vpn
         )
 endif()
 


### PR DESCRIPTION
- bumps deployment target to 10.15 because earlier versions don't
  support C++17.
- remove double-include of installer.cmake
- use new static dep lokinet build system
- replace lokinetctl with lokinet-vpn