### PR TITLE
only mark existing sessions as active

### DIFF
--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -520,13 +520,15 @@ namespace llarp
     void
     Endpoint::ConvoTagTX(const ConvoTag& tag)
     {
-      Sessions()[tag].TX();
+      if (Sessions().count(tag))
+        Sessions()[tag].TX();
     }
 
     void
     Endpoint::ConvoTagRX(const ConvoTag& tag)
     {
-      Sessions()[tag].RX();
+      if (Sessions().count(tag))
+        Sessions()[tag].RX();
     }
 
     bool


### PR DESCRIPTION
in the event that a session is removed and then gets more traffic we would re-add the session with everything blank if there was more traffic in the same tick.

this remedies this behavior by only increment usage timestamps on sessions if they exist.