### PR TITLE
bencode-dump.py: support reading from stdin

### DIFF
--- a/contrib/bencode-dump.py
+++ b/contrib/bencode-dump.py
@@ -3,11 +3,13 @@
 import sys
 import pprint
 
-if len(sys.argv) != 2 or sys.argv[1].startswith('-'):
+if len(sys.argv) == 1 or (len(sys.argv) == 2 and sys.argv[1] == '-'):
+    f = sys.stdin.buffer
+elif len(sys.argv) != 2 or sys.argv[1].startswith('-'):
     print("Usage: {} FILE -- dumps a bencoded file".format(sys.argv[0]), file=sys.stderr)
     sys.exit(1)
-
-f = open(sys.argv[1], 'rb')
+else:
+    f = open(sys.argv[1], 'rb')
 
 class HexPrinter():
     def __init__(self, data):


### PR DESCRIPTION
So that you can pipe bt-encoded output into it, e.g. from the in-progress oxend bt-rpc interface.