### PR TITLE
exclude fully failed nodes from service node testing list

### DIFF
--- a/llarp/consensus/reachability_testing.cpp
+++ b/llarp/consensus/reachability_testing.cpp
@@ -124,7 +124,8 @@ namespace llarp::consensus
       auto& [pk, retest_time, failures] = failing_queue.top();
       if (retest_time > now)
         break;
-      result.emplace_back(pk, failures);
+      if (failing.count(pk))
+        result.emplace_back(pk, failures);
       failing_queue.pop();
     }
     return result;


### PR DESCRIPTION
do not requeue nodes for testing from failing queue if we do not have them marked as failing anymore