### PR TITLE
resepct empty ipv6 range setting

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -569,7 +569,13 @@ namespace llarp
         IP6RangeDefault,
         [this](std::string arg) {
           if (arg.empty())
+          {
+            LogError(
+                "!!! Disabling ipv6 tunneling when you have ipv6 routes WILL lead to "
+                "de-anonymization as lokinet will no longer carry your ipv6 traffic !!!");
+            m_baseV6Address = std::nullopt;
             return;
+          }
           m_baseV6Address = huint128_t{};
           if (not m_baseV6Address->FromString(arg))
             throw std::invalid_argument(


### PR DESCRIPTION
set base v6 address to nullopt when explicit empty string is provided to respect user settings, also put a big fat warning when this is done so they know it's a bad idea.