### PR TITLE
unbreak ipv4 exits

### DIFF
--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -1046,7 +1046,7 @@ namespace llarp
         if (t == service::eProtocolExit)
         {
           if (pkt.IsV4())
-            dst = pkt.dst4to6Lan();
+            dst = pkt.dst4to6();
           else if (pkt.IsV6())
           {
             dst = pkt.dstv6();
@@ -1065,7 +1065,7 @@ namespace llarp
         if (pkt.IsV4())
         {
           dst = m_OurIP;
-          src = pkt.src4to6Lan();
+          src = pkt.src4to6();
         }
         else if (pkt.IsV6())
         {

--- a/llarp/rpc/rpc_server.cpp
+++ b/llarp/rpc/rpc_server.cpp
@@ -263,6 +263,7 @@ namespace llarp::rpc
                                   return;
                                 }
                                 auto onGoodResult = [r, reply](std::string reason) {
+                                  r->routePoker().Enable();
                                   r->routePoker().Up();
                                   reply(CreateJSONResponse(reason));
                                 };


### PR DESCRIPTION
this fixes a regression that was introduced when we added ipv6 nat exits that broke ipv4 exits backwards compat.