### PR TITLE
remove link layer throughput limit

### DIFF
--- a/llarp/constants/link_layer.hpp
+++ b/llarp/constants/link_layer.hpp
@@ -6,4 +6,3 @@
 
 constexpr size_t MAX_LINK_MSG_SIZE = 8192;
 static constexpr auto DefaultLinkSessionLifetime = 1min;
-constexpr size_t MaxSendQueueSize = 1024;

--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -178,8 +178,6 @@ namespace llarp
     Session::SendMessageBuffer(
         ILinkSession::Message_t buf, ILinkSession::CompletionHandler completed)
     {
-      if (m_TXMsgs.size() >= MaxSendQueueSize)
-        return false;
       const auto now = m_Parent->Now();
       const auto msgid = m_TXID++;
       const auto bufsz = buf.size();


### PR DESCRIPTION
I suspect this is what is causing most of the bottleneck on the network so we should remove this limit for now.