### PR TITLE
Fix default upstream DNS not working

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -711,6 +711,8 @@ namespace llarp
     // Default, but if we get any upstream (including upstream=, i.e. empty string) we clear it
     constexpr Default DefaultUpstreamDNS{"1.1.1.1"};
     m_upstreamDNS.emplace_back(DefaultUpstreamDNS.val);
+    if (!m_upstreamDNS.back().getPort())
+        m_upstreamDNS.back().setPort(53);
 
     conf.defineOption<std::string>(
         "dns",


### PR DESCRIPTION
The default upstream DNS was being set to 1.1.1.1:0, which doesn't work.  This fixes it to also set the port so that default upstream resolution (i.e. with an empty config) works again.