### PR TITLE
fixups in service endpont

### DIFF
--- a/llarp/handlers/tun.hpp
+++ b/llarp/handlers/tun.hpp
@@ -222,7 +222,7 @@ namespace llarp
           std::function<void(dns::Message)> reply,
           bool sendIPv6)
       {
-        if (ctx)
+        if (ctx or HasAddress(addr))
         {
           huint128_t ip = ObtainIPForAddr(addr);
           query->answers.clear();

--- a/llarp/service/outbound_context.cpp
+++ b/llarp/service/outbound_context.cpp
@@ -567,7 +567,7 @@ namespace llarp
         // verify source
         if (!frame.Verify(si))
         {
-          LogWarn("signature failed");
+          LogWarn("signature verification failed, T=", frame.T);
           return false;
         }
         // remove convotag it doesn't exist


### PR DESCRIPTION
* increase publish introset timeout so that it does not time out on the network
* remove pedantic log warn
* make sure the path we are using for replying on inbound sessions is alive
* include convotag in log message so we know wtf is going on