### PR TITLE
Clang format 11

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -217,7 +217,7 @@ local mac_builder(name, build_type='Release', werror=true, cmake_extra='', extra
                 'echo "Building on ${DRONE_STAGE_MACHINE}"',
                 apt_get_quiet + ' update',
                 apt_get_quiet + ' install -y eatmydata',
-                'eatmydata ' + apt_get_quiet + ' install -y git clang-format-9',
+                'eatmydata ' + apt_get_quiet + ' install -y git clang-format-11',
                 './contrib/ci/drone-format-verify.sh']
         }]
     },

--- a/contrib/ci/docker/lint.dockerfile
+++ b/contrib/ci/docker/lint.dockerfile
@@ -1,3 +1,3 @@
 FROM debian:sid
 RUN /bin/bash -c 'echo "man-db man-db/auto-update boolean false" | debconf-set-selections'
-RUN /bin/bash -c 'apt-get -o=Dpkg::Use-Pty=0 -q update && apt-get -o=Dpkg::Use-Pty=0 -q install -y eatmydata git clang-format-9'
+RUN /bin/bash -c 'apt-get -o=Dpkg::Use-Pty=0 -q update && apt-get -o=Dpkg::Use-Pty=0 -q install -y eatmydata git clang-format-11'

--- a/contrib/ci/drone-format-verify.sh
+++ b/contrib/ci/drone-format-verify.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 test "x$IGNORE" != "x" && exit 0
 repo=$(readlink -e $(dirname $0)/../../)
-clang-format-9 -i $(find $repo/jni $repo/daemon $repo/llarp $repo/include $repo/pybind | grep -E '\.[hc](pp)?$')
+clang-format-11 -i $(find $repo/jni $repo/daemon $repo/llarp $repo/include $repo/pybind | grep -E '\.[hc](pp)?$')
 git --no-pager diff --exit-code --color || (echo -ne '\n\n\e[31;1mLint check failed; please run ./contrib/format.sh\e[0m\n\n' ; exit 1)

--- a/contrib/format.sh
+++ b/contrib/format.sh
@@ -2,4 +2,4 @@
 
 # TODO: readlink -e is a GNU-ism
 cd "$(readlink -e $(dirname $0)/../)"
-clang-format-9 -i $(find jni daemon llarp include pybind | grep -E '\.[hc](pp)?$') &> /dev/null
+clang-format-11 -i $(find jni daemon llarp include pybind | grep -E '\.[hc](pp)?$') &> /dev/null

--- a/daemon/lokinet-vpn.cpp
+++ b/daemon/lokinet-vpn.cpp
@@ -147,10 +147,11 @@ main(int argc, char* argv[])
     return 1;
   }
 
-  lokimq::LokiMQ lmq{[](lokimq::LogLevel lvl, const char* file, int line, std::string msg) {
-                       std::cout << lvl << " [" << file << ":" << line << "] " << msg << std::endl;
-                     },
-                     logLevel};
+  lokimq::LokiMQ lmq{
+      [](lokimq::LogLevel lvl, const char* file, int line, std::string msg) {
+        std::cout << lvl << " [" << file << ":" << line << "] " << msg << std::endl;
+      },
+      logLevel};
 
   lmq.start();
 

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -376,8 +376,8 @@ main(int argc, char* argv[])
 #ifndef _WIN32
   return lokinet_main(argc, argv);
 #else
-  SERVICE_TABLE_ENTRY DispatchTable[] = {{"lokinet", (LPSERVICE_MAIN_FUNCTION)win32_daemon_entry},
-                                         {NULL, NULL}};
+  SERVICE_TABLE_ENTRY DispatchTable[] = {
+      {"lokinet", (LPSERVICE_MAIN_FUNCTION)win32_daemon_entry}, {NULL, NULL}};
   if (lstrcmpi(argv[1], "--win32-daemon") == 0)
   {
     start_as_daemon = true;
@@ -576,26 +576,27 @@ lokinet_main(int argc, char* argv[])
     // do periodic non lokinet related tasks here
     if (ctx and ctx->IsUp() and not ctx->LooksAlive())
     {
-      for (const auto& wtf : {"you have been visited by the mascott of the "
-                              "deadlocked router.",
-                              "⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄⣀⣴⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⣄⠄⠄⠄⠄",
-                              "⠄⠄⠄⠄⠄⢀⣀⣀⡀⠄⠄⠄⡠⢲⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡀⠄⠄",
-                              "⠄⠄⠄⠔⣈⣀⠄⢔⡒⠳⡴⠊⠄⠸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⣿⣿⣧⠄⠄",
-                              "⠄⢜⡴⢑⠖⠊⢐⣤⠞⣩⡇⠄⠄⠄⠙⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣆⠄⠝⠛⠋⠐",
-                              "⢸⠏⣷⠈⠄⣱⠃⠄⢠⠃⠐⡀⠄⠄⠄⠄⠙⠻⢿⣿⣿⣿⣿⣿⣿⣿⡿⠛⠸⠄⠄⠄⠄",
-                              "⠈⣅⠞⢁⣿⢸⠘⡄⡆⠄⠄⠈⠢⡀⠄⠄⠄⠄⠄⠄⠉⠙⠛⠛⠛⠉⠉⡀⠄⠡⢀⠄⣀",
-                              "⠄⠙⡎⣹⢸⠄⠆⢘⠁⠄⠄⠄⢸⠈⠢⢄⡀⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄⠃⠄⠄⠄⠄⠄",
-                              "⠄⠄⠑⢿⠈⢆⠘⢼⠄⠄⠄⠄⠸⢐⢾⠄⡘⡏⠲⠆⠠⣤⢤⢤⡤⠄⣖⡇⠄⠄⠄⠄⠄",
-                              "⣴⣶⣿⣿⣣⣈⣢⣸⠄⠄⠄⠄⡾⣷⣾⣮⣤⡏⠁⠘⠊⢠⣷⣾⡛⡟⠈⠄⠄⠄⠄⠄⠄",
-                              "⣿⣿⣿⣿⣿⠉⠒⢽⠄⠄⠄⠄⡇⣿⣟⣿⡇⠄⠄⠄⠄⢸⣻⡿⡇⡇⠄⠄⠄⠄⠄⠄⠄",
-                              "⠻⣿⣿⣿⣿⣄⠰⢼⠄⠄⠄⡄⠁⢻⣍⣯⠃⠄⠄⠄⠄⠈⢿⣻⠃⠈⡆⡄⠄⠄⠄⠄⠄",
-                              "⠄⠙⠿⠿⠛⣿⣶⣤⡇⠄⠄⢣⠄⠄⠈⠄⢠⠂⠄⠁⠄⡀⠄⠄⣀⠔⢁⠃⠄⠄⠄⠄⠄",
-                              "⠄⠄⠄⠄⠄⣿⣿⣿⣿⣾⠢⣖⣶⣦⣤⣤⣬⣤⣤⣤⣴⣶⣶⡏⠠⢃⠌⠄⠄⠄⠄⠄⠄",
-                              "⠄⠄⠄⠄⠄⠿⠿⠟⠛⡹⠉⠛⠛⠿⠿⣿⣿⣿⣿⣿⡿⠂⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄",
-                              "⠠⠤⠤⠄⠄⣀⠄⠄⠄⠑⠠⣤⣀⣀⣀⡘⣿⠿⠙⠻⡍⢀⡈⠂⠄⠄⠄⠄⠄⠄⠄⠄⠄",
-                              "⠄⠄⠄⠄⠄⠄⠑⠠⣠⣴⣾⣿⣿⣿⣿⣿⣿⣇⠉⠄⠻⣿⣷⣄⡀⠄⠄⠄⠄⠄⠄⠄⠄",
-                              "file a bug report now or be cursed with this "
-                              "annoying image in your syslog for all time."})
+      for (const auto& wtf :
+           {"you have been visited by the mascott of the "
+            "deadlocked router.",
+            "⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄⣀⣴⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⣄⠄⠄⠄⠄",
+            "⠄⠄⠄⠄⠄⢀⣀⣀⡀⠄⠄⠄⡠⢲⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⡀⠄⠄",
+            "⠄⠄⠄⠔⣈⣀⠄⢔⡒⠳⡴⠊⠄⠸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⣿⣿⣧⠄⠄",
+            "⠄⢜⡴⢑⠖⠊⢐⣤⠞⣩⡇⠄⠄⠄⠙⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣆⠄⠝⠛⠋⠐",
+            "⢸⠏⣷⠈⠄⣱⠃⠄⢠⠃⠐⡀⠄⠄⠄⠄⠙⠻⢿⣿⣿⣿⣿⣿⣿⣿⡿⠛⠸⠄⠄⠄⠄",
+            "⠈⣅⠞⢁⣿⢸⠘⡄⡆⠄⠄⠈⠢⡀⠄⠄⠄⠄⠄⠄⠉⠙⠛⠛⠛⠉⠉⡀⠄⠡⢀⠄⣀",
+            "⠄⠙⡎⣹⢸⠄⠆⢘⠁⠄⠄⠄⢸⠈⠢⢄⡀⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄⠃⠄⠄⠄⠄⠄",
+            "⠄⠄⠑⢿⠈⢆⠘⢼⠄⠄⠄⠄⠸⢐⢾⠄⡘⡏⠲⠆⠠⣤⢤⢤⡤⠄⣖⡇⠄⠄⠄⠄⠄",
+            "⣴⣶⣿⣿⣣⣈⣢⣸⠄⠄⠄⠄⡾⣷⣾⣮⣤⡏⠁⠘⠊⢠⣷⣾⡛⡟⠈⠄⠄⠄⠄⠄⠄",
+            "⣿⣿⣿⣿⣿⠉⠒⢽⠄⠄⠄⠄⡇⣿⣟⣿⡇⠄⠄⠄⠄⢸⣻⡿⡇⡇⠄⠄⠄⠄⠄⠄⠄",
+            "⠻⣿⣿⣿⣿⣄⠰⢼⠄⠄⠄⡄⠁⢻⣍⣯⠃⠄⠄⠄⠄⠈⢿⣻⠃⠈⡆⡄⠄⠄⠄⠄⠄",
+            "⠄⠙⠿⠿⠛⣿⣶⣤⡇⠄⠄⢣⠄⠄⠈⠄⢠⠂⠄⠁⠄⡀⠄⠄⣀⠔⢁⠃⠄⠄⠄⠄⠄",
+            "⠄⠄⠄⠄⠄⣿⣿⣿⣿⣾⠢⣖⣶⣦⣤⣤⣬⣤⣤⣤⣴⣶⣶⡏⠠⢃⠌⠄⠄⠄⠄⠄⠄",
+            "⠄⠄⠄⠄⠄⠿⠿⠟⠛⡹⠉⠛⠛⠿⠿⣿⣿⣿⣿⣿⡿⠂⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄⠄",
+            "⠠⠤⠤⠄⠄⣀⠄⠄⠄⠑⠠⣤⣀⣀⣀⡘⣿⠿⠙⠻⡍⢀⡈⠂⠄⠄⠄⠄⠄⠄⠄⠄⠄",
+            "⠄⠄⠄⠄⠄⠄⠑⠠⣠⣴⣾⣿⣿⣿⣿⣿⣿⣇⠉⠄⠻⣿⣷⣄⡀⠄⠄⠄⠄⠄⠄⠄⠄",
+            "file a bug report now or be cursed with this "
+            "annoying image in your syslog for all time."})
       {
         LogError(wtf);
         llarp::LogContext::Instance().ImmediateFlush();

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -1006,9 +1006,10 @@ namespace llarp
           }
           m_UniqueHopsNetmaskSize = arg;
         },
-        Comment{"Netmask for router path selection; each router must be from a distinct IP subnet "
-                "of the given size.",
-                "E.g. 16 ensures that all routers are using distinct /16 IP addresses."});
+        Comment{
+            "Netmask for router path selection; each router must be from a distinct IP subnet "
+            "of the given size.",
+            "E.g. 16 ensures that all routers are using distinct /16 IP addresses."});
 
 #ifdef WITH_GEOIP
     conf.defineOption<std::string>(
@@ -1019,9 +1020,10 @@ namespace llarp
         [=](std::string arg) {
           m_ExcludeCountries.emplace(lowercase_ascii_string(std::move(arg)));
         },
-        Comment{"exclude a country given its 2 letter country code from being used in path builds",
-                "e.g. exclude-country=DE",
-                "can be listed multiple times to exclude multiple countries"});
+        Comment{
+            "exclude a country given its 2 letter country code from being used in path builds",
+            "e.g. exclude-country=DE",
+            "can be listed multiple times to exclude multiple countries"});
 #endif
   }
 

--- a/llarp/config/definition.cpp
+++ b/llarp/config/definition.cpp
@@ -39,9 +39,9 @@ namespace llarp
             LogWarn(
                 "*** WARNING: The config option ",
                 opt,
-                (deprecated ? " is deprecated"
-                            : relay ? " is not valid in service node configuration files"
-                                    : " is not valid in client configuration files"),
+                (deprecated  ? " is deprecated"
+                     : relay ? " is not valid in service node configuration files"
+                             : " is not valid in client configuration files"),
                 " and has been ignored.");
           });
     }

--- a/llarp/dht/context.cpp
+++ b/llarp/dht/context.cpp
@@ -435,12 +435,13 @@ namespace llarp
     util::StatusObject
     Context::ExtractStatus() const
     {
-      util::StatusObject obj{{"pendingRouterLookups", pendingRouterLookups().ExtractStatus()},
-                             {"pendingIntrosetLookups", _pendingIntrosetLookups.ExtractStatus()},
-                             {"pendingExploreLookups", pendingExploreLookups().ExtractStatus()},
-                             {"nodes", _nodes->ExtractStatus()},
-                             {"services", _services->ExtractStatus()},
-                             {"ourKey", ourKey.ToHex()}};
+      util::StatusObject obj{
+          {"pendingRouterLookups", pendingRouterLookups().ExtractStatus()},
+          {"pendingIntrosetLookups", _pendingIntrosetLookups.ExtractStatus()},
+          {"pendingExploreLookups", pendingExploreLookups().ExtractStatus()},
+          {"nodes", _nodes->ExtractStatus()},
+          {"services", _services->ExtractStatus()},
+          {"ourKey", ourKey.ToHex()}};
       return obj;
     }
 

--- a/llarp/dht/messages/findname.cpp
+++ b/llarp/dht/messages/findname.cpp
@@ -16,10 +16,10 @@ namespace llarp::dht
   bool
   FindNameMessage::BEncode(llarp_buffer_t* buf) const
   {
-    const auto data = oxenmq::bt_serialize(
-        oxenmq::bt_dict{{"A", "N"sv},
-                        {"H", std::string_view{(char*)NameHash.data(), NameHash.size()}},
-                        {"T", TxID}});
+    const auto data = oxenmq::bt_serialize(oxenmq::bt_dict{
+        {"A", "N"sv},
+        {"H", std::string_view{(char*)NameHash.data(), NameHash.size()}},
+        {"T", TxID}});
     return buf->write(data.begin(), data.end());
   }
 

--- a/llarp/dht/tx.hpp
+++ b/llarp/dht/tx.hpp
@@ -36,8 +36,8 @@ namespace llarp
       util::StatusObject
       ExtractStatus() const
       {
-        util::StatusObject obj{{"whoasked", whoasked.ExtractStatus()},
-                               {"target", target.ExtractStatus()}};
+        util::StatusObject obj{
+            {"whoasked", whoasked.ExtractStatus()}, {"target", target.ExtractStatus()}};
         std::vector<util::StatusObject> foundObjs;
         std::transform(
             valuesFound.begin(),

--- a/llarp/dht/txholder.hpp
+++ b/llarp/dht/txholder.hpp
@@ -37,8 +37,8 @@ namespace llarp
             tx.end(),
             std::back_inserter(txObjs),
             [](const auto& item) -> util::StatusObject {
-              return util::StatusObject{{"owner", item.first.ExtractStatus()},
-                                        {"tx", item.second->ExtractStatus()}};
+              return util::StatusObject{
+                  {"owner", item.first.ExtractStatus()}, {"tx", item.second->ExtractStatus()}};
             });
         obj["tx"] = txObjs;
         std::transform(
@@ -46,8 +46,8 @@ namespace llarp
             timeouts.end(),
             std::back_inserter(timeoutsObjs),
             [](const auto& item) -> util::StatusObject {
-              return util::StatusObject{{"time", to_json(item.second)},
-                                        {"target", item.first.ExtractStatus()}};
+              return util::StatusObject{
+                  {"time", to_json(item.second)}, {"target", item.first.ExtractStatus()}};
             });
         obj["timeouts"] = timeoutsObjs;
         std::transform(
@@ -55,8 +55,9 @@ namespace llarp
             waiting.end(),
             std::back_inserter(waitingObjs),
             [](const auto& item) -> util::StatusObject {
-              return util::StatusObject{{"target", item.first.ExtractStatus()},
-                                        {"whoasked", item.second.ExtractStatus()}};
+              return util::StatusObject{
+                  {"target", item.first.ExtractStatus()},
+                  {"whoasked", item.second.ExtractStatus()}};
             });
         obj["waiting"] = waitingObjs;
         return obj;

--- a/llarp/exit/endpoint.cpp
+++ b/llarp/exit/endpoint.cpp
@@ -40,15 +40,16 @@ namespace llarp
     Endpoint::ExtractStatus() const
     {
       auto now = m_Parent->Now();
-      util::StatusObject obj{{"identity", m_remoteSignKey.ToString()},
-                             {"ip", m_IP.ToString()},
-                             {"txRate", m_TxRate},
-                             {"rxRate", m_RxRate},
-                             {"createdAt", to_json(createdAt)},
-                             {"exiting", !m_RewriteSource},
-                             {"looksDead", LooksDead(now)},
-                             {"expiresSoon", ExpiresSoon(now)},
-                             {"expired", IsExpired(now)}};
+      util::StatusObject obj{
+          {"identity", m_remoteSignKey.ToString()},
+          {"ip", m_IP.ToString()},
+          {"txRate", m_TxRate},
+          {"rxRate", m_RxRate},
+          {"createdAt", to_json(createdAt)},
+          {"exiting", !m_RewriteSource},
+          {"looksDead", LooksDead(now)},
+          {"expiresSoon", ExpiresSoon(now)},
+          {"expired", IsExpired(now)}};
       return obj;
     }
 

--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -296,27 +296,28 @@ namespace llarp
     {
       const auto now = m_Parent->Now();
 
-      return {{"txRateCurrent", m_Stats.currentRateTX},
-              {"rxRateCurrent", m_Stats.currentRateRX},
-              {"rxPktsRcvd", m_Stats.totalPacketsRX},
+      return {
+          {"txRateCurrent", m_Stats.currentRateTX},
+          {"rxRateCurrent", m_Stats.currentRateRX},
+          {"rxPktsRcvd", m_Stats.totalPacketsRX},
 
-              // leave 'tx' and 'rx' as duplicates of 'xRateCurrent' for compat
-              {"tx", m_Stats.currentRateTX},
-              {"rx", m_Stats.currentRateRX},
+          // leave 'tx' and 'rx' as duplicates of 'xRateCurrent' for compat
+          {"tx", m_Stats.currentRateTX},
+          {"rx", m_Stats.currentRateRX},
 
-              {"txPktsAcked", m_Stats.totalAckedTX},
-              {"txPktsDropped", m_Stats.totalDroppedTX},
-              {"txPktsInFlight", m_Stats.totalInFlightTX},
+          {"txPktsAcked", m_Stats.totalAckedTX},
+          {"txPktsDropped", m_Stats.totalDroppedTX},
+          {"txPktsInFlight", m_Stats.totalInFlightTX},
 
-              {"state", StateToString(m_State)},
-              {"inbound", m_Inbound},
-              {"replayFilter", m_ReplayFilter.size()},
-              {"txMsgQueueSize", m_TXMsgs.size()},
-              {"rxMsgQueueSize", m_RXMsgs.size()},
-              {"remoteAddr", m_RemoteAddr.toString()},
-              {"remoteRC", m_RemoteRC.ExtractStatus()},
-              {"created", to_json(m_CreatedAt)},
-              {"uptime", to_json(now - m_CreatedAt)}};
+          {"state", StateToString(m_State)},
+          {"inbound", m_Inbound},
+          {"replayFilter", m_ReplayFilter.size()},
+          {"txMsgQueueSize", m_TXMsgs.size()},
+          {"rxMsgQueueSize", m_RXMsgs.size()},
+          {"remoteAddr", m_RemoteAddr.toString()},
+          {"remoteRC", m_RemoteRC.ExtractStatus()},
+          {"created", to_json(m_CreatedAt)},
+          {"uptime", to_json(now - m_CreatedAt)}};
     }
 
     bool
@@ -737,8 +738,8 @@ namespace llarp
       }
       uint16_t sz = bufbe16toh(data.data() + CommandOverhead + PacketOverhead);
       uint64_t rxid = bufbe64toh(data.data() + CommandOverhead + sizeof(uint16_t) + PacketOverhead);
-      ShortHash h{data.data() + CommandOverhead + sizeof(uint16_t) + sizeof(uint64_t)
-                  + PacketOverhead};
+      ShortHash h{
+          data.data() + CommandOverhead + sizeof(uint16_t) + sizeof(uint64_t) + PacketOverhead};
       LogDebug("rxid=", rxid, " sz=", sz, " h=", h.ToHex());
       m_LastRX = m_Parent->Now();
       {

--- a/llarp/link/server.cpp
+++ b/llarp/link/server.cpp
@@ -291,10 +291,11 @@ namespace llarp
           [](const auto& item) -> util::StatusObject { return item.second->ExtractStatus(); });
     }
 
-    return {{"name", Name()},
-            {"rank", uint64_t(Rank())},
-            {"addr", m_ourAddr.toString()},
-            {"sessions", util::StatusObject{{"pending", pending}, {"established", established}}}};
+    return {
+        {"name", Name()},
+        {"rank", uint64_t(Rank())},
+        {"addr", m_ourAddr.toString()},
+        {"sessions", util::StatusObject{{"pending", pending}, {"established", established}}}};
   }
 
   bool

--- a/llarp/net/address_info.cpp
+++ b/llarp/net/address_info.cpp
@@ -184,10 +184,11 @@ namespace llarp
     char tmp[128] = {0};
     inet_ntop(AF_INET6, (void*)&a.ip, tmp, sizeof(tmp));
 
-    j = nlohmann::json{{"rank", a.rank},
-                       {"dialect", a.dialect},
-                       {"pubkey", a.pubkey.ToString()},
-                       {"in6_addr", tmp},
-                       {"port", a.port}};
+    j = nlohmann::json{
+        {"rank", a.rank},
+        {"dialect", a.dialect},
+        {"pubkey", a.pubkey.ToString()},
+        {"in6_addr", tmp},
+        {"port", a.port}};
   }
 }  // namespace llarp

--- a/llarp/net/net.cpp
+++ b/llarp/net/net.cpp
@@ -636,22 +636,23 @@ namespace llarp
   }
 
 #if !defined(TESTNET)
-  static constexpr std::array bogonRanges = {IPRange::FromIPv4(0, 0, 0, 0, 8),
-                                             IPRange::FromIPv4(10, 0, 0, 0, 8),
-                                             IPRange::FromIPv4(21, 0, 0, 0, 8),
-                                             IPRange::FromIPv4(100, 64, 0, 0, 10),
-                                             IPRange::FromIPv4(127, 0, 0, 0, 8),
-                                             IPRange::FromIPv4(169, 254, 0, 0, 16),
-                                             IPRange::FromIPv4(172, 16, 0, 0, 12),
-                                             IPRange::FromIPv4(192, 0, 0, 0, 24),
-                                             IPRange::FromIPv4(192, 0, 2, 0, 24),
-                                             IPRange::FromIPv4(192, 88, 99, 0, 24),
-                                             IPRange::FromIPv4(192, 168, 0, 0, 16),
-                                             IPRange::FromIPv4(198, 18, 0, 0, 15),
-                                             IPRange::FromIPv4(198, 51, 100, 0, 24),
-                                             IPRange::FromIPv4(203, 0, 113, 0, 24),
-                                             IPRange::FromIPv4(224, 0, 0, 0, 4),
-                                             IPRange::FromIPv4(240, 0, 0, 0, 4)};
+  static constexpr std::array bogonRanges = {
+      IPRange::FromIPv4(0, 0, 0, 0, 8),
+      IPRange::FromIPv4(10, 0, 0, 0, 8),
+      IPRange::FromIPv4(21, 0, 0, 0, 8),
+      IPRange::FromIPv4(100, 64, 0, 0, 10),
+      IPRange::FromIPv4(127, 0, 0, 0, 8),
+      IPRange::FromIPv4(169, 254, 0, 0, 16),
+      IPRange::FromIPv4(172, 16, 0, 0, 12),
+      IPRange::FromIPv4(192, 0, 0, 0, 24),
+      IPRange::FromIPv4(192, 0, 2, 0, 24),
+      IPRange::FromIPv4(192, 88, 99, 0, 24),
+      IPRange::FromIPv4(192, 168, 0, 0, 16),
+      IPRange::FromIPv4(198, 18, 0, 0, 15),
+      IPRange::FromIPv4(198, 51, 100, 0, 24),
+      IPRange::FromIPv4(203, 0, 113, 0, 24),
+      IPRange::FromIPv4(224, 0, 0, 0, 4),
+      IPRange::FromIPv4(240, 0, 0, 0, 4)};
 
   bool
   IsIPv4Bogon(const huint32_t& addr)

--- a/llarp/net/net_int.hpp
+++ b/llarp/net/net_int.hpp
@@ -28,7 +28,8 @@ namespace llarp
   {
     UInt_t h;
 
-    constexpr huint_t operator&(huint_t x) const
+    constexpr huint_t
+    operator&(huint_t x) const
     {
       return huint_t{UInt_t{h & x.h}};
     }
@@ -129,7 +130,8 @@ namespace llarp
   {
     UInt_t n;
 
-    constexpr nuint_t operator&(nuint_t x) const
+    constexpr nuint_t
+    operator&(nuint_t x) const
     {
       return nuint_t{UInt_t(n & x.n)};
     }

--- a/llarp/net/uint128.hpp
+++ b/llarp/net/uint128.hpp
@@ -56,7 +56,8 @@ namespace llarp
       lower &= o.lower;
       return *this;
     }
-    constexpr uint128_t operator&(const uint128_t& o) const
+    constexpr uint128_t
+    operator&(const uint128_t& o) const
     {
       uint128_t result = *this;
       result &= o;
@@ -216,8 +217,7 @@ namespace llarp
     operator<<=(uint64_t shift)
     {
       if (shift == 0)
-      {
-      }
+      {}
       else if (shift < 64)
       {
         upper = upper << shift | (lower >> (64 - shift));
@@ -251,8 +251,7 @@ namespace llarp
     operator>>=(uint64_t shift)
     {
       if (shift == 0)
-      {
-      }
+      {}
       else if (shift < 64)
       {
         lower = lower >> shift | upper << (64 - shift);

--- a/llarp/path/path.cpp
+++ b/llarp/path/path.cpp
@@ -276,10 +276,11 @@ namespace llarp
     util::StatusObject
     PathHopConfig::ExtractStatus() const
     {
-      util::StatusObject obj{{"lifetime", to_json(lifetime)},
-                             {"router", rc.pubkey.ToHex()},
-                             {"txid", txID.ToHex()},
-                             {"rxid", rxID.ToHex()}};
+      util::StatusObject obj{
+          {"lifetime", to_json(lifetime)},
+          {"router", rc.pubkey.ToHex()},
+          {"txid", txID.ToHex()},
+          {"rxid", rxID.ToHex()}};
       return obj;
     }
 
@@ -288,17 +289,18 @@ namespace llarp
     {
       auto now = llarp::time_now_ms();
 
-      util::StatusObject obj{{"intro", intro.ExtractStatus()},
-                             {"lastRecvMsg", to_json(m_LastRecvMessage)},
-                             {"lastLatencyTest", to_json(m_LastLatencyTestTime)},
-                             {"buildStarted", to_json(buildStarted)},
-                             {"expired", Expired(now)},
-                             {"expiresSoon", ExpiresSoon(now)},
-                             {"expiresAt", to_json(ExpireTime())},
-                             {"ready", IsReady()},
-                             {"txRateCurrent", m_LastTXRate},
-                             {"rxRateCurrent", m_LastRXRate},
-                             {"hasExit", SupportsAnyRoles(ePathRoleExit)}};
+      util::StatusObject obj{
+          {"intro", intro.ExtractStatus()},
+          {"lastRecvMsg", to_json(m_LastRecvMessage)},
+          {"lastLatencyTest", to_json(m_LastLatencyTestTime)},
+          {"buildStarted", to_json(buildStarted)},
+          {"expired", Expired(now)},
+          {"expiresSoon", ExpiresSoon(now)},
+          {"expiresAt", to_json(ExpireTime())},
+          {"ready", IsReady()},
+          {"txRateCurrent", m_LastTXRate},
+          {"rxRateCurrent", m_LastRXRate},
+          {"hasExit", SupportsAnyRoles(ePathRoleExit)}};
 
       std::vector<util::StatusObject> hopsObj;
       std::transform(

--- a/llarp/path/pathbuilder.cpp
+++ b/llarp/path/pathbuilder.cpp
@@ -193,9 +193,10 @@ namespace llarp
     util::StatusObject
     Builder::ExtractStatus() const
     {
-      util::StatusObject obj{{"buildStats", m_BuildStats.ExtractStatus()},
-                             {"numHops", uint64_t(numHops)},
-                             {"numPaths", uint64_t(numDesiredPaths)}};
+      util::StatusObject obj{
+          {"buildStats", m_BuildStats.ExtractStatus()},
+          {"numHops", uint64_t(numHops)},
+          {"numPaths", uint64_t(numDesiredPaths)}};
       std::transform(
           m_Paths.begin(),
           m_Paths.end(),

--- a/llarp/router/outbound_message_handler.cpp
+++ b/llarp/router/outbound_message_handler.cpp
@@ -100,13 +100,14 @@ namespace llarp
   util::StatusObject
   OutboundMessageHandler::ExtractStatus() const
   {
-    util::StatusObject status{"queueStats",
-                              {{"queued", m_queueStats.queued},
-                               {"dropped", m_queueStats.dropped},
-                               {"sent", m_queueStats.sent},
-                               {"queueWatermark", m_queueStats.queueWatermark},
-                               {"perTickMax", m_queueStats.perTickMax},
-                               {"numTicks", m_queueStats.numTicks}}};
+    util::StatusObject status{
+        "queueStats",
+        {{"queued", m_queueStats.queued},
+         {"dropped", m_queueStats.dropped},
+         {"sent", m_queueStats.sent},
+         {"queueWatermark", m_queueStats.queueWatermark},
+         {"perTickMax", m_queueStats.perTickMax},
+         {"numTicks", m_queueStats.numTicks}}};
 
     return status;
   }

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -88,14 +88,15 @@ namespace llarp
       if (m_peerDb)
         peerStatsObj = m_peerDb->ExtractStatus();
 
-      return util::StatusObject{{"running", true},
-                                {"numNodesKnown", _nodedb->NumLoaded()},
-                                {"dht", _dht->impl->ExtractStatus()},
-                                {"services", _hiddenServiceContext.ExtractStatus()},
-                                {"exit", _exitContext.ExtractStatus()},
-                                {"links", _linkManager.ExtractStatus()},
-                                {"outboundMessages", _outboundMessageHandler.ExtractStatus()},
-                                {"peerStats", peerStatsObj}};
+      return util::StatusObject{
+          {"running", true},
+          {"numNodesKnown", _nodedb->NumLoaded()},
+          {"dht", _dht->impl->ExtractStatus()},
+          {"services", _hiddenServiceContext.ExtractStatus()},
+          {"exit", _exitContext.ExtractStatus()},
+          {"links", _linkManager.ExtractStatus()},
+          {"outboundMessages", _outboundMessageHandler.ExtractStatus()},
+          {"peerStats", peerStatsObj}};
     }
     else
     {

--- a/llarp/router_contact.cpp
+++ b/llarp/router_contact.cpp
@@ -217,10 +217,11 @@ namespace llarp
   util::StatusObject
   RouterContact::ExtractStatus() const
   {
-    util::StatusObject obj{{"lastUpdated", last_updated.count()},
-                           {"publicRouter", IsPublicRouter()},
-                           {"identity", pubkey.ToString()},
-                           {"addresses", addrs}};
+    util::StatusObject obj{
+        {"lastUpdated", last_updated.count()},
+        {"publicRouter", IsPublicRouter()},
+        {"identity", pubkey.ToString()},
+        {"addresses", addrs}};
 
     if (HasNick())
     {

--- a/llarp/rpc/endpoint_rpc.cpp
+++ b/llarp/rpc/endpoint_rpc.cpp
@@ -60,8 +60,8 @@ namespace llarp::rpc
     if (not m_Conn.has_value())
     {
       // we don't have a connection to the backend so it's failed
-      reply(service::AuthResult{service::AuthResultCode::eAuthFailed,
-                                "remote has no connection to auth backend"});
+      reply(service::AuthResult{
+          service::AuthResultCode::eAuthFailed, "remote has no connection to auth backend"});
       return;
     }
 

--- a/llarp/rpc/rpc_server.cpp
+++ b/llarp/rpc/rpc_server.cpp
@@ -98,8 +98,8 @@ namespace llarp::rpc
         .add_request_command(
             "version",
             [r = m_Router](oxenmq::Message& msg) {
-              util::StatusObject result{{"version", llarp::VERSION_FULL},
-                                        {"uptime", to_json(r->Uptime())}};
+              util::StatusObject result{
+                  {"version", llarp::VERSION_FULL}, {"uptime", to_json(r->Uptime())}};
               msg.send_reply(CreateJSONResponse(result));
             })
         .add_request_command(

--- a/llarp/service/auth.cpp
+++ b/llarp/service/auth.cpp
@@ -21,9 +21,10 @@ namespace llarp::service
   AuthType
   ParseAuthType(std::string data)
   {
-    std::unordered_map<std::string, AuthType> values = {{"lmq", AuthType::eAuthTypeLMQ},
-                                                        {"whitelist", AuthType::eAuthTypeWhitelist},
-                                                        {"none", AuthType::eAuthTypeNone}};
+    std::unordered_map<std::string, AuthType> values = {
+        {"lmq", AuthType::eAuthTypeLMQ},
+        {"whitelist", AuthType::eAuthTypeWhitelist},
+        {"none", AuthType::eAuthTypeNone}};
     const auto itr = values.find(data);
     if (itr == values.end())
       throw std::invalid_argument("no such auth type: " + data);

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -1337,8 +1337,7 @@ namespace llarp
         const AlignedBuffer<32> /*addr*/, bool snode, ConvoEventListener_ptr /*ev*/)
     {
       if (snode)
-      {
-      }
+      {}
 
       // TODO: something meaningful
       return false;

--- a/llarp/service/intro.cpp
+++ b/llarp/service/intro.cpp
@@ -7,10 +7,11 @@ namespace llarp
     util::StatusObject
     Introduction::ExtractStatus() const
     {
-      util::StatusObject obj{{"router", router.ToHex()},
-                             {"expiresAt", to_json(expiresAt)},
-                             {"latency", to_json(latency)},
-                             {"version", uint64_t(version)}};
+      util::StatusObject obj{
+          {"router", router.ToHex()},
+          {"expiresAt", to_json(expiresAt)},
+          {"latency", to_json(latency)},
+          {"version", uint64_t(version)}};
       return obj;
     }
 

--- a/llarp/service/lookup.hpp
+++ b/llarp/service/lookup.hpp
@@ -71,11 +71,12 @@ namespace llarp
       ExtractStatus() const
       {
         auto now = time_now_ms();
-        util::StatusObject obj{{"txid", txid},
-                               {"endpoint", endpoint.ToHex()},
-                               {"name", name},
-                               {"timedOut", IsTimedOut(now)},
-                               {"createdAt", m_created.count()}};
+        util::StatusObject obj{
+            {"txid", txid},
+            {"endpoint", endpoint.ToHex()},
+            {"name", name},
+            {"timedOut", IsTimedOut(now)},
+            {"createdAt", m_created.count()}};
         return obj;
       }
 

--- a/llarp/service/outbound_context.cpp
+++ b/llarp/service/outbound_context.cpp
@@ -553,8 +553,8 @@ namespace llarp
           {
             if (msg.proto == eProtocolAuth and not msg.payload.empty())
             {
-              result.reason = std::string{reinterpret_cast<const char*>(msg.payload.data()),
-                                          msg.payload.size()};
+              result.reason = std::string{
+                  reinterpret_cast<const char*>(msg.payload.data()), msg.payload.size()};
             }
           }
         }
@@ -576,8 +576,8 @@ namespace llarp
           AuthResult result{AuthResultCode::eAuthAccepted, "OK"};
           if (msg->proto == eProtocolAuth and not msg->payload.empty())
           {
-            result.reason = std::string{reinterpret_cast<const char*>(msg->payload.data()),
-                                        msg->payload.size()};
+            result.reason = std::string{
+                reinterpret_cast<const char*>(msg->payload.data()), msg->payload.size()};
           }
           handler(result);
         };

--- a/llarp/service/session.cpp
+++ b/llarp/service/session.cpp
@@ -7,11 +7,12 @@ namespace llarp
     util::StatusObject
     Session::ExtractStatus() const
     {
-      util::StatusObject obj{{"lastUsed", to_json(lastUsed)},
-                             {"replyIntro", replyIntro.ExtractStatus()},
-                             {"remote", remote.Addr().ToString()},
-                             {"seqno", seqno},
-                             {"intro", intro.ExtractStatus()}};
+      util::StatusObject obj{
+          {"lastUsed", to_json(lastUsed)},
+          {"replyIntro", replyIntro.ExtractStatus()},
+          {"remote", remote.Addr().ToString()},
+          {"seqno", seqno},
+          {"intro", intro.ExtractStatus()}};
       return obj;
     }
 

--- a/llarp/util/aligned.hpp
+++ b/llarp/util/aligned.hpp
@@ -139,13 +139,15 @@ namespace llarp
       return *this;
     }
 
-    byte_t& operator[](size_t idx)
+    byte_t&
+    operator[](size_t idx)
     {
       assert(idx < SIZE);
       return m_data[idx];
     }
 
-    const byte_t& operator[](size_t idx) const
+    const byte_t&
+    operator[](size_t idx) const
     {
       assert(idx < SIZE);
       return m_data[idx];

--- a/llarp/util/buffer.hpp
+++ b/llarp/util/buffer.hpp
@@ -76,7 +76,8 @@ struct llarp_buffer_t
   /// max size of buffer
   size_t sz{0};
 
-  byte_t operator[](size_t x)
+  byte_t
+  operator[](size_t x)
   {
     return *(this->base + x);
   }

--- a/llarp/util/logging/loglevel.cpp
+++ b/llarp/util/logging/loglevel.cpp
@@ -52,12 +52,13 @@ namespace llarp
     std::transform(level.begin(), level.end(), level.begin(), [](const unsigned char ch) -> char {
       return std::tolower(ch);
     });
-    static const std::unordered_map<std::string, LogLevel> levels = {{"trace", eLogTrace},
-                                                                     {"debug", eLogDebug},
-                                                                     {"info", eLogInfo},
-                                                                     {"warn", eLogWarn},
-                                                                     {"error", eLogError},
-                                                                     {"none", eLogNone}};
+    static const std::unordered_map<std::string, LogLevel> levels = {
+        {"trace", eLogTrace},
+        {"debug", eLogDebug},
+        {"info", eLogInfo},
+        {"warn", eLogWarn},
+        {"error", eLogError},
+        {"none", eLogNone}};
 
     const auto itr = levels.find(level);
     if (itr == levels.end())

--- a/llarp/vpn/apple.hpp
+++ b/llarp/vpn/apple.hpp
@@ -71,16 +71,16 @@ namespace llarp::vpn
       if (connect(m_FD, (sockaddr*)&addr, sizeof(addr)) < 0)
       {
         ::close(m_FD);
-        throw std::runtime_error{"cannot connect to control socket address: "
-                                 + std::string{strerror(errno)}};
+        throw std::runtime_error{
+            "cannot connect to control socket address: " + std::string{strerror(errno)}};
       }
       uint32_t namesz = IFNAMSIZ;
       char name[IFNAMSIZ + 1]{};
       if (getsockopt(m_FD, SYSPROTO_CONTROL, 2, name, &namesz) < 0)
       {
         ::close(m_FD);
-        throw std::runtime_error{"cannot query for interface name: "
-                                 + std::string{strerror(errno)}};
+        throw std::runtime_error{
+            "cannot query for interface name: " + std::string{strerror(errno)}};
       }
       m_IfName = name;
       for (const auto& ifaddr : m_Info.addrs)
@@ -128,8 +128,9 @@ namespace llarp::vpn
       constexpr int uintsize = sizeof(unsigned int);
       net::IPPacket pkt{};
       unsigned int pktinfo = 0;
-      const struct iovec vecs[2] = {{.iov_base = &pktinfo, .iov_len = uintsize},
-                                    {.iov_base = pkt.buf, .iov_len = sizeof(pkt.buf)}};
+      const struct iovec vecs[2] = {
+          {.iov_base = &pktinfo, .iov_len = uintsize},
+          {.iov_base = pkt.buf, .iov_len = sizeof(pkt.buf)}};
       int sz = readv(m_FD, vecs, 2);
       if (sz >= uintsize)
         pkt.sz = sz - uintsize;


### PR DESCRIPTION
The formatting changes here are not too large and also nice: in particular clang-format-11 appears to do better handling of `{...}` constructor braces/arguments.