### PR TITLE
remove packet rate based cpu bottleneck

### DIFF
--- a/llarp/ev/ev.hpp
+++ b/llarp/ev/ev.hpp
@@ -59,12 +59,31 @@ namespace llarp
     class NetworkInterface;
   }
 
+  /// distinct event loop waker uper
+  class EventLoopWakeup
+  {
+   protected:
+    std::function<void()> callback;
+
+   public:
+    EventLoopWakeup(std::function<void()> cb) : callback{cb}
+    {}
+
+    virtual ~EventLoopWakeup() = default;
+
+    /// async wakeup and call callback once
+    virtual void
+    Wakeup() = 0;
+
+    /// end operation
+    virtual void
+    End() = 0;
+  };
+
   // this (nearly!) abstract base class
   // is overriden for each platform
   struct EventLoop
   {
-    byte_t readbuf[EV_READ_BUF_SZ] = {0};
-
     virtual bool
     init() = 0;
 
@@ -127,6 +146,10 @@ namespace llarp
 
     virtual void
     deregister_poll_fd_readable(int fd) = 0;
+
+    /// make an event loop waker on this event loop
+    virtual EventLoopWakeup*
+    make_event_loop_waker(std::function<void()> callback) = 0;
   };
 }  // namespace llarp
 #endif

--- a/llarp/ev/ev_libuv.cpp
+++ b/llarp/ev/ev_libuv.cpp
@@ -60,12 +60,6 @@ namespace libuv
     {
       uv_async_send(&m_Impl);
     }
-
-    bool
-    operator<(const UVWakeup& other) const
-    {
-      return m_Idx < other.m_Idx;
-    }
   };
 
   struct ticker_glue : public glue

--- a/llarp/ev/ev_libuv.hpp
+++ b/llarp/ev/ev_libuv.hpp
@@ -12,6 +12,8 @@
 
 namespace libuv
 {
+  class UVWakeup;
+
   struct Loop final : public llarp::EventLoop
   {
     typedef std::function<void(void)> Callback;
@@ -96,6 +98,12 @@ namespace libuv
     void
     set_pump_function(std::function<void(void)> pumpll) override;
 
+    llarp::EventLoopWakeup*
+    make_event_loop_waker(std::function<void()> callback) override;
+
+    void
+    delete_waker(int idx);
+
     void
     FlushLogic();
 
@@ -122,6 +130,9 @@ namespace libuv
     llarp::thread::Queue<PendingTimer> m_timerQueue;
     llarp::thread::Queue<uint32_t> m_timerCancelQueue;
     std::optional<std::thread::id> m_EventLoopThreadID;
+
+    int m_NumWakers;
+    std::unordered_map<int, UVWakeup*> m_Wakers;
   };
 
 }  // namespace libuv

--- a/llarp/iwp/iwp.cpp
+++ b/llarp/iwp/iwp.cpp
@@ -10,6 +10,7 @@ namespace llarp
     LinkLayer_ptr
     NewInboundLink(
         std::shared_ptr<KeyManager> keyManager,
+        std::shared_ptr<EventLoop> loop,
         GetRCFunc getrc,
         LinkMessageHandler h,
         SignBufferFunc sign,
@@ -22,12 +23,25 @@ namespace llarp
         WorkerFunc_t work)
     {
       return std::make_shared<LinkLayer>(
-          keyManager, getrc, h, sign, before, est, reneg, timeout, closed, pumpDone, work, true);
+          keyManager,
+          loop,
+          getrc,
+          h,
+          sign,
+          before,
+          est,
+          reneg,
+          timeout,
+          closed,
+          pumpDone,
+          work,
+          true);
     }
 
     LinkLayer_ptr
     NewOutboundLink(
         std::shared_ptr<KeyManager> keyManager,
+        std::shared_ptr<EventLoop> loop,
         GetRCFunc getrc,
         LinkMessageHandler h,
         SignBufferFunc sign,
@@ -40,7 +54,19 @@ namespace llarp
         WorkerFunc_t work)
     {
       return std::make_shared<LinkLayer>(
-          keyManager, getrc, h, sign, before, est, reneg, timeout, closed, pumpDone, work, false);
+          keyManager,
+          loop,
+          getrc,
+          h,
+          sign,
+          before,
+          est,
+          reneg,
+          timeout,
+          closed,
+          pumpDone,
+          work,
+          false);
     }
   }  // namespace iwp
 }  // namespace llarp

--- a/llarp/iwp/iwp.hpp
+++ b/llarp/iwp/iwp.hpp
@@ -11,6 +11,7 @@ namespace llarp::iwp
   LinkLayer_ptr
   NewInboundLink(
       std::shared_ptr<KeyManager> keyManager,
+      std::shared_ptr<EventLoop> loop,
       GetRCFunc getrc,
       LinkMessageHandler h,
       SignBufferFunc sign,
@@ -25,6 +26,7 @@ namespace llarp::iwp
   LinkLayer_ptr
   NewOutboundLink(
       std::shared_ptr<KeyManager> keyManager,
+      std::shared_ptr<EventLoop> loop,
       GetRCFunc getrc,
       LinkMessageHandler h,
       SignBufferFunc sign,

--- a/llarp/iwp/linklayer.cpp
+++ b/llarp/iwp/linklayer.cpp
@@ -4,96 +4,126 @@
 #include <memory>
 #include <unordered_set>
 
-namespace llarp
+namespace llarp::iwp
 {
-  namespace iwp
+  LinkLayer::LinkLayer(
+      std::shared_ptr<KeyManager> keyManager,
+      std::shared_ptr<EventLoop> ev,
+      GetRCFunc getrc,
+      LinkMessageHandler h,
+      SignBufferFunc sign,
+      BeforeConnectFunc_t before,
+      SessionEstablishedHandler est,
+      SessionRenegotiateHandler reneg,
+      TimeoutHandler timeout,
+      SessionClosedHandler closed,
+      PumpDoneHandler pumpDone,
+      WorkerFunc_t worker,
+      bool allowInbound)
+      : ILinkLayer(
+          keyManager, getrc, h, sign, before, est, reneg, timeout, closed, pumpDone, worker)
+      , m_Wakeup{ev->make_event_loop_waker([self = this]() { self->HandleWakeupPlaintext(); })}
+      , m_PlaintextRecv{1024}
+      , permitInbound{allowInbound}
+
+  {}
+
+  LinkLayer::~LinkLayer()
   {
-    LinkLayer::LinkLayer(
-        std::shared_ptr<KeyManager> keyManager,
-        GetRCFunc getrc,
-        LinkMessageHandler h,
-        SignBufferFunc sign,
-        BeforeConnectFunc_t before,
-        SessionEstablishedHandler est,
-        SessionRenegotiateHandler reneg,
-        TimeoutHandler timeout,
-        SessionClosedHandler closed,
-        PumpDoneHandler pumpDone,
-        WorkerFunc_t worker,
-        bool allowInbound)
-        : ILinkLayer(
-            keyManager, getrc, h, sign, before, est, reneg, timeout, closed, pumpDone, worker)
-        , permitInbound{allowInbound}
-    {}
+    m_Wakeup->End();
+  }
 
-    LinkLayer::~LinkLayer() = default;
+  const char*
+  LinkLayer::Name() const
+  {
+    return "iwp";
+  }
 
-    const char*
-    LinkLayer::Name() const
+  uint16_t
+  LinkLayer::Rank() const
+  {
+    return 2;
+  }
+
+  void
+  LinkLayer::RecvFrom(const SockAddr& from, ILinkSession::Packet_t pkt)
+  {
+    std::shared_ptr<ILinkSession> session;
+    auto itr = m_AuthedAddrs.find(from);
+    bool isNewSession = false;
+    if (itr == m_AuthedAddrs.end())
     {
-      return "iwp";
-    }
-
-    uint16_t
-    LinkLayer::Rank() const
-    {
-      return 2;
-    }
-
-    void
-    LinkLayer::RecvFrom(const SockAddr& from, ILinkSession::Packet_t pkt)
-    {
-      std::shared_ptr<ILinkSession> session;
-      auto itr = m_AuthedAddrs.find(from);
-      bool isNewSession = false;
-      if (itr == m_AuthedAddrs.end())
+      Lock_t lock(m_PendingMutex);
+      if (m_Pending.count(from) == 0)
       {
-        Lock_t lock(m_PendingMutex);
-        if (m_Pending.count(from) == 0)
-        {
-          if (not permitInbound)
-            return;
-          isNewSession = true;
-          m_Pending.insert({from, std::make_shared<Session>(this, from)});
-        }
-        session = m_Pending.find(from)->second;
+        if (not permitInbound)
+          return;
+        isNewSession = true;
+        m_Pending.insert({from, std::make_shared<Session>(this, from)});
       }
-      else
+      session = m_Pending.find(from)->second;
+    }
+    else
+    {
+      Lock_t lock(m_AuthedLinksMutex);
+      auto range = m_AuthedLinks.equal_range(itr->second);
+      session = range.first->second;
+    }
+    if (session)
+    {
+      bool success = session->Recv_LL(std::move(pkt));
+      if (!success and isNewSession)
       {
-        Lock_t lock(m_AuthedLinksMutex);
-        auto range = m_AuthedLinks.equal_range(itr->second);
-        session = range.first->second;
-      }
-      if (session)
-      {
-        bool success = session->Recv_LL(std::move(pkt));
-        if (!success and isNewSession)
-        {
-          LogWarn("Brand new session failed; removing from pending sessions list");
-          m_Pending.erase(m_Pending.find(from));
-        }
+        LogWarn("Brand new session failed; removing from pending sessions list");
+        m_Pending.erase(m_Pending.find(from));
       }
     }
+  }
 
-    bool
-    LinkLayer::MapAddr(const RouterID& r, ILinkSession* s)
-    {
-      if (!ILinkLayer::MapAddr(r, s))
-        return false;
-      m_AuthedAddrs.emplace(s->GetRemoteEndpoint(), r);
-      return true;
-    }
+  bool
+  LinkLayer::MapAddr(const RouterID& r, ILinkSession* s)
+  {
+    if (!ILinkLayer::MapAddr(r, s))
+      return false;
+    m_AuthedAddrs.emplace(s->GetRemoteEndpoint(), r);
+    return true;
+  }
 
-    void
-    LinkLayer::UnmapAddr(const IpAddress& addr)
-    {
-      m_AuthedAddrs.erase(addr);
-    }
+  void
+  LinkLayer::UnmapAddr(const IpAddress& addr)
+  {
+    m_AuthedAddrs.erase(addr);
+  }
 
-    std::shared_ptr<ILinkSession>
-    LinkLayer::NewOutboundSession(const RouterContact& rc, const AddressInfo& ai)
+  std::shared_ptr<ILinkSession>
+  LinkLayer::NewOutboundSession(const RouterContact& rc, const AddressInfo& ai)
+  {
+    return std::make_shared<Session>(this, rc, ai);
+  }
+
+  void
+  LinkLayer::AddWakeup(std::weak_ptr<Session> session)
+  {
+    m_PlaintextRecv.tryPushBack(session);
+  }
+
+  void
+  LinkLayer::WakeupPlaintext()
+  {
+    m_Wakeup->Wakeup();
+  }
+
+  void
+  LinkLayer::HandleWakeupPlaintext()
+  {
+    while (not m_PlaintextRecv.empty())
     {
-      return std::make_shared<Session>(this, rc, ai);
+      auto session = m_PlaintextRecv.popFront();
+      auto ptr = session.lock();
+      if (ptr)
+        ptr->HandlePlaintext();
     }
-  }  // namespace iwp
-}  // namespace llarp
+    PumpDone();
+  }
+
+}  // namespace llarp::iwp

--- a/llarp/iwp/linklayer.cpp
+++ b/llarp/iwp/linklayer.cpp
@@ -104,6 +104,8 @@ namespace llarp::iwp
   void
   LinkLayer::AddWakeup(std::weak_ptr<Session> session)
   {
+    if (m_PlaintextRecv.full())
+      HandleWakeupPlaintext();
     m_PlaintextRecv.tryPushBack(session);
   }
 

--- a/llarp/iwp/linklayer.hpp
+++ b/llarp/iwp/linklayer.hpp
@@ -51,7 +51,7 @@ namespace llarp::iwp
     MapAddr(const RouterID& pk, ILinkSession* s) override;
 
     void
-    UnmapAddr(const IpAddress& addr);
+    UnmapAddr(const SockAddr& addr);
 
     void
     WakeupPlaintext();
@@ -64,8 +64,8 @@ namespace llarp::iwp
     HandleWakeupPlaintext();
 
     EventLoopWakeup* const m_Wakeup;
-    llarp::thread::Queue<std::weak_ptr<Session>> m_PlaintextRecv;
-    std::unordered_map<IpAddress, RouterID, IpAddress::Hash> m_AuthedAddrs;
+    std::unordered_map<SockAddr, std::weak_ptr<Session>, SockAddr::Hash> m_PlaintextRecv;
+    std::unordered_map<SockAddr, RouterID, SockAddr::Hash> m_AuthedAddrs;
     const bool permitInbound;
   };
 

--- a/llarp/iwp/linklayer.hpp
+++ b/llarp/iwp/linklayer.hpp
@@ -7,7 +7,7 @@
 #include <crypto/types.hpp>
 #include <link/server.hpp>
 #include <config/key_manager.hpp>
-#include <util/thread/queue.hpp>
+
 #include <memory>
 
 #include <ev/ev.hpp>

--- a/llarp/iwp/linklayer.hpp
+++ b/llarp/iwp/linklayer.hpp
@@ -7,56 +7,69 @@
 #include <crypto/types.hpp>
 #include <link/server.hpp>
 #include <config/key_manager.hpp>
-
+#include <util/thread/queue.hpp>
 #include <memory>
 
-namespace llarp
+#include <ev/ev.hpp>
+
+namespace llarp::iwp
 {
-  namespace iwp
+  struct Session;
+
+  struct LinkLayer final : public ILinkLayer
   {
-    struct LinkLayer final : public ILinkLayer
-    {
-      LinkLayer(
-          std::shared_ptr<KeyManager> keyManager,
-          GetRCFunc getrc,
-          LinkMessageHandler h,
-          SignBufferFunc sign,
-          BeforeConnectFunc_t before,
-          SessionEstablishedHandler est,
-          SessionRenegotiateHandler reneg,
-          TimeoutHandler timeout,
-          SessionClosedHandler closed,
-          PumpDoneHandler pumpDone,
-          WorkerFunc_t dowork,
-          bool permitInbound);
+    LinkLayer(
+        std::shared_ptr<KeyManager> keyManager,
+        std::shared_ptr<EventLoop> ev,
+        GetRCFunc getrc,
+        LinkMessageHandler h,
+        SignBufferFunc sign,
+        BeforeConnectFunc_t before,
+        SessionEstablishedHandler est,
+        SessionRenegotiateHandler reneg,
+        TimeoutHandler timeout,
+        SessionClosedHandler closed,
+        PumpDoneHandler pumpDone,
+        WorkerFunc_t dowork,
+        bool permitInbound);
 
-      ~LinkLayer() override;
+    ~LinkLayer() override;
 
-      std::shared_ptr<ILinkSession>
-      NewOutboundSession(const RouterContact& rc, const AddressInfo& ai) override;
+    std::shared_ptr<ILinkSession>
+    NewOutboundSession(const RouterContact& rc, const AddressInfo& ai) override;
 
-      const char*
-      Name() const override;
+    const char*
+    Name() const override;
 
-      uint16_t
-      Rank() const override;
+    uint16_t
+    Rank() const override;
 
-      void
-      RecvFrom(const SockAddr& from, ILinkSession::Packet_t pkt) override;
+    void
+    RecvFrom(const SockAddr& from, ILinkSession::Packet_t pkt) override;
 
-      bool
-      MapAddr(const RouterID& pk, ILinkSession* s) override;
+    bool
+    MapAddr(const RouterID& pk, ILinkSession* s) override;
 
-      void
-      UnmapAddr(const IpAddress& addr);
+    void
+    UnmapAddr(const IpAddress& addr);
 
-     private:
-      std::unordered_map<IpAddress, RouterID, IpAddress::Hash> m_AuthedAddrs;
-      const bool permitInbound;
-    };
+    void
+    WakeupPlaintext();
 
-    using LinkLayer_ptr = std::shared_ptr<LinkLayer>;
-  }  // namespace iwp
-}  // namespace llarp
+    void
+    AddWakeup(std::weak_ptr<Session> peer);
+
+   private:
+    void
+    HandleWakeupPlaintext();
+
+    EventLoopWakeup* const m_Wakeup;
+    llarp::thread::Queue<std::weak_ptr<Session>> m_PlaintextRecv;
+    std::unordered_map<IpAddress, RouterID, IpAddress::Hash> m_AuthedAddrs;
+    const bool permitInbound;
+  };
+
+  using LinkLayer_ptr = std::shared_ptr<LinkLayer>;
+}  // namespace llarp::iwp
 
 #endif

--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -624,7 +624,7 @@ namespace llarp
         }
         ++itr;
       }
-      m_PlaintextRecv.pushBack(std::move(msgs));
+      m_PlaintextRecv.tryPushBack(std::move(msgs));
       m_Parent->WakeupPlaintext();
     }
 

--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -26,6 +26,8 @@ namespace llarp
       return pkt;
     }
 
+    constexpr size_t PlaintextQueueSize = 32;
+
     Session::Session(LinkLayer* p, const RouterContact& rc, const AddressInfo& ai)
         : m_State{State::Initial}
         , m_Inbound{false}
@@ -34,6 +36,7 @@ namespace llarp
         , m_RemoteAddr(ai.toIpAddress())
         , m_ChosenAI(ai)
         , m_RemoteRC(rc)
+        , m_PlaintextRecv{PlaintextQueueSize}
     {
       token.Zero();
       GotLIM = util::memFn(&Session::GotOutboundLIM, this);
@@ -46,6 +49,7 @@ namespace llarp
         , m_Parent(p)
         , m_CreatedAt{p->Now()}
         , m_RemoteAddr(from)
+        , m_PlaintextRecv{PlaintextQueueSize}
     {
       token.Randomize();
       GotLIM = util::memFn(&Session::GotInboundLIM, this);
@@ -130,23 +134,21 @@ namespace llarp
     void
     Session::EncryptAndSend(ILinkSession::Packet_t data)
     {
-      if (m_EncryptNext == nullptr)
-        m_EncryptNext = std::make_shared<CryptoQueue_t>();
-      m_EncryptNext->emplace_back(std::move(data));
+      m_EncryptNext.emplace_back(std::move(data));
       if (!IsEstablished())
       {
         EncryptWorker(std::move(m_EncryptNext));
-        m_EncryptNext = nullptr;
+        m_EncryptNext = CryptoQueue_t{};
       }
     }
 
     void
-    Session::EncryptWorker(CryptoQueue_ptr msgs)
+    Session::EncryptWorker(CryptoQueue_t msgs)
     {
-      LogDebug("encrypt worker ", msgs->size(), " messages");
-      for (auto& pkt : *msgs)
+      LogDebug("encrypt worker ", msgs.size(), " messages");
+      for (auto& pkt : msgs)
       {
-        llarp_buffer_t pktbuf(pkt);
+        llarp_buffer_t pktbuf{pkt};
         const TunnelNonce nonce_ptr{pkt.data() + HMACSIZE};
         pktbuf.base += PacketOverhead;
         pktbuf.cur = pktbuf.base;
@@ -243,16 +245,17 @@ namespace llarp
       }
       auto self = shared_from_this();
       assert(self.use_count() > 1);
-      if (m_EncryptNext && !m_EncryptNext->empty())
+      if (not m_EncryptNext.empty())
       {
-        m_Parent->QueueWork([self, data = std::move(m_EncryptNext)] { self->EncryptWorker(data); });
-        m_EncryptNext = nullptr;
+        m_Parent->QueueWork([self, data = m_EncryptNext] { self->EncryptWorker(data); });
+        m_EncryptNext.clear();
       }
 
-      if (m_DecryptNext && !m_DecryptNext->empty())
+      if (not m_DecryptNext.empty())
       {
-        m_Parent->QueueWork([self, data = std::move(m_DecryptNext)] { self->DecryptWorker(data); });
-        m_DecryptNext = nullptr;
+        m_Parent->AddWakeup(weak_from_this());
+        m_Parent->QueueWork([self, data = m_DecryptNext] { self->DecryptWorker(data); });
+        m_DecryptNext.clear();
       }
     }
 
@@ -596,19 +599,19 @@ namespace llarp
     void
     Session::HandleSessionData(Packet_t pkt)
     {
-      if (m_DecryptNext == nullptr)
-        m_DecryptNext = std::make_shared<CryptoQueue_t>();
-      m_DecryptNext->emplace_back(std::move(pkt));
+      m_DecryptNext.emplace_back(std::move(pkt));
     }
 
     void
-    Session::DecryptWorker(CryptoQueue_ptr msgs)
+    Session::DecryptWorker(CryptoQueue_t msgs)
     {
-      CryptoQueue_ptr recvMsgs = std::make_shared<CryptoQueue_t>();
-      for (auto& pkt : *msgs)
+      auto itr = msgs.begin();
+      while (itr != msgs.end())
       {
+        auto& pkt = *itr;
         if (not DecryptMessageInPlace(pkt))
         {
+          itr = msgs.erase(itr);
           LogError("failed to decrypt session data from ", m_RemoteAddr);
           continue;
         }
@@ -616,52 +619,54 @@ namespace llarp
         {
           LogError(
               "protocol version mismatch ", int(pkt[PacketOverhead]), " != ", LLARP_PROTO_VERSION);
+          itr = msgs.erase(itr);
           continue;
         }
-        recvMsgs->emplace_back(std::move(pkt));
+        ++itr;
       }
-      LogDebug("decrypted ", recvMsgs->size(), " packets from ", m_RemoteAddr);
-      LogicCall(m_Parent->logic(), [self = shared_from_this(), msgs = recvMsgs] {
-        self->HandlePlaintext(std::move(msgs));
-      });
+      m_PlaintextRecv.pushBack(std::move(msgs));
+      m_Parent->WakeupPlaintext();
     }
 
     void
-    Session::HandlePlaintext(CryptoQueue_ptr msgs)
+    Session::HandlePlaintext()
     {
-      for (auto& result : *msgs)
+      while (not m_PlaintextRecv.empty())
       {
-        LogDebug("Command ", int(result[PacketOverhead + 1]));
-        switch (result[PacketOverhead + 1])
+        auto queue = m_PlaintextRecv.popFront();
+        for (auto& result : queue)
         {
-          case Command::eXMIT:
-            HandleXMIT(std::move(result));
-            break;
-          case Command::eDATA:
-            HandleDATA(std::move(result));
-            break;
-          case Command::eACKS:
-            HandleACKS(std::move(result));
-            break;
-          case Command::ePING:
-            HandlePING(std::move(result));
-            break;
-          case Command::eNACK:
-            HandleNACK(std::move(result));
-            break;
-          case Command::eCLOS:
-            HandleCLOS(std::move(result));
-            break;
-          case Command::eMACK:
-            HandleMACK(std::move(result));
-            break;
-          default:
-            LogError("invalid command ", int(result[PacketOverhead + 1]), " from ", m_RemoteAddr);
+          LogDebug("Command ", int(result[PacketOverhead + 1]));
+          switch (result[PacketOverhead + 1])
+          {
+            case Command::eXMIT:
+              HandleXMIT(std::move(result));
+              break;
+            case Command::eDATA:
+              HandleDATA(std::move(result));
+              break;
+            case Command::eACKS:
+              HandleACKS(std::move(result));
+              break;
+            case Command::ePING:
+              HandlePING(std::move(result));
+              break;
+            case Command::eNACK:
+              HandleNACK(std::move(result));
+              break;
+            case Command::eCLOS:
+              HandleCLOS(std::move(result));
+              break;
+            case Command::eMACK:
+              HandleMACK(std::move(result));
+              break;
+            default:
+              LogError("invalid command ", int(result[PacketOverhead + 1]), " from ", m_RemoteAddr);
+          }
         }
       }
       SendMACK();
       Pump();
-      m_Parent->PumpDone();
     }
 
     void

--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -33,7 +33,7 @@ namespace llarp
         , m_Inbound{false}
         , m_Parent(p)
         , m_CreatedAt{p->Now()}
-        , m_RemoteAddr(ai.toIpAddress())
+        , m_RemoteAddr{ai}
         , m_ChosenAI(ai)
         , m_RemoteRC(rc)
         , m_PlaintextRecv{PlaintextQueueSize}
@@ -43,12 +43,12 @@ namespace llarp
       CryptoManager::instance()->shorthash(m_SessionKey, llarp_buffer_t(rc.pubkey));
     }
 
-    Session::Session(LinkLayer* p, const IpAddress& from)
+    Session::Session(LinkLayer* p, const SockAddr& from)
         : m_State{State::Initial}
         , m_Inbound{true}
         , m_Parent(p)
         , m_CreatedAt{p->Now()}
-        , m_RemoteAddr(from)
+        , m_RemoteAddr{from}
         , m_PlaintextRecv{PlaintextQueueSize}
     {
       token.Randomize();
@@ -62,7 +62,7 @@ namespace llarp
     {
       LogDebug("send ", sz, " to ", m_RemoteAddr);
       const llarp_buffer_t pkt(buf, sz);
-      m_Parent->SendTo_LL(m_RemoteAddr.createSockAddr(), pkt);
+      m_Parent->SendTo_LL(m_RemoteAddr, pkt);
       m_LastTX = time_now_ms();
       m_TXRate += sz;
     }

--- a/llarp/iwp/session.hpp
+++ b/llarp/iwp/session.hpp
@@ -10,6 +10,8 @@
 #include <deque>
 #include <queue>
 
+#include <util/thread/queue.hpp>
+
 namespace llarp
 {
   namespace iwp

--- a/llarp/iwp/session.hpp
+++ b/llarp/iwp/session.hpp
@@ -44,7 +44,7 @@ namespace llarp
       /// outbound session
       Session(LinkLayer* parent, const RouterContact& rc, const AddressInfo& ai);
       /// inbound session
-      Session(LinkLayer* parent, const IpAddress& from);
+      Session(LinkLayer* parent, const SockAddr& from);
 
       ~Session() = default;
 
@@ -85,7 +85,7 @@ namespace llarp
         return m_RemoteRC.pubkey;
       }
 
-      IpAddress
+      const SockAddr&
       GetRemoteEndpoint() const override
       {
         return m_RemoteAddr;
@@ -153,7 +153,7 @@ namespace llarp
       /// parent link layer
       LinkLayer* const m_Parent;
       const llarp_time_t m_CreatedAt;
-      const IpAddress m_RemoteAddr;
+      const SockAddr m_RemoteAddr;
 
       AddressInfo m_ChosenAI;
       /// remote rc

--- a/llarp/iwp/session.hpp
+++ b/llarp/iwp/session.hpp
@@ -126,6 +126,8 @@ namespace llarp
       {
         return m_Inbound;
       }
+      void
+      HandlePlaintext();
 
      private:
       enum class State
@@ -189,19 +191,18 @@ namespace llarp
       /// rx messages to send in next round of multiacks
       std::priority_queue<uint64_t, std::vector<uint64_t>, std::greater<uint64_t>> m_SendMACKs;
 
-      using CryptoQueue_t = std::list<Packet_t>;
-      using CryptoQueue_ptr = std::shared_ptr<CryptoQueue_t>;
-      CryptoQueue_ptr m_EncryptNext;
-      CryptoQueue_ptr m_DecryptNext;
+      using CryptoQueue_t = std::vector<Packet_t>;
+
+      CryptoQueue_t m_EncryptNext;
+      CryptoQueue_t m_DecryptNext;
+
+      llarp::thread::Queue<CryptoQueue_t> m_PlaintextRecv;
 
       void
-      EncryptWorker(CryptoQueue_ptr msgs);
+      EncryptWorker(CryptoQueue_t msgs);
 
       void
-      DecryptWorker(CryptoQueue_ptr msgs);
-
-      void
-      HandlePlaintext(CryptoQueue_ptr msgs);
+      DecryptWorker(CryptoQueue_t msgs);
 
       void
       HandleGotIntro(Packet_t pkt);

--- a/llarp/link/server.hpp
+++ b/llarp/link/server.hpp
@@ -258,20 +258,20 @@ namespace llarp
 
     std::shared_ptr<llarp::Logic> m_Logic = nullptr;
     llarp_ev_loop_ptr m_Loop;
-    IpAddress m_ourAddr;
+    SockAddr m_ourAddr;
     llarp_udp_io m_udp;
     SecretKey m_SecretKey;
 
     using AuthedLinks =
         std::unordered_multimap<RouterID, std::shared_ptr<ILinkSession>, RouterID::Hash>;
     using Pending =
-        std::unordered_multimap<IpAddress, std::shared_ptr<ILinkSession>, IpAddress::Hash>;
+        std::unordered_multimap<SockAddr, std::shared_ptr<ILinkSession>, SockAddr::Hash>;
     mutable DECLARE_LOCK(Mutex_t, m_AuthedLinksMutex, ACQUIRED_BEFORE(m_PendingMutex));
     AuthedLinks m_AuthedLinks GUARDED_BY(m_AuthedLinksMutex);
     mutable DECLARE_LOCK(Mutex_t, m_PendingMutex, ACQUIRED_AFTER(m_AuthedLinksMutex));
     Pending m_Pending GUARDED_BY(m_PendingMutex);
 
-    std::unordered_map<IpAddress, llarp_time_t, IpAddress::Hash> m_RecentlyClosed;
+    std::unordered_map<SockAddr, llarp_time_t, SockAddr::Hash> m_RecentlyClosed;
   };
 
   using LinkLayer_ptr = std::shared_ptr<ILinkLayer>;

--- a/llarp/link/session.hpp
+++ b/llarp/link/session.hpp
@@ -95,7 +95,7 @@ namespace llarp
     IsInbound() const = 0;
 
     /// get remote address
-    virtual IpAddress
+    virtual const SockAddr&
     GetRemoteEndpoint() const = 0;
 
     // get remote rc

--- a/llarp/net/address_info.cpp
+++ b/llarp/net/address_info.cpp
@@ -158,13 +158,11 @@ namespace llarp
   }
 
   void
-  AddressInfo::fromIpAddress(const IpAddress& address)
+  AddressInfo::fromSockAddr(const SockAddr& addr)
   {
-    SockAddr addr = address.createSockAddr();
     const sockaddr_in6* addr6 = addr;
     memcpy(ip.s6_addr, addr6->sin6_addr.s6_addr, sizeof(ip.s6_addr));
-
-    port = address.getPort().value_or(0);
+    port = addr.getPort();
   }
 
   std::ostream&

--- a/llarp/net/address_info.hpp
+++ b/llarp/net/address_info.hpp
@@ -44,7 +44,7 @@ namespace llarp
     IpAddress
     toIpAddress() const;
 
-    /// Updates our ip and port to reflact that of the given SockAddr
+    /// Updates our ip and port to reflect that of the given SockAddr
     void
     fromSockAddr(const SockAddr& address);
 

--- a/llarp/net/address_info.hpp
+++ b/llarp/net/address_info.hpp
@@ -44,9 +44,9 @@ namespace llarp
     IpAddress
     toIpAddress() const;
 
-    /// Updates our ip and port to reflact that of the given IpAddress
+    /// Updates our ip and port to reflact that of the given SockAddr
     void
-    fromIpAddress(const IpAddress& address);
+    fromSockAddr(const SockAddr& address);
 
     std::ostream&
     print(std::ostream& stream, int level, int spaces) const;

--- a/llarp/net/net.cpp
+++ b/llarp/net/net.cpp
@@ -545,7 +545,7 @@ namespace llarp
     return std::nullopt;
   }
 
-  std::optional<IpAddress>
+  std::optional<SockAddr>
   GetInterfaceAddr(const std::string& ifname, int af)
   {
     sockaddr_storage s;
@@ -553,8 +553,7 @@ namespace llarp
     sptr->sa_family = af;
     if (!llarp_getifaddr(ifname.c_str(), af, sptr))
       return std::nullopt;
-    llarp::SockAddr saddr = SockAddr{*sptr};
-    return llarp::IpAddress(saddr);
+    return SockAddr{*sptr};
   }
 
   std::optional<huint128_t>
@@ -570,7 +569,7 @@ namespace llarp
   }
 
   bool
-  AllInterfaces(int af, IpAddress& result)
+  AllInterfaces(int af, SockAddr& result)
   {
     if (af == AF_INET)
     {
@@ -578,25 +577,18 @@ namespace llarp
       addr.sin_family = AF_INET;
       addr.sin_addr.s_addr = htonl(INADDR_ANY);
       addr.sin_port = htons(0);
-      SockAddr saddr = SockAddr(addr);
-      result = IpAddress(saddr);
+      result = SockAddr{addr};
       return true;
     }
     if (af == AF_INET6)
     {
-      throw std::runtime_error("Fix me: IPv6 not supported yet");
-      /*
       sockaddr_in6 addr6;
       addr6.sin6_family = AF_INET6;
       addr6.sin6_port = htons(0);
       addr6.sin6_addr = IN6ADDR_ANY_INIT;
-      result = IpAddress(SockAddr(addr6));
+      result = SockAddr{addr6};
       return true;
-      */
     }
-
-    // TODO: implement sockaddr_ll
-
     return false;
   }
 

--- a/llarp/net/net.hpp
+++ b/llarp/net/net.hpp
@@ -59,7 +59,7 @@ namespace llarp
   IsBogonRange(const in6_addr& host, const in6_addr& mask);
 
   bool
-  AllInterfaces(int af, IpAddress& addr);
+  AllInterfaces(int af, SockAddr& addr);
 
   /// get first network interface with public address
   bool
@@ -74,7 +74,7 @@ namespace llarp
   FindFreeTun();
 
   /// get network interface address for network interface with ifname
-  std::optional<IpAddress>
+  std::optional<SockAddr>
   GetInterfaceAddr(const std::string& ifname, int af = AF_INET);
 
   /// get an interface's ip6 address

--- a/llarp/net/net_int.cpp
+++ b/llarp/net/net_int.cpp
@@ -5,6 +5,13 @@
 namespace llarp
 {
   template <>
+  huint32_t
+  ToHost(nuint32_t n)
+  {
+    return xntohl(n);
+  }
+
+  template <>
   nuint32_t
   ToNet(huint32_t h)
   {

--- a/llarp/net/route.cpp
+++ b/llarp/net/route.cpp
@@ -375,7 +375,8 @@ namespace llarp::net
       throw std::runtime_error("we dont have our own net interface?");
     int nl_cmd = RTM_NEWROUTE;
     int nl_flags = NLM_F_CREATE | NLM_F_EXCL;
-    read_addr(maybe->toHost().c_str(), &gw_addr);
+    const auto host = maybe->asIPv4().ToString();
+    read_addr(host.c_str(), &gw_addr);
     read_addr("0.0.0.0", &to_addr, 1);
     do_route(sock.fd, nl_cmd, nl_flags, &to_addr, &gw_addr, GatewayMode::eLowerDefault, if_idx);
     read_addr("128.0.0.0", &to_addr, 1);
@@ -441,7 +442,8 @@ namespace llarp::net
       throw std::runtime_error("we dont have our own net interface?");
     int nl_cmd = RTM_DELROUTE;
     int nl_flags = 0;
-    read_addr(maybe->toHost().c_str(), &gw_addr);
+    const auto host = maybe->asIPv4().ToString();
+    read_addr(host.c_str(), &gw_addr);
     read_addr("0.0.0.0", &to_addr, 1);
     do_route(sock.fd, nl_cmd, nl_flags, &to_addr, &gw_addr, GatewayMode::eLowerDefault, if_idx);
     read_addr("128.0.0.0", &to_addr, 1);

--- a/llarp/net/sock_addr.hpp
+++ b/llarp/net/sock_addr.hpp
@@ -20,6 +20,8 @@ inet_pton(int af, const char* src, void* dst);
 
 namespace llarp
 {
+  struct AddressInfo;
+
   /// A simple SockAddr wrapper which provides a sockaddr_in (IPv4). Memory management is handled
   /// in constructor and destructor (if needed) and copying is disabled.
   struct SockAddr
@@ -28,6 +30,8 @@ namespace llarp
     SockAddr(uint8_t a, uint8_t b, uint8_t c, uint8_t d);
     SockAddr(uint8_t a, uint8_t b, uint8_t c, uint8_t d, uint16_t port);
     SockAddr(std::string_view addr);
+
+    SockAddr(const AddressInfo&);
 
     SockAddr(const SockAddr&);
     SockAddr&
@@ -75,14 +79,30 @@ namespace llarp
     void
     setIPv4(uint8_t a, uint8_t b, uint8_t c, uint8_t d);
 
+    /// port is in host order
     void
     setPort(uint16_t port);
 
+    /// port is in host order
     uint16_t
     getPort() const;
 
     huint128_t
     asIPv6() const;
+
+    huint32_t
+    asIPv4() const;
+
+    struct Hash
+    {
+      size_t
+      operator()(const SockAddr& addr) const noexcept
+      {
+        const std::hash<uint16_t> port{};
+        const std::hash<huint128_t> ip{};
+        return (port(addr.getPort()) << 3) ^ ip(addr.asIPv6());
+      }
+    };
 
    private:
     bool m_empty = true;

--- a/llarp/router/route_poker.cpp
+++ b/llarp/router/route_poker.cpp
@@ -174,7 +174,8 @@ namespace llarp
   {
     // explicit route pokes for first hops
     m_Router->ForEachPeer(
-        [&](auto session, auto) mutable { AddRoute(session->GetRemoteEndpoint().toIP()); }, false);
+        [&](auto session, auto) mutable { AddRoute(session->GetRemoteEndpoint().asIPv4()); },
+        false);
     // add default route
     const auto ep = m_Router->hiddenServiceContext().GetDefault();
     net::AddDefaultRouteViaInterface(ep->GetIfName());
@@ -185,7 +186,8 @@ namespace llarp
   {
     // unpoke routes for first hops
     m_Router->ForEachPeer(
-        [&](auto session, auto) mutable { DelRoute(session->GetRemoteEndpoint().toIP()); }, false);
+        [&](auto session, auto) mutable { DelRoute(session->GetRemoteEndpoint().asIPv4()); },
+        false);
     // remove default route
     const auto ep = m_Router->hiddenServiceContext().GetDefault();
     net::DelDefaultRouteViaInterface(ep->GetIfName());

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -472,7 +472,7 @@ namespace llarp
     transport_keyfile = m_keyManager->m_transportKeyPath;
     ident_keyfile = m_keyManager->m_idKeyPath;
 
-    _ourAddress = conf.router.m_publicAddress;
+    _ourAddress = conf.router.m_publicAddress.createSockAddr();
 
     RouterContact::BlockBogons = conf.router.m_blockBogons;
 
@@ -1032,9 +1032,9 @@ namespace llarp
       if (link->GetOurAddressInfo(ai))
       {
         // override ip and port
-        if (not _ourAddress.isEmpty())
+        if (_ourAddress)
         {
-          ai.fromIpAddress(_ourAddress);
+          ai.fromSockAddr(*_ourAddress);
         }
         if (RouterContact::BlockBogons && IsBogon(ai.ip))
           return;

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -612,6 +612,7 @@ namespace llarp
     {
       auto server = iwp::NewInboundLink(
           m_keyManager,
+          netloop(),
           util::memFn(&AbstractRouter::rc, this),
           util::memFn(&AbstractRouter::HandleRecvLinkMessageBuffer, this),
           util::memFn(&AbstractRouter::Sign, this),
@@ -1313,6 +1314,7 @@ namespace llarp
   {
     auto link = iwp::NewOutboundLink(
         m_keyManager,
+        netloop(),
         util::memFn(&AbstractRouter::rc, this),
         util::memFn(&AbstractRouter::HandleRecvLinkMessageBuffer, this),
         util::memFn(&AbstractRouter::Sign, this),

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -178,7 +178,7 @@ namespace llarp
     void
     QueueDiskIO(std::function<void(void)> func) override;
 
-    IpAddress _ourAddress;
+    std::optional<SockAddr> _ourAddress;
 
     llarp_ev_loop_ptr _netloop;
     std::shared_ptr<Logic> _logic;

--- a/test/iwp/test_iwp_session.cpp
+++ b/test/iwp/test_iwp_session.cpp
@@ -76,6 +76,7 @@ struct IWPLinkContext
   {
     link = make_link<inbound>(
         keyManager,
+        m_Loop,
         // getrc
         [&]() -> const llarp::RouterContact& { return rc; },
         // link message handler


### PR DESCRIPTION
this removed the packet based cpu use bottleneck which came from primarily a lack of coalescing of udp reads.

this also removes use of `llarp::IpAddress` from hotpaths as it does a lot of unneeded allocations.