### PR TITLE
expire paths on path builder stop

### DIFF
--- a/llarp/path/pathbuilder.cpp
+++ b/llarp/path/pathbuilder.cpp
@@ -264,6 +264,14 @@ namespace llarp
     Builder::Stop()
     {
       _run = false;
+      // tell all our paths that they have expired
+      const auto now = Now();
+      for (auto& item : m_Paths)
+      {
+        item.second->EnterState(ePathExpired, now);
+      }
+      // remove expired paths
+      ExpirePaths(now, m_router);
       return true;
     }
 


### PR DESCRIPTION
when we stop a path builder we want to expire all of their paths so they go away, this allows dead sessions on a service endpoint to remove themselves cleanly.