### PR TITLE
add llarp.endpoint rpc command 

### DIFF
--- a/llarp/service/address.hpp
+++ b/llarp/service/address.hpp
@@ -104,4 +104,17 @@ namespace llarp
   }  // namespace service
 }  // namespace llarp
 
+namespace std
+{
+  template <>
+  struct hash<llarp::service::Address>
+  {
+    size_t
+    operator()(const llarp::service::Address& addr) const
+    {
+      return llarp::service::Address::Hash{}(addr);
+    }
+  };
+}  // namespace std
+
 #endif

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -345,6 +345,25 @@ namespace llarp
       itr->second.lastUsed = Now();
     }
 
+    size_t
+    Endpoint::RemoveAllConvoTagsFor(service::Address remote)
+    {
+      size_t removed = 0;
+      auto& sessions = Sessions();
+      auto itr = sessions.begin();
+      while (itr != sessions.end())
+      {
+        if (itr->second.remote.Addr() == remote)
+        {
+          itr = sessions.erase(itr);
+          removed++;
+        }
+        else
+          ++itr;
+      }
+      return removed;
+    }
+
     bool
     Endpoint::GetSenderFor(const ConvoTag& tag, ServiceInfo& si) const
     {

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -269,6 +269,9 @@ namespace llarp
 
       using PendingBufferQueue = std::deque<PendingBuffer>;
 
+      size_t
+      RemoveAllConvoTagsFor(service::Address remote);
+
       bool
       WantsOutboundSession(const Address&) const override;
 


### PR DESCRIPTION
add llarp.endpoint rpc command with a parameter "kill" to kill all active convotags given a list of or a single remote service address.
this is useful for endpoints that use lmq authentication.