### PR TITLE
Build mac uninstaller as subproject instead of externalproject

### DIFF
--- a/cmake/macos_installer_deps.cmake
+++ b/cmake/macos_installer_deps.cmake
@@ -20,13 +20,7 @@ set(MACOS_NOTARIZE_ASC ""
 
 include(ExternalProject)
 
-message(STATUS "Building UninstallLokinet.app")
-
-ExternalProject_Add(lokinet-uninstaller
-    SOURCE_DIR ${CMAKE_SOURCE_DIR}/contrib/macos/uninstaller
-    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR} -DMACOS_SIGN=${MACOS_SIGN_APP}
-        -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
-)
+add_subdirectory(${PROJECT_SOURCE_DIR}/contrib/macos/uninstaller)
 
 message(STATUS "Building LokinetGUI.app from ${LOKINET_GUI_REPO} @ ${LOKINET_GUI_CHECKOUT}")
 
@@ -51,13 +45,6 @@ install(PROGRAMS ${CMAKE_SOURCE_DIR}/contrib/macos/lokinet_uninstall.sh
         COMPONENT lokinet)
 
 install(DIRECTORY ${PROJECT_BINARY_DIR}/LokinetGUI.app
-        DESTINATION "../../Applications/Lokinet"
-        USE_SOURCE_PERMISSIONS
-        COMPONENT gui
-        PATTERN "*"
-        )
-
-install(DIRECTORY ${PROJECT_BINARY_DIR}/UninstallLokinet.app
         DESTINATION "../../Applications/Lokinet"
         USE_SOURCE_PERMISSIONS
         COMPONENT gui

--- a/contrib/macos/uninstaller/CMakeLists.txt
+++ b/contrib/macos/uninstaller/CMakeLists.txt
@@ -13,8 +13,7 @@ if(CCACHE_PROGRAM)
   endforeach()
 endif()
 
-set(PROJECT_NAME lokinet-uninstaller)
-project(${PROJECT_NAME}
+project(lokinet-uninstaller
     VERSION 0.0.1
     DESCRIPTION "lokinet uninstaller for macos"
     LANGUAGES CXX)
@@ -54,7 +53,7 @@ set_target_properties(${PROJECT_NAME}
 set(MACOSX_BUNDLE_BUNDLE_NAME UninstallLokinet)
 set(MACOSX_BUNDLE_GUI_IDENTIFIER org.lokinet.lokinet-uninstaller)
 set(MACOSX_BUNDLE_INFO_STRING "Lokinet uninstaller")
-set(MACOSX_BUNDLE_ICON_FILE lokinet-uninstall.icns)
+set(MACOSX_BUNDLE_ICON_FILE ${CMAKE_CURRENT_BINARY_DIR}/lokinet-uninstall.icns)
 set(MACOSX_BUNDLE_LONG_VERSION_STRING ${PROJECT_VERSION})
 set(MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION})
 set(MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION})
@@ -79,7 +78,7 @@ else()
     )
 endif()
 
-install(TARGETS lokinet-uninstaller
-    RUNTIME DESTINATION bin
-    BUNDLE DESTINATION .
-    RESOURCE DESTINATION .)
+install(TARGETS ${PROJECT_NAME}
+    DESTINATION "../../Applications/Lokinet"
+    COMPONENT gui
+    )


### PR DESCRIPTION
This makes it easier to build/rebuild via a target, and is a bit cleaner.