### PR TITLE
client side exit node pooling

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -454,6 +454,7 @@ namespace llarp
         "network",
         "exit-node",
         ClientOnly,
+        MultiValue,
         Comment{
             "Specify a `.loki` address and an optional ip range to use as an exit broker.",
             "Example:",
@@ -496,12 +497,13 @@ namespace llarp
         "network",
         "exit-auth",
         ClientOnly,
+        MultiValue,
         Comment{
             "Specify an optional authentication code required to use a non-public exit node.",
             "For example:",
             "    exit-auth=myfavouriteexit.loki:abc",
             "uses the authentication code `abc` whenever myfavouriteexit.loki is accessed.",
-            "Can be specified multiple time to store codes for different exit nodes.",
+            "Can be specified multiple times to store codes for different exit nodes.",
         },
         [this](std::string arg) {
           if (arg.empty())

--- a/llarp/handlers/tun.hpp
+++ b/llarp/handlers/tun.hpp
@@ -222,7 +222,20 @@ namespace llarp
       /// a hidden service
       std::unordered_map<AlignedBuffer<32>, bool> m_SNodes;
 
+      /// maps ip address to an exit endpoint, useful when we have multiple exits on a range
+      std::unordered_map<huint128_t, service::Address> m_ExitIPToExitAddress;
+
      private:
+      /// given an ip address that is not mapped locally find the address it shall be forwarded to
+      /// optionally provide a custom selection strategy, if none is provided it will choose a
+      /// random entry from the available choices
+      /// return std::nullopt if we cannot route this address to an exit
+      std::optional<service::Address>
+      ObtainExitAddressFor(
+          huint128_t ip,
+          std::function<service::Address(std::unordered_set<service::Address>)> exitSelectionStrat =
+              nullptr);
+
       template <typename Addr_t, typename Endpoint_t>
       void
       SendDNSReply(


### PR DESCRIPTION
users can now provide multiple `exit-node` values in network section to randomly pool over all provided exits for each range they are mapped to.
implement exit node pooling, allows users to use multiple exits for an address range.
mappings per ip stick to the same exit, each new ip is mapped to a random exit in the specified pool.