### PR TITLE
Move resolvconf from deb branches to contrib/

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -50,7 +50,7 @@ local debian_pipeline(name, image,
                 'cd build',
                 'cmake .. -G Ninja -DCMAKE_CXX_FLAGS=-fdiagnostics-color=always -DCMAKE_BUILD_TYPE='+build_type+' ' +
                     (if werror then '-DWARNINGS_AS_ERRORS=ON ' else '') +
-                    (if lto then '' else '-DWITH_LTO=OFF ') +
+                    '-DWITH_LTO=' + (if lto then 'ON ' else 'OFF ') +
                 cmake_extra,
                 'ninja -v',
                 '../contrib/ci/drone-gdb.sh ./test/testAll --gtest_color=yes',
@@ -192,10 +192,10 @@ local mac_builder(name, build_type='Release', werror=true, cmake_extra='', extra
     },
 
     // Various debian builds
-    debian_pipeline("Debian sid (amd64)", "debian:sid", lto=true),
+    debian_pipeline("Debian sid (amd64)", "debian:sid"),
     debian_pipeline("Debian sid/Debug (amd64)", "debian:sid", build_type='Debug', lto=true),
     debian_pipeline("Debian sid/clang-11 (amd64)", "debian:sid", deps='clang-11 '+default_deps_nocxx,
-                    cmake_extra='-DCMAKE_C_COMPILER=clang-11 -DCMAKE_CXX_COMPILER=clang++-11 ', lto=true),
+                    cmake_extra='-DCMAKE_C_COMPILER=clang-11 -DCMAKE_CXX_COMPILER=clang++-11 '),
     debian_pipeline("Debian buster (i386)", "i386/debian:buster", cmake_extra='-DDOWNLOAD_SODIUM=ON'),
     debian_pipeline("Ubuntu focal (amd64)", "ubuntu:focal"),
     debian_pipeline("Ubuntu bionic (amd64)", "ubuntu:bionic", deps='g++-8 ' + default_deps_nocxx,

--- a/contrib/lokinet-resolvconf
+++ b/contrib/lokinet-resolvconf
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Script to invoke resolvconf (if installed) to add/remove lokinet into/from the resolvconf DNS
+# server list.  This script does not add if any of these are true:
+#
+# - /sbin/resolvconf does not exist
+# - the systemd-resolved service is active
+# - a `no-resolvconf=1` item is present in the [dns] section of lokinet.ini
+#
+# It always attempts to remove if resolvconf is installed (so that commenting out while running,
+# then stopping still removes the added entry).
+#
+# Usage: lokinet-resolvconf {add|remove} /etc/loki/lokinet.ini
+
+set -e
+
+action="$1"
+conf="$2"
+
+if [[ ! ("$action" == "add" || "$action" == "remove") || ! -f "$conf" ]]; then
+    echo "Usage: $0 {add|remove} /path/to/lokinet.ini" >&2
+    exit 1
+fi
+
+if ! [ -x /sbin/resolvconf ]; then
+    exit 0
+fi
+
+if [ -x /bin/systemctl ] && /bin/systemctl --quiet is-active systemd-resolved.service; then
+    exit 0
+fi
+
+if [ "$action" == "add" ]; then
+    if ! [ -x /sbin/resolvconf ]; then exit 0; fi
+
+    lokinet_ns=$(perl -e '
+    $ns = "127.3.2.1"; # default if none found in .ini
+    while (<>) {
+        if ((/^\[dns\]/ ... /^\[/)) {
+            if (/^bind\s*=\s*([\d.]+)(?::53)?\s*$/) {
+                $ns=$1;
+            } elsif (/^no-resolvconf\s*=\s*1\s*/) {
+                exit;
+            }
+        }
+    }
+    print $ns' "$conf")
+
+    if [ -n "$lokinet_ns" ]; then
+        echo "nameserver $lokinet_ns" | /sbin/resolvconf -a lo.000lokinet
+    fi
+else
+    /sbin/resolvconf -d lo.000lokinet
+fi


### PR DESCRIPTION
This script gets invoked by the systemd service after startup to update
resolvconf with the lokinet dns server.

It was previously living in debian/lokinet-resolvconf in the
debian/ubuntu branches, but really belongs in contrib/ instead.