### PR TITLE
Fixes subtle memory leak, adds comments

### DIFF
--- a/llarp/path/path_context.cpp
+++ b/llarp/path/path_context.cpp
@@ -302,7 +302,7 @@ namespace llarp
         {
           if (itr->second->Expired(now))
           {
-            m_Router->outboundMessageHandler().QueueRemoveEmptyPath(itr->first);
+            m_Router->outboundMessageHandler().RemovePath(itr->first);
             itr = map.erase(itr);
           }
           else

--- a/llarp/path/pathset.cpp
+++ b/llarp/path/pathset.cpp
@@ -85,9 +85,9 @@ namespace llarp
         if (itr->second->Expired(now))
         {
           PathID_t txid = itr->second->TXID();
-          router->outboundMessageHandler().QueueRemoveEmptyPath(std::move(txid));
+          router->outboundMessageHandler().RemovePath(std::move(txid));
           PathID_t rxid = itr->second->RXID();
-          router->outboundMessageHandler().QueueRemoveEmptyPath(std::move(rxid));
+          router->outboundMessageHandler().RemovePath(std::move(rxid));
           itr = m_Paths.erase(itr);
         }
         else

--- a/llarp/router/i_outbound_message_handler.hpp
+++ b/llarp/router/i_outbound_message_handler.hpp
@@ -38,7 +38,7 @@ namespace llarp
     Tick() = 0;
 
     virtual void
-    QueueRemoveEmptyPath(const PathID_t& pathid) = 0;
+    RemovePath(const PathID_t& pathid) = 0;
 
     virtual util::StatusObject
     ExtractStatus() const = 0;

--- a/llarp/router/outbound_message_handler.hpp
+++ b/llarp/router/outbound_message_handler.hpp
@@ -4,6 +4,7 @@
 
 #include <llarp/ev/ev.hpp>
 #include <llarp/util/thread/queue.hpp>
+#include <llarp/util/decaying_hashset.hpp>
 #include <llarp/path/path_types.hpp>
 #include <llarp/router_id.hpp>
 
@@ -27,15 +28,45 @@ namespace llarp
 
     OutboundMessageHandler(size_t maxQueueSize = MAX_OUTBOUND_QUEUE_SIZE);
 
+    /* Called to queue a message to be sent to a router.
+     *
+     * If there is no session with the destination router, the message is added to a
+     * pending session queue for that router.  If there is no pending session to that
+     * router, one is created.
+     *
+     * If there is a session to the destination router, the message is placed on the shared
+     * outbound message queue to be processed on Tick().
+     *
+     * When this class' Tick() is called, that queue is emptied and the messages there
+     * are placed in their paths' respective individual queues.
+     *
+     * Returns false if encoding the message into a buffer fails, true otherwise.
+     * A return value of true merely means we successfully processed the queue request,
+     * so for example an invalid destination still yields a true return.
+     */
     bool
     QueueMessage(const RouterID& remote, const ILinkMessage& msg, SendStatusHandler callback)
         override EXCLUDES(_mutex);
 
+    /* Called once per event loop tick.
+     *
+     * Processes messages on the shared message queue into their paths' respective
+     * individual queues.
+     *
+     * Removes the individual queues for paths which have died / expired, as informed by
+     * QueueRemoveEmptyPath.
+     *
+     * Sends all routing messages that have been queued, indicated by pathid 0 when queued.
+     * Sends messages from path queues until all are empty or a set cap has been reached.
+     */
     void
     Tick() override;
 
+    /* Called from outside this class to inform it that a path has died / expired
+     * and its queue should be discarded.
+     */
     void
-    QueueRemoveEmptyPath(const PathID_t& pathid) override;
+    RemovePath(const PathID_t& pathid) override;
 
     util::StatusObject
     ExtractStatus() const override;
@@ -46,6 +77,9 @@ namespace llarp
    private:
     using Message = std::pair<std::vector<byte_t>, SendStatusHandler>;
 
+    /* A message that has been queued for sending, but not yet
+     * processed into an individual path's message queue.
+     */
     struct MessageQueueEntry
     {
       uint16_t priority;
@@ -73,6 +107,14 @@ namespace llarp
 
     using MessageQueue = std::priority_queue<MessageQueueEntry>;
 
+    /* If a session is not yet created with the destination router for a message,
+     * a special queue is created for that router and an attempt is made to
+     * establish a session.  When this establish attempt concludes, either
+     * the messages are then sent to that router immediately, on success, or
+     * the messages are dropped and their send status callbacks are invoked with
+     * the appropriate send status.
+     */
+
     void
     OnSessionEstablished(const RouterID& router);
 
@@ -91,6 +133,7 @@ namespace llarp
     void
     OnSessionResult(const RouterID& router, const SessionResult result);
 
+    /* queues a message's send result callback onto the event loop */
     void
     DoCallback(SendStatusHandler callback, SendStatus status);
 
@@ -100,30 +143,62 @@ namespace llarp
     bool
     EncodeBuffer(const ILinkMessage& msg, llarp_buffer_t& buf);
 
+    /* sends the message along to the link layer, and hopefully out to the network
+     *
+     * returns the result of the call to LinkManager::SendTo()
+     */
     bool
     Send(const RouterID& remote, const Message& msg);
 
+    /* Sends the message along to the link layer if we have a session to the remote
+     *
+     * returns the result of the Send() call, or false if no session.
+     */
     bool
     SendIfSession(const RouterID& remote, const Message& msg);
 
+    /* queues a message to the shared outbound message queue.
+     *
+     * If the queue is full, the message is dropped and the message's status
+     * callback is invoked with a congestion status.
+     *
+     * When this class' Tick() is called, that queue is emptied and the messages there
+     * are placed in their paths' respective individual queues.
+     */
     bool
     QueueOutboundMessage(
         const RouterID& remote, Message&& msg, const PathID_t& pathid, uint16_t priority = 0);
 
+    /* Processes messages on the shared message queue into their paths' respective
+     * individual queues.
+     */
     void
     ProcessOutboundQueue();
 
-    void
-    RemoveEmptyPathQueues();
-
+    /*
+     * Sends all routing messages that have been queued, indicated by pathid 0 when queued.
+     *
+     * Sends messages from path queues until all are empty or a set cap has been reached.
+     * This will send one message from each queue in a round-robin fashion such that they
+     * all have roughly equal access to bandwidth.  A notion of priority may be introduced
+     * at a later time, but for now only routing messages get priority.
+     */
     void
     SendRoundRobin();
 
+    /* Invoked when an outbound session establish attempt has concluded.
+     *
+     * If the outbound session was successfully created, sends any messages queued
+     * for that destination along to it.
+     *
+     * If the session was unsuccessful, invokes the send status callbacks of those
+     * queued messages and drops them.
+     */
     void
     FinalizeSessionRequest(const RouterID& router, SendStatus status) EXCLUDES(_mutex);
 
     llarp::thread::Queue<MessageQueueEntry> outboundQueue;
-    llarp::thread::Queue<PathID_t> removedPaths;
+    llarp::util::DecayingHashSet<PathID_t> recentlyRemovedPaths;
     bool removedSomePaths;
 
     mutable util::Mutex _mutex;  // protects pendingSessionMessageQueues


### PR DESCRIPTION
Fixes a subtle memory leak that was a result of outbound messages which
were in the shared queue (not yet sorted into a per-path queue) when a
path was removed, resulting in a ghost path queue (and thus round-robin
order entry as well).

Adds much needed documentation to the outbound message handler class.