### PR TITLE
disable lokinet-bootstrap in static linux ci pipeline

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -305,7 +305,7 @@ local mac_builder(name,
                               '-DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8 ' +
                               '-DCMAKE_CXX_FLAGS="-march=x86-64 -mtune=haswell" ' +
                               '-DCMAKE_C_FLAGS="-march=x86-64 -mtune=haswell" ' +
-                              '-DNATIVE_BUILD=OFF -DWITH_SYSTEMD=OFF',
+                              '-DNATIVE_BUILD=OFF -DWITH_SYSTEMD=OFF -DWITH_BOOTSTRAP=OFF',
                   extra_cmds=[
                     '../contrib/ci/drone-check-static-libs.sh',
                     '../contrib/ci/drone-static-upload.sh',
@@ -317,7 +317,7 @@ local mac_builder(name,
                   deps=['g++', 'python3-dev', 'automake', 'libtool'],
                   cmake_extra='-DBUILD_STATIC_DEPS=ON -DBUILD_SHARED_LIBS=OFF -DSTATIC_LINK=ON ' +
                               '-DCMAKE_CXX_FLAGS="-march=armv7-a+fp -Wno-psabi" -DCMAKE_C_FLAGS="-march=armv7-a+fp" ' +
-                              '-DNATIVE_BUILD=OFF -DWITH_SYSTEMD=OFF',
+                              '-DNATIVE_BUILD=OFF -DWITH_SYSTEMD=OFF -DWITH_BOOTSTRAP=OFF',
                   extra_cmds=[
                     '../contrib/ci/drone-check-static-libs.sh',
                     'UPLOAD_OS=linux-armhf ../contrib/ci/drone-static-upload.sh',

--- a/contrib/ci/drone-static-upload.sh
+++ b/contrib/ci/drone-static-upload.sh
@@ -44,7 +44,8 @@ elif [ -e lokinet.apk ] ; then
     archive="$base.apk"
     cp -av lokinet.apk "$archive"
 else
-    cp -av daemon/lokinet daemon/lokinet-vpn daemon/lokinet-bootstrap "$base"
+    cp -av daemon/lokinet daemon/lokinet-vpn "$base"
+    cp -av ../contrib/bootstrap/mainnet.signed "$base/bootstrap.signed"
     # tar dat shiz up yo
     archive="$base.tar.xz"
     tar cJvf "$archive" "$base"


### PR DESCRIPTION
in static linux ci pipeline disable building lokinet-bootstrap and bundle a bootstrap.signed so that people who download it dont run the broken lokinet-bootstrap binary.