### PR TITLE
increase session reestablish timeout

### DIFF
--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -131,8 +131,6 @@ namespace llarp
         m_Resolver->Restart();
     }
 
-    constexpr auto DefaultAlignmentTimeout = 15s;
-
     bool
     TunEndpoint::Configure(const NetworkConfig& conf, const DnsConfig& dnsConf)
     {
@@ -174,7 +172,7 @@ namespace llarp
         m_PathAlignmentTimeout = *conf.m_PathAlignmentTimeout;
       }
       else
-        m_PathAlignmentTimeout = DefaultAlignmentTimeout;
+        m_PathAlignmentTimeout = service::Endpoint::PathAlignmentTimeout();
 
       for (const auto& item : conf.m_mapAddrs)
       {
@@ -279,7 +277,7 @@ namespace llarp
               SendDNSReply(snode, s, msg, reply, isV6);
             });
       };
-      auto ReplyToLokiDNSWhenReady = [this, reply, timeout = m_PathAlignmentTimeout](
+      auto ReplyToLokiDNSWhenReady = [this, reply, timeout = PathAlignmentTimeout()](
                                          service::Address addr, auto msg, bool isV6) -> bool {
         using service::Address;
         using service::OutboundContext;
@@ -305,7 +303,7 @@ namespace llarp
         }
       };
 
-      auto ReplyToLokiSRVWhenReady = [this, reply, timeout = m_PathAlignmentTimeout](
+      auto ReplyToLokiSRVWhenReady = [this, reply, timeout = PathAlignmentTimeout()](
                                          service::Address addr, auto msg) -> bool {
         using service::Address;
         using service::OutboundContext;
@@ -932,7 +930,7 @@ namespace llarp
                 }
                 self->SendToOrQueue(addr, pkt.ConstBuffer(), service::ProtocolType::Exit);
               },
-              m_PathAlignmentTimeout);
+              PathAlignmentTimeout());
           return;
         }
         bool rewriteAddrs = true;

--- a/llarp/handlers/tun.hpp
+++ b/llarp/handlers/tun.hpp
@@ -136,7 +136,7 @@ namespace llarp
       }
 
       llarp_time_t
-      DefaultPathAlignmentTimeout() const override
+      PathAlignmentTimeout() const override
       {
         return m_PathAlignmentTimeout;
       }

--- a/llarp/handlers/tun.hpp
+++ b/llarp/handlers/tun.hpp
@@ -135,6 +135,12 @@ namespace llarp
         return m_OwnedRanges;
       }
 
+      llarp_time_t
+      DefaultPathAlignmentTimeout() const override
+      {
+        return m_PathAlignmentTimeout;
+      }
+
       /// ip packet against any exit policies we have
       /// returns false if this traffic is disallowed by any of those policies
       /// returns true otherwise

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -1850,7 +1850,7 @@ namespace llarp
               }
               self->m_state->m_PendingTraffic.erase(addr);
             },
-            1500ms);
+            DefaultPathAlignmentTimeout());
         return true;
       }
       LogDebug("SendOrQueue failed: no inbound/outbound sessions");

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -1850,7 +1850,7 @@ namespace llarp
               }
               self->m_state->m_PendingTraffic.erase(addr);
             },
-            DefaultPathAlignmentTimeout());
+            PathAlignmentTimeout());
         return true;
       }
       LogDebug("SendOrQueue failed: no inbound/outbound sessions");

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -306,6 +306,12 @@ namespace llarp
       bool
       ShouldBuildMore(llarp_time_t now) const override;
 
+      virtual llarp_time_t
+      DefaultPathAlignmentTimeout() const
+      {
+        return 10s;
+      }
+
       bool
       EnsurePathTo(
           std::variant<Address, RouterID> addr,

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -307,9 +307,10 @@ namespace llarp
       ShouldBuildMore(llarp_time_t now) const override;
 
       virtual llarp_time_t
-      DefaultPathAlignmentTimeout() const
+      PathAlignmentTimeout() const
       {
-        return 10s;
+        constexpr auto DefaultPathAlignmentTimeout = 30s;
+        return DefaultPathAlignmentTimeout;
       }
 
       bool


### PR DESCRIPTION
when we have to reestablish an outbound session use a much much higher timeout for restablishment

so it doesn't time out and get into a state that's totally screwed.