### PR TITLE
prevent bizare half open state.

### DIFF
--- a/llarp/path/pathbuilder.hpp
+++ b/llarp/path/pathbuilder.hpp
@@ -110,7 +110,7 @@ namespace llarp
       llarp_time_t
       Now() const override;
 
-      void
+      virtual void
       Tick(llarp_time_t now) override;
 
       void

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -1100,13 +1100,14 @@ namespace llarp
 
     bool
     Endpoint::HandleDataMessage(
-        path::Path_ptr, const PathID_t from, std::shared_ptr<ProtocolMessage> msg)
+        path::Path_ptr p, const PathID_t from, std::shared_ptr<ProtocolMessage> msg)
     {
       PutSenderFor(msg->tag, msg->sender, true);
       Introduction intro = msg->introReply;
       if (HasInboundConvo(msg->sender.Addr()))
       {
         intro.pathID = from;
+        intro.router = p->Endpoint();
       }
       PutReplyIntroFor(msg->tag, intro);
       ConvoTagRX(msg->tag);

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -470,6 +470,7 @@ namespace llarp
       if (itr == Sessions().end())
         return false;
       si = itr->second.remote;
+      si.UpdateAddr();
       return true;
     }
 

--- a/llarp/service/intro.hpp
+++ b/llarp/service/intro.hpp
@@ -13,7 +13,7 @@ namespace llarp
   {
     struct Introduction
     {
-      PubKey router;
+      RouterID router;
       PathID_t pathID;
       llarp_time_t latency = 0s;
       llarp_time_t expiresAt = 0s;

--- a/llarp/service/outbound_context.hpp
+++ b/llarp/service/outbound_context.hpp
@@ -23,6 +23,9 @@ namespace llarp
 
       ~OutboundContext() override;
 
+      void
+      Tick(llarp_time_t now) override;
+
       util::StatusObject
       ExtractStatus() const;
 
@@ -129,6 +132,9 @@ namespace llarp
       void
       KeepAlive();
 
+      bool
+      ShouldKeepAlive(llarp_time_t now) const;
+
       const IntroSet&
       GetCurrentIntroSet() const
       {
@@ -170,6 +176,7 @@ namespace llarp
       bool sentIntro = false;
       std::vector<std::function<void(OutboundContext*)>> m_ReadyHooks;
       llarp_time_t m_LastIntrosetUpdateAt = 0s;
+      llarp_time_t m_LastKeepAliveAt = 0s;
     };
   }  // namespace service
 

--- a/llarp/service/sendcontext.hpp
+++ b/llarp/service/sendcontext.hpp
@@ -45,7 +45,7 @@ namespace llarp
       llarp_time_t lastGoodSend = 0s;
       const llarp_time_t createdAt;
       llarp_time_t sendTimeout = path::build_timeout;
-      llarp_time_t connectTimeout = path::build_timeout;
+      llarp_time_t connectTimeout = path::build_timeout * 2;
       llarp_time_t shiftTimeout = (path::build_timeout * 5) / 2;
       llarp_time_t estimatedRTT = 0s;
       bool markedBad = false;


### PR DESCRIPTION
sometimes outbound contexts get stuck in a half open state. this prevents that by making sure we remove ones that happen to hit that case.