### PR TITLE
add format verify option to contrib/format.sh

### DIFF
--- a/contrib/format.sh
+++ b/contrib/format.sh
@@ -16,6 +16,9 @@ if [ $? -ne 0 ]; then
     fi
 fi
 
-# TODO: readlink -e is a GNU-ism
-cd "$(readlink -e $(dirname $0)/../)"
-$binary -i $(find jni daemon llarp include pybind | grep -E '\.[hc](pp)?$') &> /dev/null
+cd "$(dirname $0)/../"
+if [ "$1" = "verify" ] ; then
+    exit $($binary --output-replacements-xml $(find jni daemon llarp include pybind | grep -E '\.[hc](pp)?$' | grep -v '\#') | grep '</replacement>' | wc -l)
+else
+    $binary -i $(find jni daemon llarp include pybind | grep -E '\.[hc](pp)?$' | grep -v '\#') &> /dev/null
+fi

--- a/contrib/git-hook-pre-push.sh
+++ b/contrib/git-hook-pre-push.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# pre-push hook for git
+# this script is probably overkill for most contributors
+#
+# "i use this to prevent foot cannons caused by commiting broken code"
+#
+# ~ jeff (lokinet author and crazy person)
+#
+#
+# to use this as a git hook do this in the root of the repo:
+#
+# cp contrib/git-hook-pre-push.sh .git/hooks/pre-push
+#
+
+
+set -e
+
+cd "$(dirname $0)/../.."
+echo "check format..."
+./contrib/format.sh verify
+echo "format is gucci af fam"
+
+echo "remove old test build directory..."
+rm -rf build-git-hook
+mkdir build-git-hook
+echo "configuring test build jizz..."
+cmake -S . -B build-git-hook -DWITH_LTO=OFF -DWITH_HIVE=ON -G Ninja
+echo "ensure this shit compiles..."
+ninja -C build-git-hook all
+echo "ensure unit tests aren't fucked..."
+ninja -C build-git-hook check
+
+echo "we gud UmU"
+echo ""


### PR DESCRIPTION
* add format verify mode to `contrib/format.sh` (run with `./contrib/format.sh verify`) exits nonzero if you need to run the script
* make `contrib/format.sh` non-gnu portable (for macos)
* add my pre-push git hook so it doesn't get lost