### PR TITLE
use correct path for windows service

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -641,7 +641,7 @@ win32_daemon_entry(DWORD argc, LPTSTR* argv)
   ReportSvcStatus(SERVICE_START_PENDING, NO_ERROR, 3000);
   // SCM clobbers startup args, regenerate them here
   argc = 2;
-  argv[1] = "c:/programdata/.lokinet/lokinet.ini";
+  argv[1] = "c:/programdata/lokinet/lokinet.ini";
   argv[2] = nullptr;
   lokinet_main(argc, argv);
 }


### PR DESCRIPTION
the gui uses `lokinet` not `.lokinet`, using `.lokinet` on windows was a bug.