### PR TITLE
prevent crash by removing duplicate logic

### DIFF
--- a/llarp/path/path_context.cpp
+++ b/llarp/path/path_context.cpp
@@ -320,7 +320,6 @@ namespace llarp
         {
           if (itr->second->Expired(now))
           {
-            itr->second->m_PathSet->RemovePath(itr->second);
             itr = map.erase(itr);
           }
           else

--- a/llarp/path/pathset.cpp
+++ b/llarp/path/pathset.cpp
@@ -266,13 +266,6 @@ namespace llarp
       }
     }
 
-    void
-    PathSet::RemovePath(Path_ptr path)
-    {
-      Lock_t l(m_PathsMutex);
-      m_Paths.erase({path->Upstream(), path->RXID()});
-    }
-
     Path_ptr
     PathSet::GetByUpstream(RouterID remote, PathID_t rxid) const
     {

--- a/llarp/path/pathset.hpp
+++ b/llarp/path/pathset.hpp
@@ -119,9 +119,6 @@ namespace llarp
       size_t
       NumPathsExistingAt(llarp_time_t futureTime) const;
 
-      void
-      RemovePath(Path_ptr path);
-
       virtual void
       HandlePathBuilt(Path_ptr path) = 0;
 


### PR DESCRIPTION
when a path expires or fails or something causes its lifecycle to end we have cleanup
logic that handles clean up for it. this removes a code path that was crashing that
is duplicated elsewhere and is thus probably safe to bin. yolo.