### PR TITLE
configurable route poker

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -539,10 +539,11 @@ namespace llarp
         ClientOnly,
         Default{true},
         Comment{
-            "enable / disable auto routing. When using an exit lokinet will add routes to "
-            "the OS to make traffic go over the network interface via lokinet.",
-            "enabled by default.",
-        },
+            "Enable / disable automatic route configuration.",
+            "When this is enabled and an exit is used Lokinet will automatically configure "
+            "operating system routes to route traffic through the exit node.",
+            "This is enabled by default, but can be disabled to perform advanced exit routing "
+            "configuration manually."},
         AssignmentAcceptor(m_EnableRoutePoker));
 
     conf.defineOption<std::string>(

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -533,6 +533,18 @@ namespace llarp
           m_ExitAuths.emplace(exit, auth);
         });
 
+    conf.defineOption<bool>(
+        "network",
+        "auto-routing",
+        ClientOnly,
+        Default{true},
+        Comment{
+            "enable / disable auto routing. When using an exit lokinet will add routes to "
+            "the OS to make traffic go over the network interface via lokinet.",
+            "enabled by default.",
+        },
+        AssignmentAcceptor(m_EnableRoutePoker));
+
     conf.defineOption<std::string>(
         "network",
         "ifname",

--- a/llarp/config/config.hpp
+++ b/llarp/config/config.hpp
@@ -129,6 +129,8 @@ namespace llarp
 
     std::optional<fs::path> m_AddrMapPersistFile;
 
+    bool m_EnableRoutePoker;
+
     void
     defineConfigOptions(ConfigDefinition& conf, const ConfigGenParameters& params);
   };

--- a/llarp/router/route_poker.cpp
+++ b/llarp/router/route_poker.cpp
@@ -162,10 +162,13 @@ namespace llarp
     if (m_Enabled)
       return;
 
-    m_Enabling = true;
-    Update();
-    m_Enabling = false;
-    m_Enabled = true;
+    if (m_Router->GetConfig()->network.m_EnableRoutePoker)
+    {
+      m_Enabling = true;
+      Update();
+      m_Enabling = false;
+      m_Enabled = true;
+    }
 
     systemd_resolved_set_dns(
         m_Router->hiddenServiceContext().GetDefault()->GetIfName(),
@@ -191,6 +194,9 @@ namespace llarp
   void
   RoutePoker::Up()
   {
+    if (not m_Router->GetConfig()->network.m_EnableRoutePoker)
+      return;
+
     vpn::IRouteManager& route = m_Router->GetVPNPlatform()->RouteManager();
 
     // black hole all routes by default
@@ -207,6 +213,9 @@ namespace llarp
   void
   RoutePoker::Down()
   {
+    if (not m_Router->GetConfig()->network.m_EnableRoutePoker)
+      return;
+
     // unpoke routes for first hops
     m_Router->ForEachPeer(
         [&](auto session, auto) mutable { DelRoute(session->GetRemoteEndpoint().asIPv4()); },


### PR DESCRIPTION
this allows you to use exit nodes without forcing routes over the interface, useful for using lokinet with an exit and selectively routing over the lokinet interface using an external socks proxy or binding to device explicitly.

* make route poker configurable, defaults to enabled but allows disabling it on runtime if desired
* add config option [network]:auto-routing to enable/disable route poker