### PR TITLE
make ipv6 range used by exit traffic configurable.

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -261,6 +261,7 @@ namespace llarp
     static constexpr Default ReachableDefault{true};
     static constexpr Default HopsDefault{4};
     static constexpr Default PathsDefault{6};
+    static constexpr Default IP6RangeDefault{"fd00::"};
 
     conf.defineOption<std::string>(
         "network", "type", Default{"tun"}, Hidden, AssignmentAcceptor(m_endpointType));
@@ -517,6 +518,24 @@ namespace llarp
           }
         });
 
+    conf.defineOption<std::string>(
+        "network",
+        "ip6-range",
+        ClientOnly,
+        Comment{
+            "For all ipv6 exit traffic you will use this as the base address bitwised or'd with "
+            "the v4 address in use.",
+            "To disable ipv6 set this to an empty value.",
+        },
+        IP6RangeDefault,
+        [this](std::string arg) {
+          if (arg.empty())
+            return;
+          m_baseV6Address = huint128_t{};
+          if (not m_baseV6Address->FromString(arg))
+            throw std::invalid_argument(
+                stringify("[network]:ip6-range invalid value: '", arg, "'"));
+        });
     // TODO: could be useful for snodes in the future, but currently only implemented for clients:
     conf.defineOption<std::string>(
         "network",

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -526,6 +526,8 @@ namespace llarp
             "For all ipv6 exit traffic you will use this as the base address bitwised or'd with "
             "the v4 address in use.",
             "To disable ipv6 set this to an empty value.",
+            "!!! WARNING !!! Disabling ipv6 tunneling when you have ipv6 routes WILL lead to "
+            "de-anonymization as lokinet will no longer carry your ipv6 traffic.",
         },
         IP6RangeDefault,
         [this](std::string arg) {

--- a/llarp/config/config.hpp
+++ b/llarp/config/config.hpp
@@ -19,6 +19,7 @@
 
 #include <cstdlib>
 #include <functional>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -117,6 +118,8 @@ namespace llarp
     std::unordered_set<service::Address, service::Address::Hash> m_AuthWhitelist;
 
     std::vector<llarp::dns::SRVData> m_SRVRecords;
+
+    std::optional<huint128_t> m_baseV6Address;
 
     // TODO:
     // on-up

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -233,6 +233,8 @@ namespace llarp
       m_LocalResolverAddr = dnsConf.m_bind;
       m_UpstreamResolvers = dnsConf.m_upstreamDNS;
 
+      m_BaseV6Address = conf.m_baseV6Address;
+
       for (const auto& item : conf.m_mapAddrs)
       {
         if (not MapAddress(item.second, item.first, false))
@@ -800,10 +802,14 @@ namespace llarp
 
       vpn::InterfaceInfo info;
       info.addrs.emplace(m_OurRange);
-      IPRange v6range = m_OurRange;
-      v6range.addr = net::ExpandV4Lan(net::TruncateV6(m_OurRange.addr));
-      LogInfo(Name(), " using v6 range: ", v6range);
-      info.addrs.emplace(v6range, AF_INET6);
+
+      if (m_BaseV6Address)
+      {
+        IPRange v6range = m_OurRange;
+        v6range.addr = m_BaseV6Address.value() | m_OurRange.addr;
+        LogInfo(Name(), " using v6 range: ", v6range);
+        info.addrs.emplace(v6range, AF_INET6);
+      }
 
       info.ifname = m_IfName;
       info.dnsaddr.FromString(m_LocalResolverAddr.toHost());

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -806,7 +806,7 @@ namespace llarp
       if (m_BaseV6Address)
       {
         IPRange v6range = m_OurRange;
-        v6range.addr = m_BaseV6Address.value() | m_OurRange.addr;
+        v6range.addr = (*m_BaseV6Address) | m_OurRange.addr;
         LogInfo(Name(), " using v6 range: ", v6range);
         info.addrs.emplace(v6range, AF_INET6);
       }

--- a/llarp/handlers/tun.hpp
+++ b/llarp/handlers/tun.hpp
@@ -253,6 +253,8 @@ namespace llarp
       bool m_UseV6;
       std::string m_IfName;
 
+      std::optional<huint128_t> m_BaseV6Address;
+
       std::shared_ptr<vpn::NetworkInterface> m_NetIf;
 
       std::unique_ptr<vpn::PacketRouter> m_PacketRouter;


### PR DESCRIPTION
* add ip6-range option to network section to control which range we want to use for ipv6 traffic
* make ip6-range able to disable ipv6 exits ( i dont like this but eh )