### PR TITLE
Redo how we build ngtcp2 lib

### DIFF
--- a/cmake/ngtcp2_lib.cmake
+++ b/cmake/ngtcp2_lib.cmake
@@ -1,0 +1,52 @@
+# ngtcp2's top-level CMakeLists.txt loads a bunch of crap we don't want (examples, a conflicting
+# 'check' target, etc.); instead we directly include it's lib subdirectory to build just the
+# library, but we have to set up a couple things to make that work:
+function(add_ngtcp2_lib)
+  file(STRINGS ngtcp2/CMakeLists.txt ngtcp2_project_line REGEX "^project\\(ngtcp2 ")
+  if(NOT ngtcp2_project_line MATCHES "^project\\(ngtcp2 VERSION ([0-9]+)\\.([0-9]+)\\.([0-9]+)\\)$")
+    message(FATAL_ERROR "Unable to extract ngtcp2 version from ngtcp2/CMakeLists.txt (found '${ngtcp2_project_line}')")
+  endif()
+
+  set(PACKAGE_VERSION "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}")
+  include(ngtcp2/cmake/Version.cmake)
+  HexVersion(PACKAGE_VERSION_NUM ${CMAKE_MATCH_1} ${CMAKE_MATCH_2} ${CMAKE_MATCH_3})
+  configure_file("ngtcp2/lib/includes/ngtcp2/version.h.in" "ngtcp2/lib/includes/ngtcp2/version.h" @ONLY)
+
+  # Checks for header files.
+  include(CheckIncludeFile)
+  check_include_file("arpa/inet.h"   HAVE_ARPA_INET_H)
+  check_include_file("netinet/in.h"  HAVE_NETINET_IN_H)
+  check_include_file("stddef.h"      HAVE_STDDEF_H)
+  check_include_file("stdint.h"      HAVE_STDINT_H)
+  check_include_file("stdlib.h"      HAVE_STDLIB_H)
+  check_include_file("string.h"      HAVE_STRING_H)
+  check_include_file("unistd.h"      HAVE_UNISTD_H)
+  check_include_file("sys/endian.h"  HAVE_SYS_ENDIAN_H)
+  check_include_file("endian.h"      HAVE_ENDIAN_H)
+  check_include_file("byteswap.h"    HAVE_BYTESWAP_H)
+
+  include(CheckTypeSize)
+  check_type_size("ssize_t" SIZEOF_SSIZE_T)
+  if(SIZEOF_SSIZE_T STREQUAL "")
+    set(ssize_t ptrdiff_t)
+  endif()
+
+  include(CheckSymbolExists)
+  if(HAVE_ENDIAN_H)
+    check_symbol_exists(be64toh "endian.h" HAVE_BE64TOH)
+  endif()
+  if(NOT HAVE_BE64TO AND HAVE_SYS_ENDIAN_H)
+    check_symbol_exists(be64toh "sys/endian.h" HAVE_BE64TOH)
+  endif()
+
+  check_symbol_exists(bswap_64 "byteswap.h" HAVE_BSWAP_64)
+
+  configure_file(ngtcp2/cmakeconfig.h.in ngtcp2/config.h)
+  include_directories("${CMAKE_CURRENT_BINARY_DIR}/ngtcp2") # for config.h
+
+  add_subdirectory(ngtcp2/lib EXCLUDE_FROM_ALL)
+
+  target_compile_definitions(ngtcp2 PRIVATE -DHAVE_CONFIG_H -D_GNU_SOURCE)
+endfunction()
+
+

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -50,15 +50,9 @@ add_library(uvw INTERFACE)
 target_include_directories(uvw INTERFACE uvw/src)
 target_link_libraries(uvw INTERFACE libuv)
 
-
-
-# We don't need any of these as we don't use the ssl crypto helper code at all:
-set(ENABLE_GNUTLS OFF CACHE BOOL "Disable gnutls for ngtcp2")
-set(ENABLE_OPENSSL OFF CACHE BOOL "Disable openssl for ngtcp2")
-set(ENABLE_BORINGSSL OFF CACHE BOOL "Disable boringssl for ngtcp2")
-
-add_definitions(-D_GNU_SOURCE)
-add_subdirectory(ngtcp2 EXCLUDE_FROM_ALL)
+# ngtcp2 needs some massaging to build nicely:
+include(ngtcp2_lib)
+add_ngtcp2_lib()
 
 # cpr configuration.  Ideally we'd just do this via add_subdirectory, but cpr's cmake requires
 # 3.15+, and we target lower than that (and this is fairly simple to build).


### PR DESCRIPTION
ngtcp2's top-level CMakeLists.txt is not friendly to being used as a subdirectory (for instance, it always adds a `check` target when cunit is installed), so stop using it in favour of skipping directly into the ngtcp2/lib subdir.

This requires some hackery to set up a couple of the things the top-level cmake does, but it isn't *too* painful.

This will fix some of the reported issues in #1733