### PR TITLE
Remove double cpr submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -35,6 +35,3 @@
 [submodule "external/ngtcp2"]
 	path = external/ngtcp2
 	url = https://github.com/ngtcp2/ngtcp2.git
-[submodule "external/cpr"]
-	path = external/cpr
-	url = https://github.com/whoshuu/cpr

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -25,7 +25,6 @@ if(SUBMODULE_CHECK)
     check_submodule(uvw)
     check_submodule(cpr)
     check_submodule(ngtcp2)
-    check_submodule(cpr)
   endif()
 endif()
 


### PR DESCRIPTION
Fix cpr being listed twice in .gitmodules and submodule check.