### PR TITLE
limit RC gossip to 20 peers max

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -22,6 +22,7 @@ local debian_pipeline(name, image,
         cmake_extra='',
         extra_cmds=[],
         jobs=6,
+        tests=true,
         loki_repo=false,
         allow_fail=false) = {
     kind: 'pipeline',
@@ -55,10 +56,12 @@ local debian_pipeline(name, image,
                 'cmake .. -DWITH_SETCAP=OFF -DCMAKE_CXX_FLAGS=-fdiagnostics-color=always -DCMAKE_BUILD_TYPE='+build_type+' ' +
                     (if werror then '-DWARNINGS_AS_ERRORS=ON ' else '') +
                     '-DWITH_LTO=' + (if lto then 'ON ' else 'OFF ') +
+                    (if tests then '' else '-DWITH_TESTS=OFF ') +
                 cmake_extra,
                 'VERBOSE=1 make -j' + jobs,
-                '../contrib/ci/drone-gdb.sh ./test/testAll --use-colour yes',
-            ] + extra_cmds,
+            ]
+            + (if tests then ['../contrib/ci/drone-gdb.sh ./test/testAll --use-colour yes'] else [])
+            + extra_cmds,
         }
     ],
 };
@@ -253,7 +256,7 @@ local mac_builder(name,
     ]),
 
     // Static build (on bionic) which gets uploaded to builds.lokinet.dev:
-    debian_pipeline("Static (bionic amd64)", docker_base+'ubuntu-bionic', deps='g++-8 python3-dev automake libtool', lto=true,
+    debian_pipeline("Static (bionic amd64)", docker_base+'ubuntu-bionic', deps='g++-8 python3-dev automake libtool', lto=true, tests=false,
                     cmake_extra='-DBUILD_STATIC_DEPS=ON -DBUILD_SHARED_LIBS=OFF -DSTATIC_LINK=ON -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8 ' +
                         '-DCMAKE_CXX_FLAGS="-march=x86-64 -mtune=haswell" -DCMAKE_C_FLAGS="-march=x86-64 -mtune=haswell" -DNATIVE_BUILD=OFF ' +
                         '-DWITH_SYSTEMD=OFF',

--- a/llarp/router/i_gossiper.hpp
+++ b/llarp/router/i_gossiper.hpp
@@ -3,6 +3,9 @@
 
 namespace llarp
 {
+  /// The maximum number of peers we will flood a gossiped RC to when propagating an RC
+  constexpr size_t MaxGossipPeers = 20;
+
   struct I_RCGossiper
   {
     virtual ~I_RCGossiper() = default;

--- a/llarp/router/rc_gossiper.cpp
+++ b/llarp/router/rc_gossiper.cpp
@@ -92,13 +92,10 @@ namespace llarp
         },
         true);
 
-    // limit the number of peers we gossip to
-    if (gossipTo.size() > MaxGossipPeers)
-    {
-      gossipTo.resize(MaxGossipPeers);
-    }
-
-    const std::unordered_set<RouterID> keys{gossipTo.begin(), gossipTo.end()};
+    std::unordered_set<RouterID> keys;
+    // grab the keys we want to use
+    std::sample(
+        gossipTo.begin(), gossipTo.end(), std::inserter(keys, keys.end()), MaxGossipPeers, CSRNG{});
 
     m_LinkManager->ForEachPeer([&](ILinkSession* peerSession) {
       if (not(peerSession && peerSession->IsEstablished()))


### PR DESCRIPTION
only gossip RCs to 20 peers at a time maximum.
this should reduce the load on service nodes when gossiping RCs.