### PR TITLE
Add full-static-deps armhf build (+upload)

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -215,7 +215,7 @@ local mac_builder(name, build_type='Release', werror=true, cmake_extra='', extra
     debian_pipeline("Debian sid (ARM64)", "debian:sid", arch="arm64"),
     debian_pipeline("Debian buster (armhf)", "arm32v7/debian:buster", arch="arm64", cmake_extra='-DDOWNLOAD_SODIUM=ON'),
     // Static armhf build (gets uploaded)
-    debian_pipeline("Static (buster armhf)", "arm32v7/debian:buster", arch="arm64", deps='g++ python3-dev', lto=true,
+    debian_pipeline("Static (buster armhf)", "arm32v7/debian:buster", arch="arm64", deps='g++ python3-dev',
                     cmake_extra='-DBUILD_STATIC_DEPS=ON -DBUILD_SHARED_LIBS=OFF -DSTATIC_LINK=ON ' +
                         '-DCMAKE_CXX_FLAGS="-march=armv7-a+fp" -DCMAKE_C_FLAGS="-march=armv7-a+fp" -DNATIVE_BUILD=OFF ' +
                         '-DWITH_SYSTEMD=OFF',

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -214,6 +214,15 @@ local mac_builder(name, build_type='Release', werror=true, cmake_extra='', extra
     // ARM builds (ARM64 and armhf)
     debian_pipeline("Debian sid (ARM64)", "debian:sid", arch="arm64"),
     debian_pipeline("Debian buster (armhf)", "arm32v7/debian:buster", arch="arm64", cmake_extra='-DDOWNLOAD_SODIUM=ON'),
+    // Static armhf build (gets uploaded)
+    debian_pipeline("Static (buster armhf)", "arm32v7/debian:buster", arch="arm64", deps='g++ python3-dev', lto=true,
+                    cmake_extra='-DBUILD_STATIC_DEPS=ON -DBUILD_SHARED_LIBS=OFF -DSTATIC_LINK=ON ' +
+                        '-DCMAKE_CXX_FLAGS="-march=armv7-a+fp" -DCMAKE_C_FLAGS="-march=armv7-a+fp" -DNATIVE_BUILD=OFF ' +
+                        '-DWITH_SYSTEMD=OFF',
+                    extra_cmds=[
+                        '../contrib/ci/drone-check-static-libs.sh',
+                        'UPLOAD_OS=linux-armhf ../contrib/ci/drone-static-upload.sh'
+                    ]),
     
     // Windows builds (x64)
     windows_cross_pipeline("Windows (amd64)", "debian:testing",

--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -200,6 +200,9 @@ if(CMAKE_CROSSCOMPILING)
     set(openssl_system_env SYSTEM=Linux MACHINE=${android_machine} LD=${deps_ld} RANLIB=${deps_ranlib} AR=${deps_ar})
     set(openssl_extra_opts no-asm)
   endif()
+elseif(CMAKE_C_FLAGS MATCHES "-march=armv7")
+  # Help openssl figure out that we're building from armv7 even if on armv8 hardware:
+  set(openssl_system_env SYSTEM=Linux MACHINE=armv7)
 endif()
 build_external(openssl
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env CC=${deps_cc} ${openssl_system_env} ./config

--- a/contrib/ci/drone-check-static-libs.sh
+++ b/contrib/ci/drone-check-static-libs.sh
@@ -11,7 +11,7 @@ if [ "$DRONE_STAGE_OS" == "darwin" ]; then
         bad=1
     fi
 elif [ "$DRONE_STAGE_OS" == "linux" ]; then
-    if ldd daemon/lokinet | grep -Ev '(linux-vdso|ld-linux-x86-64|lib(pthread|dl|rt|stdc\+\+|gcc_s|c|m))\.so'; then
+    if ldd daemon/lokinet | grep -Ev '(linux-vdso|ld-linux-(x86-64|armhf|aarch64)|lib(pthread|dl|rt|stdc\+\+|gcc_s|c|m))\.so'; then
         bad=1
     fi
 else

--- a/contrib/ci/drone-static-upload.sh
+++ b/contrib/ci/drone-static-upload.sh
@@ -19,7 +19,7 @@ set -o xtrace  # Don't start tracing until *after* we write the ssh key
 
 chmod 600 ssh_key
 
-os="$DRONE_STAGE_OS-$DRONE_STAGE_ARCH"
+os="${UPLOAD_OS:-$DRONE_STAGE_OS-$DRONE_STAGE_ARCH}"
 if [ -n "$WINDOWS_BUILD_NAME" ]; then
     os="windows-$WINDOWS_BUILD_NAME"
 fi


### PR DESCRIPTION
@necro-nemesis is playing around with making lokinet work on arm devices (particularly ones where system libs are unreliable), and requested a full-static build for armhf that he can use.  This is it.  First upload from the PR branch is: https://builds.lokinet.dev/jagerman/loki-network/static-armhf/lokinet-linux-armhf-20210104T202644Z-a16dd97c4.tar.xz