### PR TITLE
disable ip6 upstream dns in libunbound

### DIFF
--- a/llarp/dns/unbound_resolver.cpp
+++ b/llarp/dns/unbound_resolver.cpp
@@ -106,6 +106,9 @@ namespace llarp::dns
       return false;
     }
 
+    // disable ip6 for upstream dns
+    ub_ctx_set_option(unboundContext, "prefer-ip6", "0");
+    // enable async
     ub_ctx_async(unboundContext, 1);
 #ifdef _WIN32
     runner = std::thread{[&]() {


### PR DESCRIPTION
when lokinet looses ip4 connectivity libunbound used to freak out and only use ip6 after such an event.
as a result dns queries stop working because we blackhole ip6 routes if exit mode is on.
this prevents this case from being hit.