### PR TITLE
yet another round of macos uninstaller fixes

### DIFF
--- a/contrib/macos/lokinet_uninstall.sh
+++ b/contrib/macos/lokinet_uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -x
 test `whoami` == root || exit 1
 
@@ -28,11 +28,12 @@ SERVICE_NAME=`scutil_query Setup:/Network/Service/$SERVICE_GUID \
 # tell dns to be "empty" so that it's reset
 networksetup -setdnsservers "$SERVICE_NAME" empty
 
-# shut off exit if it's up
-pgrep lokinet$ && /opt/lokinet/bin/lokinet-vpn --down
-
  # Prevent restarting on exit
 touch /var/lib/lokinet/suspend-launchd-service
+
+# shut off lokinet gracefully
+pgrep lokinet$ && /opt/lokinet/bin/lokinet-vpn --kill
+
 # kill the gui and such
 killall LokinetGUI
 killall lokinet

--- a/daemon/lokinet-vpn.cpp
+++ b/daemon/lokinet-vpn.cpp
@@ -59,6 +59,7 @@ main(int argc, char* argv[])
   opts.add_options()
     ("v,verbose", "Verbose", cxxopts::value<bool>())
     ("h,help", "help", cxxopts::value<bool>())
+    ("kill", "kill the daemon", cxxopts::value<bool>())
     ("up", "put vpn up", cxxopts::value<bool>())
     ("down", "put vpn down", cxxopts::value<bool>())
     ("exit", "specify exit node address", cxxopts::value<std::string>())
@@ -77,6 +78,7 @@ main(int argc, char* argv[])
   bool goUp = false;
   bool goDown = false;
   bool printStatus = false;
+  bool killDaemon = false;
   try
   {
     const auto result = opts.parse(argc, argv);
@@ -102,6 +104,7 @@ main(int argc, char* argv[])
     goUp = result.count("up") > 0;
     goDown = result.count("down") > 0;
     printStatus = result.count("status") > 0;
+    killDaemon = result.count("kill") > 0;
 
     if (result.count("endpoint") > 0)
     {
@@ -127,7 +130,7 @@ main(int argc, char* argv[])
     std::cout << ex.what() << std::endl;
     return 1;
   }
-  if ((not goUp) and (not goDown) and (not printStatus))
+  if ((not goUp) and (not goDown) and (not printStatus) and (not killDaemon))
   {
     std::cout << opts.help() << std::endl;
     return 1;
@@ -159,6 +162,17 @@ main(int argc, char* argv[])
   if (not ftr.get())
   {
     return 1;
+  }
+
+  if (killDaemon)
+  {
+    const auto maybe = LMQ_Request(lmq, connID, "llarp.halt");
+    if (not maybe.has_value())
+    {
+      std::cout << "call to llarp.admin.die failed" << std::endl;
+      return 1;
+    }
+    return 0;
   }
 
   if (printStatus)

--- a/llarp/rpc/rpc_server.cpp
+++ b/llarp/rpc/rpc_server.cpp
@@ -93,8 +93,8 @@ namespace llarp::rpc
                 msg.send_reply(CreateJSONError("router is not running"));
                 return;
               }
-              m_Router->Stop();
               msg.send_reply(CreateJSONResponse("OK"));
+              m_Router->Stop();
             })
         .add_request_command(
             "version",


### PR DESCRIPTION
* make llarp.halt rpc call actually return a reply
* add --kill flag to lokinet-vpn that calls llarp.halt
* make macos uninstaller kill lokinet via lokinet-vpn --kill