### PR TITLE
SockAddr fixes and cleanups

### DIFF
--- a/llarp/net/ip_range.hpp
+++ b/llarp/net/ip_range.hpp
@@ -20,12 +20,12 @@ namespace llarp
       return IPRange{net::ExpandV4(ipaddr_ipv4_bits(a, b, c, d)), netmask_ipv6_bits(mask + 96)};
     }
 
-    /// return true if this iprange is in the SIIT range for containing ipv4 addresses
+    /// return true if this iprange is in the IPv4 mapping range for containing ipv4 addresses
     constexpr bool
     IsV4() const
     {
-      constexpr auto siit = IPRange{huint128_t{0x0000'ffff'0000'0000UL}, netmask_ipv6_bits(96)};
-      return siit.Contains(addr);
+      constexpr auto ipv4_map = IPRange{huint128_t{0x0000'ffff'0000'0000UL}, netmask_ipv6_bits(96)};
+      return ipv4_map.Contains(addr);
     }
 
     /// return the number of bits set in the hostmask

--- a/llarp/net/net.cpp
+++ b/llarp/net/net.cpp
@@ -599,7 +599,7 @@ namespace llarp
     (void)addr;
     return false;
 #else
-    if (!ipv6_is_siit(addr))
+    if (!ipv6_is_mapped_ipv4(addr))
     {
       static in6_addr zero = {};
       if (addr == zero)

--- a/llarp/net/net_bits.hpp
+++ b/llarp/net/net_bits.hpp
@@ -37,12 +37,15 @@ namespace llarp
     return huint32_t{(d) | (c << 8) | (b << 16) | (a << 24)};
   }
 
+  // IPv4 mapped address live at ::ffff:0:0/96
+  constexpr std::array<uint8_t, 12> ipv4_map_prefix{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff};
+
   constexpr bool
-  ipv6_is_siit(const in6_addr& addr)
+  ipv6_is_mapped_ipv4(const in6_addr& addr)
   {
-    return addr.s6_addr[11] == 0xff && addr.s6_addr[10] == 0xff && addr.s6_addr[9] == 0
-        && addr.s6_addr[8] == 0 && addr.s6_addr[7] == 0 && addr.s6_addr[6] == 0
-        && addr.s6_addr[5] == 0 && addr.s6_addr[4] == 0 && addr.s6_addr[3] == 0
-        && addr.s6_addr[2] == 0 && addr.s6_addr[1] == 0 && addr.s6_addr[0] == 0;
+    for (size_t i = 0; i < ipv4_map_prefix.size(); i++)
+      if (addr.s6_addr[i] != ipv4_map_prefix[i])
+        return false;
+    return true;
   }
 }  // namespace llarp

--- a/llarp/net/sock_addr.hpp
+++ b/llarp/net/sock_addr.hpp
@@ -30,6 +30,7 @@ namespace llarp
     SockAddr(uint8_t a, uint8_t b, uint8_t c, uint8_t d);
     SockAddr(uint8_t a, uint8_t b, uint8_t c, uint8_t d, uint16_t port);
     SockAddr(std::string_view addr);
+    SockAddr(std::string_view addr, uint16_t port);
 
     SockAddr(const AddressInfo&);
 
@@ -64,7 +65,7 @@ namespace llarp
     operator==(const SockAddr& other) const;
 
     void
-    fromString(std::string_view str);
+    fromString(std::string_view str, bool allow_port = true);
 
     std::string
     toString() const;
@@ -113,7 +114,7 @@ namespace llarp
     init();
 
     void
-    applySIITBytes();
+    applyIPv4MapBytes();
   };
 
   std::ostream&


### PR DESCRIPTION
- Remove SIIT from method names & comments because we're doing IPv4
mapped addresses (::ffff:0:0/96) rather than actual SIIT
(::ffff:0:0:0/96).

- add constructor taking a string+numeric port (and then don't allow a
port in the string).

- simplify IP string parsing by using parse_int()

- replace addrIsV4 with call to ipv6_is_mapped_ipv4 (this also fixes a
bug where addrIsV4 was not checking for leading 0s and so could return
true for a public IPv6 that happened to have ffff in the wrong spot).