### PR TITLE
Reduce macOS target to 10.12, and fix target for deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)  # bionic's cmake version
 
 # Has to be set before `project()`, and ignored on non-macos:
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14 CACHE STRING "macOS deployment target (Apple clang only)")
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "macOS deployment target (Apple clang only)")
 
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)


### PR DESCRIPTION
This is relatively painless for lokinet as it already had workarounds
during 0.8 dev work for the things macos hated in 10.13.

Dependencies, however, were not being built with the proper macos target
junk, so this fixes that.