### PR TITLE
[feature] optionally keep inbound convos mapped to same IP on restart 

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -674,6 +674,21 @@ namespace llarp
           m_PathAlignmentTimeout = std::chrono::seconds{val};
         });
 
+    conf.defineOption<std::string>(
+        "network",
+        "persist-addrmap-file",
+        ClientOnly,
+        Comment{
+            "persist mapped ephemeral addresses to a file",
+            "on restart the mappings will be loaded so that ip addresses will not be mapped to a "
+            "different address",
+        },
+        [this](std::string arg) {
+          if (arg.empty())
+            throw std::invalid_argument("persist-addrmap-file cannot be empty");
+          m_AddrMapPersistFile = fs::path{arg};
+        });
+
     // Deprecated options:
     conf.defineOption<std::string>("network", "enabled", Deprecated);
   }

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -674,19 +674,20 @@ namespace llarp
           m_PathAlignmentTimeout = std::chrono::seconds{val};
         });
 
-    conf.defineOption<std::string>(
+    conf.defineOption<fs::path>(
         "network",
         "persist-addrmap-file",
         ClientOnly,
+        Default{fs::path{params.defaultDataDir / "addrmap.dat"}},
         Comment{
             "persist mapped ephemeral addresses to a file",
             "on restart the mappings will be loaded so that ip addresses will not be mapped to a "
             "different address",
         },
-        [this](std::string arg) {
+        [this](fs::path arg) {
           if (arg.empty())
             throw std::invalid_argument("persist-addrmap-file cannot be empty");
-          m_AddrMapPersistFile = fs::path{arg};
+          m_AddrMapPersistFile = arg;
         });
 
     // Deprecated options:

--- a/llarp/config/config.hpp
+++ b/llarp/config/config.hpp
@@ -127,10 +127,7 @@ namespace llarp
 
     std::optional<llarp_time_t> m_PathAlignmentTimeout;
 
-    // TODO:
-    // on-up
-    // on-down
-    // on-ready
+    std::optional<fs::path> m_AddrMapPersistFile;
 
     void
     defineConfigOptions(ConfigDefinition& conf, const ConfigGenParameters& params);

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -956,15 +956,11 @@ namespace llarp
           std::map<std::string, std::string> addrmap;
           for (const auto& [ip, addr] : m_IPToAddr)
           {
-            if (m_SNodes.at(addr))
-            {
-              const RouterID r{addr.as_array()};
-              addrmap[ip.ToString()] = r.ToString();
-            }
-            else
+            if (not m_SNodes.at(addr))
             {
               const service::Address a{addr.as_array()};
-              addrmap[ip.ToString()] = a.ToString();
+              if (HasInboundConvo(a))
+                addrmap[ip.ToString()] = a.ToString();
             }
           }
           const auto data = oxenmq::bt_serialize(addrmap);

--- a/llarp/handlers/tun.hpp
+++ b/llarp/handlers/tun.hpp
@@ -290,6 +290,9 @@ namespace llarp
 
       /// idempotent wakeup for writing messages to network
       std::shared_ptr<EventLoopWakeup> m_MessageSendWaker;
+
+      /// a file to load / store the ephemeral address map to
+      std::optional<fs::path> m_PersistAddrMapFile;
     };
 
   }  // namespace handlers


### PR DESCRIPTION
* add `[network]:persist-addrmap-file` config option to store ip address mappings to disk
* restore any inbound convo's address/ip mappings if configured to do so