### PR TITLE
Allow multiple gradles to run on the same box

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -80,7 +80,7 @@ local apk_builder(name, image, extra_cmds=[], allow_fail=false) = {
                 "rm -f local.properties",
                 "echo 'sdk.dir=/usr/lib/android-sdk' >> local.properties",
                 "echo 'ndk.dir=/usr/lib/android-ndk' >> local.properties",
-                "GRADLE_USER_HOME=/cache/gradle gradle --no-daemon assembleDebug",
+                "GRADLE_USER_HOME=/cache/gradle/${DRONE_STAGE_MACHINE} gradle --no-daemon assembleDebug",
             ] + extra_cmds
         }
     ]


### PR DESCRIPTION
/cache is shared among multiple runners that can potentiall run at
once, but gradle's cache is retarded and just completely blocks anything
from using the cache for the span of the entire build.  Work around it
by sticking the unique builder identifier in the cache path.