### PR TITLE
dont use non tested paths

### DIFF
--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -131,7 +131,7 @@ namespace llarp
         m_Resolver->Restart();
     }
 
-    constexpr auto DefaultAlignmentTimeout = 10s;
+    constexpr auto DefaultAlignmentTimeout = 15s;
 
     bool
     TunEndpoint::Configure(const NetworkConfig& conf, const DnsConfig& dnsConf)

--- a/llarp/path/pathset.cpp
+++ b/llarp/path/pathset.cpp
@@ -156,7 +156,8 @@ namespace llarp
           {
             if (chosen == nullptr)
               chosen = itr->second;
-            else if (chosen->intro.latency > itr->second->intro.latency)
+            else if (
+                chosen->intro.latency != 0s and chosen->intro.latency > itr->second->intro.latency)
               chosen = itr->second;
           }
         }
@@ -429,7 +430,7 @@ namespace llarp
       llarp_time_t minLatency = 30s;
       for (const auto& path : established)
       {
-        if (path->intro.latency < minLatency)
+        if (path->intro.latency < minLatency and path->intro.latency != 0s)
         {
           minLatency = path->intro.latency;
           chosen = path;


### PR DESCRIPTION
* if a path's latency is zero dont use it because it's not actually a zero latency path it's probably about to be failed or timed out
* increase default path alignment timeout