### PR TITLE
dns refactor

### DIFF
--- a/llarp/dns/unbound_resolver.hpp
+++ b/llarp/dns/unbound_resolver.hpp
@@ -13,6 +13,8 @@
 
 #ifdef _WIN32
 #include <thread>
+#else
+#include <uvw.hpp>
 #endif
 
 namespace llarp::dns
@@ -28,11 +30,16 @@ namespace llarp::dns
     ub_ctx* unboundContext;
 
     std::atomic<bool> started;
-    std::unique_ptr<std::thread> runner;
+
+#ifdef _WIN32
+    std::thread runner;
+#else
+    std::weak_ptr<uvw::Loop> loop;
+    std::shared_ptr<uvw::PollHandle> udp;
+#endif
 
     ReplyFunction replyFunc;
     FailFunction failFunc;
-
     void
     Reset();
 


### PR DESCRIPTION
when we reset the unbound context we need to cancel any pending queries so the unbound context cleanly tears itself down, on windows.

on everything else use a pollable fd.