### PR TITLE
Install less stuff on windows CI

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -90,7 +90,7 @@ local windows_cross_pipeline(name, image,
                 'echo "man-db man-db/auto-update boolean false" | debconf-set-selections',
                 apt_get_quiet + ' update',
                 apt_get_quiet + ' install -y eatmydata',
-                'eatmydata ' + apt_get_quiet + ' install -y build-essential cmake git ninja-build pkg-config ccache mingw-w64 nsis zip',
+                'eatmydata ' + apt_get_quiet + ' install -y build-essential cmake git ninja-build pkg-config ccache g++-mingw-w64-x86-64-posix nsis zip',
                 'update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix',
                 'update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix',
                 'git clone https://github.com/despair86/libuv.git win32-setup/libuv',
@@ -215,8 +215,8 @@ local mac_builder(name, build_type='Release', werror=true, cmake_extra='', extra
     debian_pipeline("Debian sid (ARM64)", "debian:sid", arch="arm64"),
     debian_pipeline("Debian buster (armhf)", "arm32v7/debian:buster", arch="arm64", cmake_extra='-DDOWNLOAD_SODIUM=ON'),
     
-    // Windows builds (WOW64 and native)
-    windows_cross_pipeline("win32 (amd64)", "debian:testing",
+    // Windows builds (x64)
+    windows_cross_pipeline("Windows (amd64)", "debian:testing",
         toolchain='64', extra_cmds=[
           '../contrib/ci/drone-static-upload.sh'
     ]),


### PR DESCRIPTION
mingw-w64 is a metapackage that pulls in 4 different compilers
{i686,x86_64}×{-posix,-win32} but we only need x86_64-posix, so just
install that package.