### PR TITLE
make path alignment timeout configuable

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -659,6 +659,21 @@ namespace llarp
           m_SRVRecords.push_back(std::move(newSRV));
         });
 
+    conf.defineOption<int>(
+        "network",
+        "path-alignment-timeout",
+        ClientOnly,
+        Comment{
+            "time in milliseconds how long to wait for a path to align to pivot routers",
+            "if not provided a sensible default will be used",
+        },
+        [this](int val) {
+          if (val <= 200)
+            throw std::invalid_argument{
+                "invalid path alignment timeout: " + std::to_string(val) + " <= 200"};
+          m_PathAlignmentTimeout = std::chrono::milliseconds{val};
+        });
+
     // Deprecated options:
     conf.defineOption<std::string>("network", "enabled", Deprecated);
   }

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -664,14 +664,14 @@ namespace llarp
         "path-alignment-timeout",
         ClientOnly,
         Comment{
-            "time in milliseconds how long to wait for a path to align to pivot routers",
+            "time in seconds how long to wait for a path to align to pivot routers",
             "if not provided a sensible default will be used",
         },
         [this](int val) {
-          if (val <= 200)
+          if (val <= 0)
             throw std::invalid_argument{
-                "invalid path alignment timeout: " + std::to_string(val) + " <= 200"};
-          m_PathAlignmentTimeout = std::chrono::milliseconds{val};
+                "invalid path alignment timeout: " + std::to_string(val) + " <= 0"};
+          m_PathAlignmentTimeout = std::chrono::seconds{val};
         });
 
     // Deprecated options:

--- a/llarp/config/config.hpp
+++ b/llarp/config/config.hpp
@@ -125,6 +125,8 @@ namespace llarp
     std::set<IPRange> m_OwnedRanges;
     std::optional<net::TrafficPolicy> m_TrafficPolicy;
 
+    std::optional<llarp_time_t> m_PathAlignmentTimeout;
+
     // TODO:
     // on-up
     // on-down

--- a/llarp/handlers/tun.hpp
+++ b/llarp/handlers/tun.hpp
@@ -267,6 +267,8 @@ namespace llarp
       std::optional<net::TrafficPolicy> m_TrafficPolicy;
       /// ranges we advetise as reachable
       std::set<IPRange> m_OwnedRanges;
+      /// how long to wait for path alignment
+      llarp_time_t m_PathAlignmentTimeout;
     };
 
   }  // namespace handlers


### PR DESCRIPTION
adds [network] section parameter called path-alignment-timeout that allows configring the timeout
for optional name lookup + introset lookup + aligned path build, used by tun endpoint dns, provided
as milliseconds.