### PR TITLE
re-enable multithreading

### DIFF
--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -1292,8 +1292,7 @@ namespace llarp
   void
   Router::QueueWork(std::function<void(void)> func)
   {
-    _loop->call_soon(func);
-    // m_lmq->job(std::move(func));
+    m_lmq->job(std::move(func));
   }
 
   void


### PR DESCRIPTION
this re-enabled multi-threading, it was accidentally committed while we disabled it for testing