### PR TITLE
check for intersecting ip ranges correctly, add unit test

### DIFF
--- a/llarp/net/ip_range.hpp
+++ b/llarp/net/ip_range.hpp
@@ -63,6 +63,13 @@ namespace llarp
       return bits::count_bits(netmask_bits);
     }
 
+    /// return true if our range and other intersect
+    constexpr bool
+    operator*(const IPRange& other) const
+    {
+      return Contains(other) or other.Contains(*this);
+    }
+
     /// return true if the other range is inside our range
     constexpr bool
     Contains(const IPRange& other) const

--- a/llarp/net/net.cpp
+++ b/llarp/net/net.cpp
@@ -503,10 +503,10 @@ namespace llarp
               IPRange{net::ExpandV4(xntohl(ifaddr)), net::ExpandV4(xntohl(ifmask))});
       }
     });
-    auto ownsRange = [&currentRanges](IPRange range) -> bool {
+    auto ownsRange = [&currentRanges](const IPRange& range) -> bool {
       for (const auto& ownRange : currentRanges)
       {
-        if (ownRange.Contains(range))
+        if (ownRange * range)
           return true;
       }
       return false;

--- a/test/net/test_llarp_net.cpp
+++ b/test/net/test_llarp_net.cpp
@@ -60,6 +60,17 @@ TEST_CASE("Range")
     REQUIRE(!llarp::IPRange::FromIPv4(192, 168, 0, 1, 24)
                  .Contains(llarp::ipaddr_ipv4_bits(10, 200, 0, 253)));
   }
+  SECTION("Intersecting networks")
+  {
+      const auto range_16 = llarp::IPRange::FromIPv4(10,9,0,1, 16);
+      const auto range_24a = llarp::IPRange::FromIPv4(10,9,0,1, 24);
+      const auto range_24b = llarp::IPRange::FromIPv4(10,9,1,1, 24);
+      const auto range_unrelated = llarp::IPRange::FromIPv4(1,9,1,1, 8);
+      REQUIRE(range_16 * range_24a);
+      REQUIRE(range_16 * range_24b);
+      REQUIRE(not(range_24a * range_24b));
+      REQUIRE(not(range_16 * range_unrelated));
+  }
 }
 
 TEST_CASE("IPv4 netmask")


### PR DESCRIPTION
when a network uses 172.16.0.1/24 we don't detect it right because of a bug, this fixes that bug and adds a unit test to verify that.