### PR TITLE
Some Windows fixes

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -304,7 +304,8 @@ TellWindowsServiceStopped()
   {
     auto error_code = GetLastError();
     if (error_code == ERROR_INVALID_DATA)
-      llarp::LogError("SetServiceStatus failed: \"The specified service status structure is invalid.\"");
+      llarp::LogError(
+          "SetServiceStatus failed: \"The specified service status structure is invalid.\"");
     else if (error_code == ERROR_INVALID_HANDLE)
       llarp::LogError("SetServiceStatus failed: \"The specified handle is invalid.\"");
     else

--- a/llarp/dns/server.cpp
+++ b/llarp/dns/server.cpp
@@ -50,7 +50,8 @@ namespace llarp
       LogicCall(m_ClientLogic, [=]() {
         llarp_ev_add_udp(self->m_ClientLoop.get(), &self->m_Client, any.createSockAddr());
       });
-      return (llarp_ev_add_udp(self->m_ServerLoop.get(), &self->m_Server, addr.createSockAddr()) == 0);
+      return (
+          llarp_ev_add_udp(self->m_ServerLoop.get(), &self->m_Server, addr.createSockAddr()) == 0);
     }
 
     static Proxy::Buffer_t

--- a/llarp/dns/server.cpp
+++ b/llarp/dns/server.cpp
@@ -40,6 +40,7 @@ namespace llarp
       {
         if (not SetupUnboundResolver(resolvers))
         {
+          llarp::LogError("Failed to add upstream resolvers during DNS server setup.");
           return false;
         }
       }
@@ -49,7 +50,7 @@ namespace llarp
       LogicCall(m_ClientLogic, [=]() {
         llarp_ev_add_udp(self->m_ClientLoop.get(), &self->m_Client, any.createSockAddr());
       });
-      return llarp_ev_add_udp(self->m_ServerLoop.get(), &self->m_Server, addr.createSockAddr());
+      return (llarp_ev_add_udp(self->m_ServerLoop.get(), &self->m_Server, addr.createSockAddr()) == 0);
     }
 
     static Proxy::Buffer_t

--- a/llarp/dns/unbound_resolver.cpp
+++ b/llarp/dns/unbound_resolver.cpp
@@ -122,6 +122,11 @@ namespace llarp::dns
     {
       return false;
     }
+
+#ifdef _WIN32
+    ub_ctx_async(unboundContext, 1);
+#endif
+
     started = true;
     RegisterPollFD();
     return true;

--- a/llarp/dns/unbound_resolver.cpp
+++ b/llarp/dns/unbound_resolver.cpp
@@ -41,6 +41,8 @@ namespace llarp::dns
     runnerThread = std::make_unique<std::thread>([self = shared_from_this()]() {
       while (self->started)
       {
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for(20ms);
         ub_wait(self->unboundContext);
       }
     });

--- a/llarp/ev/ev.cpp
+++ b/llarp/ev/ev.cpp
@@ -37,10 +37,14 @@ int
 llarp_ev_add_udp(struct llarp_ev_loop* ev, struct llarp_udp_io* udp, const llarp::SockAddr& src)
 {
   if (ev == nullptr or udp == nullptr)
+  {
+    llarp::LogError("Attempting llarp_ev_add_udp() with null event loop or udp io struct.");
     return -1;
+  }
   udp->parent = ev;
   if (ev->udp_listen(udp, src))
     return 0;
+  llarp::LogError("llarp_ev_add_udp() call to udp_listen failed.");
   return -1;
 }
 

--- a/llarp/ev/ev_libuv.cpp
+++ b/llarp/ev/ev_libuv.cpp
@@ -294,8 +294,10 @@ namespace libuv
     static void
     OnTick(uv_check_t* t)
     {
+      llarp::LogTrace("conn_glue::OnTick() start");
       conn_glue* conn = static_cast<conn_glue*>(t->data);
       conn->Tick();
+      llarp::LogTrace("conn_glue::OnTick() end");
     }
 
     void
@@ -367,10 +369,12 @@ namespace libuv
     static void
     OnTick(uv_check_t* t)
     {
+      llarp::LogTrace("ticker_glue::OnTick() start");
       ticker_glue* ticker = static_cast<ticker_glue*>(t->data);
       ticker->func();
       Loop* loop = static_cast<Loop*>(t->loop->data);
       loop->FlushLogic();
+      llarp::LogTrace("ticker_glue::OnTick() end");
     }
 
     bool
@@ -446,8 +450,10 @@ namespace libuv
     static void
     OnTick(uv_check_t* t)
     {
+      llarp::LogTrace("udp_glue::OnTick() start");
       udp_glue* udp = static_cast<udp_glue*>(t->data);
       udp->Tick();
+      llarp::LogTrace("udp_glue::OnTick() end");
     }
 
     void
@@ -570,8 +576,10 @@ namespace libuv
     static void
     OnTick(uv_check_t* h)
     {
+      llarp::LogTrace("pipe_glue::OnTick() start");
       pipe_glue* pipe = static_cast<pipe_glue*>(h->data);
       LoopCall(h, std::bind(&pipe_glue::Tick, pipe));
+      llarp::LogTrace("pipe_glue::OnTick() end");
     }
 
     bool
@@ -613,8 +621,10 @@ namespace libuv
     static void
     OnTick(uv_check_t* timer)
     {
+      llarp::LogTrace("tun_glue::OnTick() start");
       tun_glue* tun = static_cast<tun_glue*>(timer->data);
       tun->Tick();
+      llarp::LogTrace("tun_glue::OnTick() end");
     }
 
     static void
@@ -740,16 +750,19 @@ namespace libuv
   void
   Loop::FlushLogic()
   {
+    llarp::LogTrace("Loop::FlushLogic() start");
     while (not m_LogicCalls.empty())
     {
       auto f = m_LogicCalls.popFront();
       f();
     }
+    llarp::LogTrace("Loop::FlushLogic() end");
   }
 
   static void
   OnAsyncWake(uv_async_t* async_handle)
   {
+    llarp::LogTrace("OnAsyncWake, ticking event loop.");
     Loop* loop = static_cast<Loop*>(async_handle->data);
     loop->update_time();
     loop->process_timer_queue();
@@ -825,6 +838,7 @@ namespace libuv
   int
   Loop::run()
   {
+    llarp::LogTrace("Loop::run()");
     m_EventLoopThreadID = std::this_thread::get_id();
     return uv_run(&m_Impl, UV_RUN_DEFAULT);
   }
@@ -871,6 +885,7 @@ namespace libuv
   uint32_t
   Loop::call_after_delay(llarp_time_t delay_ms, std::function<void(void)> callback)
   {
+    llarp::LogTrace("Loop::call_after_delay()");
 #ifdef TESTNET_SPEED
     delay_ms *= TESTNET_SPEED;
 #endif
@@ -982,6 +997,7 @@ namespace libuv
     {
       return true;
     }
+    llarp::LogError("Loop::udp_listen failed to bind");
     delete impl;
     return false;
   }

--- a/llarp/ev/ev_libuv.cpp
+++ b/llarp/ev/ev_libuv.cpp
@@ -1077,16 +1077,9 @@ namespace libuv
     }
     const auto inEventLoop = *m_EventLoopThreadID == std::this_thread::get_id();
 
-    while (m_LogicCalls.full() and inEventLoop)
-    {
-      FlushLogic();
-    }
     if (inEventLoop)
     {
-      if (m_LogicCalls.tryPushBack(f) != llarp::thread::QueueReturn::Success)
-      {
-        LogError("logic job queue is full");
-      }
+      f();
     }
     else
       m_LogicCalls.pushBack(f);

--- a/llarp/ev/ev_libuv.cpp
+++ b/llarp/ev/ev_libuv.cpp
@@ -6,7 +6,6 @@
 
 namespace libuv
 {
-
 #define LoopCall(h, ...)    \
   {                         \
     auto __f = __VA_ARGS__; \

--- a/llarp/ev/ev_libuv.cpp
+++ b/llarp/ev/ev_libuv.cpp
@@ -6,7 +6,12 @@
 
 namespace libuv
 {
-#define LoopCall(h, ...) LogicCall(static_cast<Loop*>((h)->loop->data)->m_Logic, __VA_ARGS__)
+
+#define LoopCall(h, ...)    \
+  {                         \
+    auto __f = __VA_ARGS__; \
+    __f();                  \
+  }
 
   struct glue
   {

--- a/llarp/ev/ev_win32.cpp
+++ b/llarp/ev/ev_win32.cpp
@@ -180,12 +180,7 @@ tun_ev_loop(void* u)
       byte_t* readbuf = (byte_t*)malloc(1500);
       ev->read(readbuf, 1500);
     }
-    else
-    {
-      // ok let's queue another read!
-      byte_t* readbuf = (byte_t*)malloc(1500);
-      ev->read(readbuf, 1500);
-    }
+
     logic->call_soon([ev]() {
       ev->flush_write();
       if (ev->t->tick)

--- a/llarp/ev/ev_win32.cpp
+++ b/llarp/ev/ev_win32.cpp
@@ -148,7 +148,8 @@ tun_ev_loop(void* u)
       // cycle regardless of any io being done, this manages the internal state
       // of the tun logic
 
-      if (tick_queued.test_and_set()) continue; // if tick queued, don't queue another
+      if (tick_queued.test_and_set())
+        continue;  // if tick queued, don't queue another
 
       logic->call_soon([&]() {
         for (const auto& tun : tun_listeners)
@@ -161,7 +162,6 @@ tun_ev_loop(void* u)
       });
 
       continue;
-
     }
     if (listener == (ULONG_PTR)~0)
       break;

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -878,9 +878,8 @@ namespace llarp
       }
       if (!m_Resolver->Start(m_LocalResolverAddr, m_UpstreamResolvers))
       {
-        // downgrade DNS server failure to a warning
-        llarp::LogWarn(Name(), " failed to start dns server");
-        // return false;
+        llarp::LogError(Name(), " failed to start DNS server");
+        return false;
       }
       return true;
     }

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -51,6 +51,7 @@ namespace llarp
     void
     TunEndpoint::tunifTick(llarp_tun_io* tun)
     {
+      llarp::LogTrace("TunEndpoint::tunifTick()");
       auto* self = static_cast<TunEndpoint*>(tun->user);
       self->Flush();
     }
@@ -748,6 +749,7 @@ namespace llarp
         };
         // event loop ticker
         auto ticker = [self, sendpkt]() {
+          llarp::LogTrace("TunEndpoint ticker() start");
           TunEndpoint* ep = self.get();
           const bool running = not ep->IsStopped();
           auto impl = ep->GetVPNImpl();
@@ -772,6 +774,7 @@ namespace llarp
           // if impl has a tick function call it
           if (impl && impl->parent && impl->parent->tick)
             impl->parent->tick(impl->parent);
+          llarp::LogTrace("TunEndpoint ticker() end");
         };
         if (not loop->add_ticker(ticker))
         {

--- a/llarp/net/route.cpp
+++ b/llarp/net/route.cpp
@@ -445,6 +445,7 @@ namespace llarp::net
       std::string interface_name{interface_str.data()};
       if ((!gateway.S_un.S_addr) and interface_name != ifname)
       {
+        llarp::LogTrace("Win32 find gateway: Adding gateway (", interface_name, ") to list of gateways.");
         gateways.push_back(std::move(interface_name));
       }
     });

--- a/llarp/net/route.cpp
+++ b/llarp/net/route.cpp
@@ -445,7 +445,8 @@ namespace llarp::net
       std::string interface_name{interface_str.data()};
       if ((!gateway.S_un.S_addr) and interface_name != ifname)
       {
-        llarp::LogTrace("Win32 find gateway: Adding gateway (", interface_name, ") to list of gateways.");
+        llarp::LogTrace(
+            "Win32 find gateway: Adding gateway (", interface_name, ") to list of gateways.");
         gateways.push_back(std::move(interface_name));
       }
     });

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -164,12 +164,14 @@ namespace llarp
   void
   Router::PumpLL()
   {
+    llarp::LogTrace("Router::PumpLL() start");
     if (_stopping.load())
       return;
     paths.PumpDownstream();
     paths.PumpUpstream();
     _outboundMessageHandler.Tick();
     _linkManager.PumpLinks();
+    llarp::LogTrace("Router::PumpLL() end");
   }
 
   bool
@@ -1272,6 +1274,7 @@ namespace llarp
         [&](llarp::RouterContact rc) {
           if (IsServiceNode())
             return;
+          llarp::LogTrace("Before connect, outbound link adding route to (", rc.addrs[0].toIpAddress().toIP(), ") via gateway.");
           m_RoutePoker.AddRoute(rc.addrs[0].toIpAddress().toIP());
         },
         util::memFn(&Router::ConnectionEstablished, this),

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -1274,7 +1274,10 @@ namespace llarp
         [&](llarp::RouterContact rc) {
           if (IsServiceNode())
             return;
-          llarp::LogTrace("Before connect, outbound link adding route to (", rc.addrs[0].toIpAddress().toIP(), ") via gateway.");
+          llarp::LogTrace(
+              "Before connect, outbound link adding route to (",
+              rc.addrs[0].toIpAddress().toIP(),
+              ") via gateway.");
           m_RoutePoker.AddRoute(rc.addrs[0].toIpAddress().toIP());
         },
         util::memFn(&Router::ConnectionEstablished, this),

--- a/llarp/util/logging/logger.cpp
+++ b/llarp/util/logging/logger.cpp
@@ -80,10 +80,7 @@ namespace llarp
   SetLogLevel(LogLevel lvl)
   {
     LogContext::Instance().curLevel = lvl;
-    if (lvl == eLogDebug)
-    {
-      LogContext::Instance().runtimeLevel = lvl;
-    }
+    LogContext::Instance().runtimeLevel = lvl;
   }
 
   LogLevel
@@ -107,6 +104,9 @@ namespace llarp
       std::function<void(IOFunc_t)> io)
   {
     SetLogLevel(level);
+    if (level == eLogTrace)
+      LogTrace("Set log level to trace.");
+
     nodeName = nickname;
 
     FILE* logfile = nullptr;


### PR DESCRIPTION
Includes some LogTrace additions that I added in pursuit of a Windows issue.  They make sense to stay, and so they are in this PR.

- Fix some issues with informing Windows about Lokinet running as a service
- Windows tun I/O, don't queue a read after a finished write, only after a finished read.
- Windows tun I/O,  if tun object tickers are queued, don't queue them again
- Logger, respect the configured log level.
- General, don't queue stuff to logic thread if in logic thread, because the thing that clears the queue...clears it.  So you're just delaying and adding overhead.
- General, DNS server correctly return result of `llarp_ev_add_udp`