### PR TITLE
fix profiles permissions error

### DIFF
--- a/llarp/profiling.cpp
+++ b/llarp/profiling.cpp
@@ -239,7 +239,7 @@ namespace llarp
   }
 
   bool
-  Profiling::Save(const char* fname)
+  Profiling::Save(const fs::path fpath)
   {
     std::shared_lock lock{m_ProfilesMutex};
     size_t sz = (m_Profiles.size() * (RouterProfile::MaxSize + 32 + 8)) + 8;
@@ -250,7 +250,6 @@ namespace llarp
     if (res)
     {
       buf.sz = buf.cur - buf.base;
-      const fs::path fpath = std::string(fname);
       auto optional_f = util::OpenFileStream<std::ofstream>(fpath, std::ios::binary);
       if (!optional_f)
         return false;
@@ -302,11 +301,17 @@ namespace llarp
   }
 
   bool
-  Profiling::Load(const char* fname)
+  Profiling::BDecode(llarp_buffer_t* buf)
+  {
+    return bencode_decode_dict(*this, buf);
+  }
+
+  bool
+  Profiling::Load(const fs::path fname)
   {
     util::Lock lock(m_ProfilesMutex);
     m_Profiles.clear();
-    if (!BDecodeReadFromFile(fname, *this))
+    if (!BDecodeReadFile(fname, *this))
     {
       llarp::LogWarn("failed to load router profiles from ", fname);
       return false;

--- a/llarp/profiling.hpp
+++ b/llarp/profiling.hpp
@@ -91,14 +91,17 @@ namespace llarp
     BEncode(llarp_buffer_t* buf) const EXCLUDES(m_ProfilesMutex);
 
     bool
+    BDecode(llarp_buffer_t* buf);
+
+    bool
     DecodeKey(const llarp_buffer_t& k, llarp_buffer_t* buf) NO_THREAD_SAFETY_ANALYSIS;
     // disabled because we do load -> bencode::BDecodeReadFromFile -> DecodeKey
 
     bool
-    Load(const char* fname) EXCLUDES(m_ProfilesMutex);
+    Load(const fs::path fname) EXCLUDES(m_ProfilesMutex);
 
     bool
-    Save(const char* fname) EXCLUDES(m_ProfilesMutex);
+    Save(const fs::path fname) EXCLUDES(m_ProfilesMutex);
 
     bool
     ShouldSave(llarp_time_t now) const;

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -273,10 +273,8 @@ namespace llarp
     std::shared_ptr<rpc::LokidRpcClient> m_lokidRpcClient;
 
     lokimq::address lokidRPCAddr;
-
     Profiling _routerProfiling;
-    std::string routerProfilesFile = "profiles.dat";
-
+    fs::path _profilesFile;
     OutboundMessageHandler _outboundMessageHandler;
     OutboundSessionMaker _outboundSessionMaker;
     LinkManager _linkManager;

--- a/llarp/util/bencode.hpp
+++ b/llarp/util/bencode.hpp
@@ -296,7 +296,7 @@ namespace llarp
   /// read entire file and decode its contents into t
   template <typename T>
   bool
-  BDecodeReadFile(const fs::path& fpath, T& t)
+  BDecodeReadFile(const fs::path fpath, T& t)
   {
     std::vector<byte_t> ptr;
     {
@@ -316,39 +316,10 @@ namespace llarp
     return t.BDecode(&buf);
   }
 
-  /// read entire file and decode its contents into t
-  template <typename T>
-  bool
-  BDecodeReadFromFile(const char* fpath, T& t)
-  {
-    std::vector<byte_t> ptr;
-    {
-      std::ifstream f;
-      f.open(fpath);
-      if (!f.is_open())
-      {
-        return false;
-      }
-      f.seekg(0, std::ios::end);
-      const std::streampos sz = f.tellg();
-      f.seekg(0, std::ios::beg);
-      ptr.resize(sz);
-      f.read((char*)ptr.data(), sz);
-    }
-    llarp_buffer_t buf(ptr);
-    auto result = bencode_decode_dict(t, &buf);
-    if (!result)
-    {
-      LogError("BDecodeReadFromFile() failed for file ", fpath, " contents:");
-      DumpBuffer(buf);
-    }
-    return result;
-  }
-
   /// bencode and write to file
   template <typename T, size_t bufsz>
   bool
-  BEncodeWriteFile(const char* fpath, const T& t)
+  BEncodeWriteFile(const fs::path fpath, const T& t)
   {
     std::array<byte_t, bufsz> tmp;
     llarp_buffer_t buf(tmp);
@@ -356,8 +327,7 @@ namespace llarp
       return false;
     buf.sz = buf.cur - buf.base;
     {
-      const fs::path path = std::string(fpath);
-      auto f = llarp::util::OpenFileStream<std::ofstream>(path, std::ios::binary);
+      auto f = llarp::util::OpenFileStream<std::ofstream>(fpath, std::ios::binary);
       if (not f or not f->is_open())
         return false;
       f->write((char*)buf.base, buf.sz);


### PR DESCRIPTION
profiles.dat is always relative so if you spawn lokinet in / then it will error about permissions.

* use absolute path for profiles.dat.

* remove old bencoding bits to use const fs::path instead of const char *

fixes #1448 