### PR TITLE
thaw network when default gateway changes

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -279,6 +279,7 @@ run_main_context(std::optional<fs::path> confFile, const llarp::RuntimeOptions o
     signal(SIGTERM, handle_signal);
 #ifndef _WIN32
     signal(SIGHUP, handle_signal);
+    signal(SIGUSR1, handle_signal);
 #endif
 
     ctx->Setup(opts);

--- a/llarp/context.cpp
+++ b/llarp/context.cpp
@@ -158,6 +158,10 @@ namespace llarp
     {
       Reload();
     }
+    if (sig == SIGUSR1 and router)
+    {
+      router->Thaw();
+    }
 #endif
   }
 

--- a/llarp/context.cpp
+++ b/llarp/context.cpp
@@ -158,10 +158,6 @@ namespace llarp
     {
       Reload();
     }
-    if (sig == SIGUSR1 and router)
-    {
-      router->Thaw();
-    }
 #endif
   }
 

--- a/llarp/dns/server.cpp
+++ b/llarp/dns/server.cpp
@@ -86,6 +86,16 @@ namespace llarp
       return *itr;
     }
 
+    void
+    Proxy::Restart()
+    {
+      if (m_UnboundResolver)
+      {
+        LogInfo("reset libunbound's internal stuff");
+        m_UnboundResolver->Init();
+      }
+    }
+
     bool
     Proxy::SetupUnboundResolver(const std::vector<IpAddress>& resolvers)
     {

--- a/llarp/dns/server.hpp
+++ b/llarp/dns/server.hpp
@@ -43,6 +43,9 @@ namespace llarp
       void
       Stop();
 
+      void
+      Restart();
+
       using Buffer_t = std::vector<uint8_t>;
 
      private:

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -76,6 +76,13 @@ namespace llarp
       return obj;
     }
 
+    void
+    TunEndpoint::Thaw()
+    {
+      if (m_Resolver)
+        m_Resolver->Restart();
+    }
+
     bool
     TunEndpoint::Configure(const NetworkConfig& conf, const DnsConfig& dnsConf)
     {

--- a/llarp/handlers/tun.hpp
+++ b/llarp/handlers/tun.hpp
@@ -31,6 +31,9 @@ namespace llarp
         return shared_from_this();
       }
 
+      void
+      Thaw() override;
+
       bool
       Configure(const NetworkConfig& conf, const DnsConfig& dnsConf) override;
 

--- a/llarp/link/i_link_manager.hpp
+++ b/llarp/link/i_link_manager.hpp
@@ -70,6 +70,9 @@ namespace llarp
     virtual void
     ForEachInboundLink(std::function<void(LinkLayer_ptr)> visit) const = 0;
 
+    virtual void
+    ForEachOutboundLink(std::function<void(LinkLayer_ptr)> visit) const = 0;
+
     /// close all connections to this peer
     /// remove all link layer commits
     virtual void

--- a/llarp/link/link_manager.cpp
+++ b/llarp/link/link_manager.cpp
@@ -225,6 +225,15 @@ namespace llarp
     }
   }
 
+  void
+  LinkManager::ForEachOutboundLink(std::function<void(LinkLayer_ptr)> visit) const
+  {
+    for (const auto& link : outboundLinks)
+    {
+      visit(link);
+    }
+  }
+
   size_t
   LinkManager::NumberOfConnectedRouters() const
   {

--- a/llarp/link/link_manager.hpp
+++ b/llarp/link/link_manager.hpp
@@ -65,6 +65,9 @@ namespace llarp
     void
     ForEachInboundLink(std::function<void(LinkLayer_ptr)> visit) const override;
 
+    void
+    ForEachOutboundLink(std::function<void(LinkLayer_ptr)> visit) const override;
+
     size_t
     NumberOfConnectedRouters() const override;
 

--- a/llarp/link/server.cpp
+++ b/llarp/link/server.cpp
@@ -407,17 +407,20 @@ namespace llarp
   {
     static constexpr auto CloseGraceWindow = 500ms;
     const auto now = Now();
-    Lock_t l(m_AuthedLinksMutex);
-    RouterID r = remote;
-    llarp::LogInfo("Closing all to ", r);
-    auto range = m_AuthedLinks.equal_range(r);
-    auto itr = range.first;
-    while (itr != range.second)
     {
-      itr->second->Close();
-      m_RecentlyClosed.emplace(itr->second->GetRemoteEndpoint(), now + CloseGraceWindow);
-      itr = m_AuthedLinks.erase(itr);
+      Lock_t l(m_AuthedLinksMutex);
+      RouterID r = remote;
+      llarp::LogInfo("Closing all to ", r);
+      auto range = m_AuthedLinks.equal_range(r);
+      auto itr = range.first;
+      while (itr != range.second)
+      {
+        itr->second->Close();
+        m_RecentlyClosed.emplace(itr->second->GetRemoteEndpoint(), now + CloseGraceWindow);
+        itr = m_AuthedLinks.erase(itr);
+      }
     }
+    SessionClosed(remote);
   }
 
   void

--- a/llarp/router/abstractrouter.hpp
+++ b/llarp/router/abstractrouter.hpp
@@ -198,6 +198,10 @@ namespace llarp
     virtual void
     Stop() = 0;
 
+    /// thaw from long sleep or network changed event
+    virtual void
+    Thaw() = 0;
+
     /// non gracefully stop the router
     virtual void
     Die() = 0;

--- a/llarp/router/route_poker.cpp
+++ b/llarp/router/route_poker.cpp
@@ -166,6 +166,7 @@ namespace llarp
       return;
 
     DisableAllRoutes();
+    m_Enabled = false;
   }
 
   void

--- a/llarp/router/route_poker.cpp
+++ b/llarp/router/route_poker.cpp
@@ -132,13 +132,10 @@ namespace llarp
     {
       LogInfo("found default gateway: ", gateway);
       m_CurrentGateway = gateway;
-      if (m_Enabled)  // if route was already set up
-      {
-        DisableAllRoutes();
-      }
       if (m_Enabling)
       {
         EnableAllRoutes();
+        Up();
       }
     }
     // revive network connectitivity on gateway change or network wakeup

--- a/llarp/router/route_poker.cpp
+++ b/llarp/router/route_poker.cpp
@@ -115,23 +115,38 @@ namespace llarp
     if (not m_Router)
       throw std::runtime_error("Attempting to use RoutePoker before calling Init");
 
+    // check for network
     const auto maybe = GetDefaultGateway();
     if (not maybe.has_value())
     {
       LogError("Network is down");
+      // mark network lost
+      m_HasNetwork = false;
       return;
     }
     const huint32_t gateway = *maybe;
-    if (m_CurrentGateway != gateway or m_Enabling)
+
+    const bool gatewayChanged = m_CurrentGateway.h != 0 and m_CurrentGateway != gateway;
+
+    if (m_CurrentGateway != gateway)
     {
       LogInfo("found default gateway: ", gateway);
       m_CurrentGateway = gateway;
-
-      if (not m_Enabling)  // if route was already set up
+      if (m_Enabled)  // if route was already set up
+      {
         DisableAllRoutes();
-      EnableAllRoutes();
-
-      Up();
+      }
+      if (m_Enabling)
+      {
+        EnableAllRoutes();
+      }
+    }
+    // revive network connectitivity on gateway change or network wakeup
+    if (gatewayChanged or not m_HasNetwork)
+    {
+      LogInfo("our network changed, thawing router state");
+      m_Router->Thaw();
+      m_HasNetwork = true;
     }
   }
 

--- a/llarp/router/route_poker.cpp
+++ b/llarp/router/route_poker.cpp
@@ -9,7 +9,7 @@ namespace llarp
   void
   RoutePoker::AddRoute(huint32_t ip)
   {
-    m_PokedRoutes.emplace(ip, m_CurrentGateway);
+    m_PokedRoutes[ip] = m_CurrentGateway;
     if (m_CurrentGateway.h == 0)
     {
       llarp::LogDebug("RoutePoker::AddRoute no current gateway, cannot enable route.");
@@ -44,10 +44,10 @@ namespace llarp
     const auto itr = m_PokedRoutes.find(ip);
     if (itr == m_PokedRoutes.end())
       return;
-    m_PokedRoutes.erase(itr);
 
     if (m_Enabled)
       DisableRoute(itr->first, itr->second);
+    m_PokedRoutes.erase(itr);
   }
 
   void

--- a/llarp/router/route_poker.hpp
+++ b/llarp/router/route_poker.hpp
@@ -69,5 +69,7 @@ namespace llarp
     bool m_Enabling = false;
 
     AbstractRouter* m_Router = nullptr;
+
+    bool m_HasNetwork = true;
   };
 }  // namespace llarp

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -124,7 +124,6 @@ namespace llarp
   void
   Router::Thaw()
   {
-    LogInfo("We arise from a long sleep, probably need to reset the network state");
     // get pubkeys we are connected to
     std::unordered_set<RouterID> peerPubkeys;
     linkManager().ForEachPeer([&peerPubkeys](auto peer) {
@@ -143,7 +142,7 @@ namespace llarp
       ep->Thaw();
       return true;
     });
-    LogInfo("We are ready to go bruh");
+    LogInfo("We are ready to go bruh...  probably");
   }
 
   void
@@ -827,13 +826,18 @@ namespace llarp
 
     _linkManager.CheckPersistingSessions(now);
 
-    if (HasClientExit())
+    if (not isSvcNode)
     {
-      m_RoutePoker.Enable();
+      if (HasClientExit())
+      {
+        m_RoutePoker.Enable();
+      }
+      else
+      {
+        m_RoutePoker.Disable();
+      }
       m_RoutePoker.Update();
     }
-    else
-      m_RoutePoker.Disable();
 
     size_t connected = NumberOfConnectedRouters();
     if (not isSvcNode)

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -122,6 +122,18 @@ namespace llarp
   }
 
   void
+  Router::Thaw()
+  {
+    LogInfo("We arise from a long sleep, probably need to reset the network state");
+    hiddenServiceContext().ForEachService([](const auto& name, const auto& ep) -> bool {
+      LogInfo(name, " thawing...");
+      ep->Thaw();
+      return true;
+    });
+    LogInfo("We are ready to go bruh");
+  }
+
+  void
   Router::PersistSessionUntil(const RouterID& remote, llarp_time_t until)
   {
     _linkManager.PersistSessionUntil(remote, until);

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -363,6 +363,9 @@ namespace llarp
     bool
     StartRpcServer() override;
 
+    void
+    Thaw() override;
+
     bool
     Run() override;
 

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -127,6 +127,9 @@ namespace llarp
         return {0};
       }
 
+      virtual void
+      Thaw(){};
+
       void
       ResetInternalState() override;
 

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -112,6 +112,9 @@ namespace llarp
       virtual std::string
       GetIfName() const = 0;
 
+      std::optional<ConvoTag>
+      GetBestConvoTagForService(Address addr) const;
+
       /// inject vpn io
       /// return false if not supported
       virtual bool


### PR DESCRIPTION
thaw does the following when the default gateway changes or we come back from a lost network event.

1) close all link sessions
2) reset all upstream dns contexts

in that order