### PR TITLE
fix path reference leak

### DIFF
--- a/llarp/path/path_context.cpp
+++ b/llarp/path/path_context.cpp
@@ -320,6 +320,7 @@ namespace llarp
         {
           if (itr->second->Expired(now))
           {
+            itr->second->m_PathSet->RemovePath(itr->second);
             itr = map.erase(itr);
           }
           else

--- a/llarp/path/pathbuilder.cpp
+++ b/llarp/path/pathbuilder.cpp
@@ -141,8 +141,9 @@ namespace llarp
         else
         {
           LogError(ctx->pathset->Name(), " failed to send LRCM to ", ctx->path->Upstream());
-          ctx->pathset->HandlePathBuildFailed(std::move(ctx->path));
+          ctx->path->EnterState(path::ePathFailed, ctx->router->Now());
         }
+        ctx->path = nullptr;
         ctx->pathset = nullptr;
       };
       if (ctx->router->SendToOrQueue(remote, msg, sentHandler))

--- a/llarp/path/pathset.cpp
+++ b/llarp/path/pathset.cpp
@@ -338,6 +338,12 @@ namespace llarp
     }
 
     void
+    PathSet::HandlePathDied(Path_ptr p)
+    {
+      LogWarn(Name(), " path ", p->ShortName(), " died");
+    }
+
+    void
     PathSet::PathBuildStarted(Path_ptr p)
     {
       LogInfo(Name(), " path build ", p->ShortName(), " started");

--- a/llarp/path/pathset.hpp
+++ b/llarp/path/pathset.hpp
@@ -136,7 +136,7 @@ namespace llarp
 
       /// a path died now what?
       virtual void
-      HandlePathDied(Path_ptr path) = 0;
+      HandlePathDied(Path_ptr path);
 
       bool
       GetNewestIntro(service::Introduction& intro) const;

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -317,8 +317,7 @@ namespace llarp
       }
       std::unique_ptr<IServiceLookup> lookup = std::move(itr->second);
       lookups.erase(itr);
-      if (not lookup->HandleIntrosetResponse(remote))
-        lookups.emplace(msg->txid, std::move(lookup));
+      lookup->HandleIntrosetResponse(remote);
       return true;
     }
 
@@ -1065,9 +1064,11 @@ namespace llarp
       return true;
     }
 
-    void Endpoint::HandlePathDied(path::Path_ptr)
+    void
+    Endpoint::HandlePathDied(path::Path_ptr p)
     {
       RegenAndPublishIntroSet(true);
+      path::Builder::HandlePathDied(p);
     }
 
     bool

--- a/llarp/service/outbound_context.cpp
+++ b/llarp/service/outbound_context.cpp
@@ -154,6 +154,13 @@ namespace llarp
     }
 
     void
+    OutboundContext::HandlePathBuildFailed(path::Path_ptr p)
+    {
+      ShiftIntroRouter(p->Endpoint());
+      path::Builder::HandlePathBuildFailed(p);
+    }
+
+    void
     OutboundContext::HandlePathBuilt(path::Path_ptr p)
     {
       path::Builder::HandlePathBuilt(p);

--- a/llarp/service/outbound_context.hpp
+++ b/llarp/service/outbound_context.hpp
@@ -103,6 +103,9 @@ namespace llarp
       void
       HandlePathBuildTimeout(path::Path_ptr path) override;
 
+      void
+      HandlePathBuildFailed(path::Path_ptr path) override;
+
       bool
       SelectHop(
           llarp_nodedb* db,


### PR DESCRIPTION
* there was a reference leak with paths between the path context and the pathset where the path context was removing paths but not the pathset itself. this fixes it by removing the path from the pathset as well as the path context.
* on failure to deliver LRCM there was a reference leak of paths. fix this by changing the state of the path using EnterState
* when a path build fails on an outbound context we should rotate the intro router but we don't, this fixes that by doing so.