### PR TITLE
Add python packages to ci images

### DIFF
--- a/contrib/ci/docker/10-debian-bullseye.dockerfile
+++ b/contrib/ci/docker/10-debian-bullseye.dockerfile
@@ -1,6 +1,8 @@
 ARG ARCH=amd64
 FROM registry.oxen.rocks/lokinet-ci-debian-bullseye-base/${ARCH}
-RUN apt-get -o=Dpkg::Use-Pty=0 -q install --no-install-recommends -y \
+RUN apt-get -o=Dpkg::Use-Pty=0 -q update \
+    && apt-get -o=Dpkg::Use-Pty=0 -q dist-upgrade -y \
+    && apt-get -o=Dpkg::Use-Pty=0 -q install --no-install-recommends -y \
         automake \
         ccache \
         cmake \

--- a/contrib/ci/docker/10-debian-bullseye.dockerfile
+++ b/contrib/ci/docker/10-debian-bullseye.dockerfile
@@ -35,5 +35,10 @@ RUN apt-get -o=Dpkg::Use-Pty=0 -q install --no-install-recommends -y \
         openssh-client \
         patch \
         pkg-config \
+        pybind11-dev \
         python3-dev \
+        python3-pip \
+        python3-pybind11 \
+        python3-pytest \
+        python3-setuptools \
         qttools5-dev

--- a/contrib/ci/docker/10-debian-buster.dockerfile
+++ b/contrib/ci/docker/10-debian-buster.dockerfile
@@ -1,6 +1,8 @@
 ARG ARCH=amd64
 FROM registry.oxen.rocks/lokinet-ci-debian-buster-base/${ARCH}
-RUN apt-get -o=Dpkg::Use-Pty=0 -q install --no-install-recommends -y \
+RUN apt-get -o=Dpkg::Use-Pty=0 -q update \
+    && apt-get -o=Dpkg::Use-Pty=0 -q dist-upgrade -y \
+    && apt-get -o=Dpkg::Use-Pty=0 -q install --no-install-recommends -y \
         automake \
         ccache \
         cmake \

--- a/contrib/ci/docker/10-debian-buster.dockerfile
+++ b/contrib/ci/docker/10-debian-buster.dockerfile
@@ -35,6 +35,11 @@ RUN apt-get -o=Dpkg::Use-Pty=0 -q install --no-install-recommends -y \
         openssh-client \
         patch \
         pkg-config \
+        pybind11-dev \
         python3-dev \
+        python3-pip \
+        python3-pybind11 \
+        python3-pytest \
+        python3-setuptools \
         qttools5-dev \
         xz-utils

--- a/contrib/ci/docker/10-debian-sid.dockerfile
+++ b/contrib/ci/docker/10-debian-sid.dockerfile
@@ -35,5 +35,10 @@ RUN apt-get -o=Dpkg::Use-Pty=0 --no-install-recommends -q install -y \
         openssh-client \
         patch \
         pkg-config \
+        pybind11-dev \
         python3-dev \
+        python3-pip \
+        python3-pybind11 \
+        python3-pytest \
+        python3-setuptools \
         qttools5-dev

--- a/contrib/ci/docker/10-debian-sid.dockerfile
+++ b/contrib/ci/docker/10-debian-sid.dockerfile
@@ -1,6 +1,8 @@
 ARG ARCH=amd64
 FROM registry.oxen.rocks/lokinet-ci-debian-sid-base/${ARCH}
-RUN apt-get -o=Dpkg::Use-Pty=0 --no-install-recommends -q install -y \
+RUN apt-get -o=Dpkg::Use-Pty=0 -q update \
+    && apt-get -o=Dpkg::Use-Pty=0 -q dist-upgrade -y \
+    && apt-get -o=Dpkg::Use-Pty=0 -q install --no-install-recommends -y \
         automake \
         ccache \
         cmake \

--- a/contrib/ci/docker/10-debian-stable.dockerfile
+++ b/contrib/ci/docker/10-debian-stable.dockerfile
@@ -35,5 +35,10 @@ RUN apt-get -o=Dpkg::Use-Pty=0 -q install --no-install-recommends -y \
         openssh-client \
         patch \
         pkg-config \
+        pybind11-dev \
         python3-dev \
+        python3-pip \
+        python3-pybind11 \
+        python3-pytest \
+        python3-setuptools \
         qttools5-dev

--- a/contrib/ci/docker/10-debian-stable.dockerfile
+++ b/contrib/ci/docker/10-debian-stable.dockerfile
@@ -1,6 +1,8 @@
 ARG ARCH=amd64
 FROM registry.oxen.rocks/lokinet-ci-debian-stable-base/${ARCH}
-RUN apt-get -o=Dpkg::Use-Pty=0 -q install --no-install-recommends -y \
+RUN apt-get -o=Dpkg::Use-Pty=0 -q update \
+    && apt-get -o=Dpkg::Use-Pty=0 -q dist-upgrade -y \
+    && apt-get -o=Dpkg::Use-Pty=0 -q install --no-install-recommends -y \
         automake \
         ccache \
         cmake \

--- a/contrib/ci/docker/10-ubuntu-bionic.dockerfile
+++ b/contrib/ci/docker/10-ubuntu-bionic.dockerfile
@@ -26,6 +26,11 @@ RUN apt-get -o=Dpkg::Use-Pty=0 -q update \
         openssh-client \
         patch \
         pkg-config \
+        pybind11-dev \
         python3-dev \
+        python3-pip \
+        python3-pybind11 \
+        python3-pytest \
+        python3-setuptools \
         qttools5-dev \
     && mkdir -p /usr/lib/x86_64-linux-gnu/pgm-5.2/include

--- a/contrib/ci/docker/10-ubuntu-focal.dockerfile
+++ b/contrib/ci/docker/10-ubuntu-focal.dockerfile
@@ -38,5 +38,10 @@ RUN apt-get -o=Dpkg::Use-Pty=0 -q update \
         openssh-client \
         patch \
         pkg-config \
+        pybind11-dev \
         python3-dev \
+        python3-pip \
+        python3-pybind11 \
+        python3-pytest \
+        python3-setuptools \
         qttools5-dev

--- a/contrib/ci/docker/10-ubuntu-impish.dockerfile
+++ b/contrib/ci/docker/10-ubuntu-impish.dockerfile
@@ -38,5 +38,10 @@ RUN apt-get -o=Dpkg::Use-Pty=0 -q update \
         openssh-client \
         patch \
         pkg-config \
+        pybind11-dev \
         python3-dev \
+        python3-pip \
+        python3-pybind11 \
+        python3-pytest \
+        python3-setuptools \
         qttools5-dev

--- a/contrib/ci/docker/10-ubuntu-lts.dockerfile
+++ b/contrib/ci/docker/10-ubuntu-lts.dockerfile
@@ -38,5 +38,10 @@ RUN apt-get -o=Dpkg::Use-Pty=0 -q update \
         openssh-client \
         patch \
         pkg-config \
+        pybind11-dev \
         python3-dev \
+        python3-pip \
+        python3-pybind11 \
+        python3-pytest \
+        python3-setuptools \
         qttools5-dev

--- a/contrib/ci/docker/10-ubuntu-rolling.dockerfile
+++ b/contrib/ci/docker/10-ubuntu-rolling.dockerfile
@@ -38,5 +38,10 @@ RUN apt-get -o=Dpkg::Use-Pty=0 -q update \
         openssh-client \
         patch \
         pkg-config \
+        pybind11-dev \
         python3-dev \
+        python3-pip \
+        python3-pybind11 \
+        python3-pytest \
+        python3-setuptools \
         qttools5-dev

--- a/contrib/ci/docker/rebuild-docker-images.sh
+++ b/contrib/ci/docker/rebuild-docker-images.sh
@@ -28,7 +28,7 @@ for file in "${files[@]}"; do
     namearch=$registry/lokinet-ci-$name/$arch
     latest=$registry/lokinet-ci-$name:latest
     echo -e "\e[32;1mrebuilding \e[35;1m$namearch\e[0m"
-    docker build --pull -f $file -t $namearch --build-arg ARCH=$arch .
+    docker build --pull -f $file -t $namearch --build-arg ARCH=$arch $DOCKER_BUILD_OPTS .
     docker push $namearch
 
     manifests[$latest]="${manifests[$latest]} $namearch"


### PR DESCRIPTION
- Adds python packages to the CI images need to build pyoxenmq
- Adds a apt-get update to the non-base debian/ubuntu images, because the base they build on may be out of date
- Adds a DOCKER_BUILD_OPTS to the rebuild script so that you can do `DOCKER_BUILD_OPTS=--no-cache ./rebuild-docker-images.sh` to force everything to rebuild.