### PR TITLE
add exit.localhost.loki cname record

### DIFF
--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -529,7 +529,7 @@ namespace llarp
             {
               if (HasExit())
               {
-                M_ExitMap.ForEachEntry(
+                m_ExitMap.ForEachEntry(
                     [&msg](const auto&, const auto& exit) { msg.AddCNAMEReply(exit.ToString()); });
                 msg.AddINReply(ip, isV6);
               }

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -527,14 +527,16 @@ namespace llarp
           {
             if (lookingForExit)
             {
-              if (not HasExit())
+              if (HasExit())
+              {
+                M_ExitMap.ForEachEntry(
+                    [&msg](const auto&, const auto& exit) { msg.AddCNAMEReply(exit.ToString()); });
+                msg.AddINReply(ip, isV6);
+              }
+              else
               {
                 msg.AddNXReply();
-                return false;
               }
-              m_ExitMap.ForEachEntry(
-                  [&msg](const auto&, const auto& exit) { msg.AddCNAMEReply(exit.ToString()); });
-              msg.AddINReply(ip, isV6);
             }
             else
             {

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -464,17 +464,10 @@ namespace llarp
         else if (msg.questions[0].IsLocalhost() and msg.questions[0].HasSubdomains())
         {
           const auto subdomain = msg.questions[0].Subdomains();
-          if (subdomain == "exit")
+          if (subdomain == "exit" and HasExit())
           {
-            if (HasExit())
-            {
-              m_ExitMap.ForEachEntry(
-                  [&msg](const auto&, const auto& exit) { msg.AddCNAMEReply(exit.ToString(), 1); });
-            }
-            else
-            {
-              msg.AddNXReply();
-            }
+            m_ExitMap.ForEachEntry(
+                [&msg](const auto&, const auto& exit) { msg.AddCNAMEReply(exit.ToString(), 1); });
           }
           else
           {

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -461,6 +461,26 @@ namespace llarp
           else
             msg.AddNXReply();
         }
+        else if (msg.questions[0].IsLocalhost() and msg.questions[0].HasSubdomains())
+        {
+          const auto subdomain = msg.questions[0].Subdomains();
+          if (subdomain == "exit")
+          {
+            if (HasExit())
+            {
+              m_ExitMap.ForEachEntry(
+                  [&msg](const auto&, const auto& exit) { msg.AddCNAMEReply(exit.ToString(), 1); });
+            }
+            else
+            {
+              msg.AddNXReply();
+            }
+          }
+          else
+          {
+            msg.AddNXReply();
+          }
+        }
         else if (is_localhost_loki(msg))
         {
           size_t counter = 0;


### PR DESCRIPTION
adds a CNAME record for `exit.localhost.loki` that points to the address of the exit used.