### PR TITLE
Make windows work again

### DIFF
--- a/cmake/win32.cmake
+++ b/cmake/win32.cmake
@@ -15,8 +15,9 @@ if(NOT MSVC_VERSION)
   # to .r[o]data section one after the other!
   add_compile_options(-fno-ident -Wa,-mbig-obj)
   link_libraries( -lws2_32 -lshlwapi -ldbghelp -luser32 -liphlpapi -lpsapi -luserenv)
-  # zmq requires windows xp or higher
-  add_definitions(-DWINVER=0x0501 -D_WIN32_WINNT=0x0501)
+  # the minimum windows version, set to 6 rn because supporting older windows is hell
+  set(_winver 0x0600)
+  add_definitions(-DWINVER=${_winver} -D_WIN32_WINNT=${_winver})
 endif()
 
 if(EMBEDDED_CFG)

--- a/llarp/apple/vpn_interface.hpp
+++ b/llarp/apple/vpn_interface.hpp
@@ -17,7 +17,10 @@ namespace llarp::apple
     using on_readable_callback = std::function<void(VPNInterface&)>;
 
     explicit VPNInterface(
-        Context& ctx, packet_write_callback packet_writer, on_readable_callback on_readable);
+        Context& ctx,
+        packet_write_callback packet_writer,
+        on_readable_callback on_readable,
+        AbstractRouter* router);
 
     // Method to call when a packet has arrived to deliver the packet to lokinet
     bool
@@ -35,6 +38,9 @@ namespace llarp::apple
     bool
     WritePacket(net::IPPacket pkt) override;
 
+    void
+    MaybeWakeUpperLayers() const override;
+
    private:
     // Function for us to call when we have a packet to emit.  Should return true if the packet was
     // handed off to the OS successfully.
@@ -46,6 +52,8 @@ namespace llarp::apple
     static inline constexpr auto PacketQueueSize = 1024;
 
     thread::Queue<net::IPPacket> m_ReadQueue{PacketQueueSize};
+
+    AbstractRouter* const _router;
   };
 
 }  // namespace llarp::apple

--- a/llarp/apple/vpn_platform.cpp
+++ b/llarp/apple/vpn_platform.cpp
@@ -15,8 +15,9 @@ namespace llarp::apple
       , m_OnReadable{std::move(on_readable)}
   {}
 
-  std::shared_ptr<vpn::NetworkInterface> VPNPlatform::ObtainInterface(vpn::InterfaceInfo)
+  std::shared_ptr<vpn::NetworkInterface>
+  VPNPlatform::ObtainInterface(vpn::InterfaceInfo, AbstractRouter* router)
   {
-    return std::make_shared<VPNInterface>(m_Context, m_PacketWriter, m_OnReadable);
+    return std::make_shared<VPNInterface>(m_Context, m_PacketWriter, m_OnReadable, router);
   }
 }  // namespace llarp::apple

--- a/llarp/apple/vpn_platform.hpp
+++ b/llarp/apple/vpn_platform.hpp
@@ -16,7 +16,8 @@ namespace llarp::apple
         llarp_route_callbacks route_callbacks,
         void* callback_context);
 
-    std::shared_ptr<vpn::NetworkInterface> ObtainInterface(vpn::InterfaceInfo) override;
+    std::shared_ptr<vpn::NetworkInterface>
+    ObtainInterface(vpn::InterfaceInfo, AbstractRouter*) override;
 
     vpn::IRouteManager&
     RouteManager() override

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -798,12 +798,12 @@ namespace llarp
       const IpAddress addr{value};
       if (not addr.hasPort())
         throw std::invalid_argument("no port provided in link address");
-      info.interface = addr.toHost();
+      info.m_interface = addr.toHost();
       info.port = *addr.getPort();
     }
     else
     {
-      info.interface = std::string{name};
+      info.m_interface = std::string{name};
 
       std::vector<std::string_view> splits = split(value, ",");
       for (std::string_view str : splits)

--- a/llarp/config/config.hpp
+++ b/llarp/config/config.hpp
@@ -147,7 +147,7 @@ namespace llarp
   {
     struct LinkInfo
     {
-      std::string interface;
+      std::string m_interface;
       int addressFamily = -1;
       uint16_t port = -1;
     };

--- a/llarp/ev/vpn.hpp
+++ b/llarp/ev/vpn.hpp
@@ -9,7 +9,8 @@
 namespace llarp
 {
   struct Context;
-}
+  struct AbstractRouter;
+}  // namespace llarp
 
 namespace llarp::vpn
 {
@@ -59,6 +60,10 @@ namespace llarp::vpn
     /// returns false if we dropped it
     virtual bool
     WritePacket(net::IPPacket pkt) = 0;
+
+    /// idempotently wake up the upper layers as needed (platform dependant)
+    virtual void
+    MaybeWakeUpperLayers() const {};
   };
 
   class IRouteManager
@@ -112,7 +117,7 @@ namespace llarp::vpn
     /// get a new network interface fully configured given the interface info
     /// blocks until ready, throws on error
     virtual std::shared_ptr<NetworkInterface>
-    ObtainInterface(InterfaceInfo info) = 0;
+    ObtainInterface(InterfaceInfo info, AbstractRouter* router) = 0;
 
     /// get owned ip route manager for managing routing table
     virtual IRouteManager&

--- a/llarp/handlers/exit.cpp
+++ b/llarp/handlers/exit.cpp
@@ -443,7 +443,7 @@ namespace llarp
         info.ifname = m_ifname;
         info.addrs.emplace(m_OurRange);
 
-        m_NetIf = GetRouter()->GetVPNPlatform()->ObtainInterface(std::move(info));
+        m_NetIf = GetRouter()->GetVPNPlatform()->ObtainInterface(std::move(info), m_Router);
         if (not m_NetIf)
         {
           llarp::LogError("Could not create interface");

--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -908,7 +908,7 @@ namespace llarp
 
       try
       {
-        m_NetIf = Router()->GetVPNPlatform()->ObtainInterface(std::move(info));
+        m_NetIf = Router()->GetVPNPlatform()->ObtainInterface(std::move(info), Router());
       }
       catch (std::exception& ex)
       {

--- a/llarp/net/sock_addr.hpp
+++ b/llarp/net/sock_addr.hpp
@@ -7,11 +7,6 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <wspiapi.h>
-extern "C" const char*
-inet_ntop(int af, const void* src, char* dst, size_t size);
-extern "C" int
-inet_pton(int af, const char* src, void* dst);
-#define inet_aton(x, y) inet_pton(AF_INET, x, y)
 #endif
 
 #include <string_view>

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -709,7 +709,7 @@ namespace llarp
           util::memFn(&AbstractRouter::TriggerPump, this),
           util::memFn(&AbstractRouter::QueueWork, this));
 
-      const std::string& key = serverConfig.interface;
+      const std::string& key = serverConfig.m_interface;
       int af = serverConfig.addressFamily;
       uint16_t port = serverConfig.port;
       if (!server->Configure(this, key, af, port))
@@ -1241,10 +1241,6 @@ namespace llarp
 
     LogInfo("have ", _nodedb->NumLoaded(), " routers");
 
-#ifdef _WIN32
-    // windows uses proactor event loop so we need to constantly pump
-    _loop->add_ticker([this] { PumpLL(); });
-#endif
     _loop->call_every(ROUTER_TICK_INTERVAL, weak_from_this(), [this] { Tick(); });
     _running.store(true);
     _startedAt = Now();

--- a/llarp/rpc/rpc_server.cpp
+++ b/llarp/rpc/rpc_server.cpp
@@ -512,8 +512,7 @@ namespace llarp::rpc
                                   }
                                   onGoodResult(result.reason);
                                 });
-                          },
-                          2s);
+                          });
                     };
                     if (exit.has_value())
                     {

--- a/llarp/rpc/rpc_server.cpp
+++ b/llarp/rpc/rpc_server.cpp
@@ -513,7 +513,7 @@ namespace llarp::rpc
                                   onGoodResult(result.reason);
                                 });
                           },
-                          5s);
+                          2s);
                     };
                     if (exit.has_value())
                     {
@@ -564,8 +564,8 @@ namespace llarp::rpc
                   {
                     r->routePoker().Down();
                     ep->UnmapExitRange(range);
+                    reply(CreateJSONResponse("OK"));
                   }
-                  reply(CreateJSONResponse("OK"));
                 });
               });
             })

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -323,10 +323,15 @@ namespace llarp
       // nullptr if the path was not made before the timeout
       using PathEnsureHook = std::function<void(Address, OutboundContext*)>;
 
+      static constexpr auto DefaultPathEnsureTimeout = 2s;
+
       /// return false if we have already called this function before for this
       /// address
       bool
-      EnsurePathToService(const Address remote, PathEnsureHook h, llarp_time_t timeoutMS);
+      EnsurePathToService(
+          const Address remote,
+          PathEnsureHook h,
+          llarp_time_t timeoutMS = DefaultPathEnsureTimeout);
 
       using SNodeEnsureHook = std::function<void(const RouterID, exit::BaseSession_ptr, ConvoTag)>;
 

--- a/llarp/vpn/android.hpp
+++ b/llarp/vpn/android.hpp
@@ -92,7 +92,7 @@ namespace llarp::vpn
     {}
 
     std::shared_ptr<NetworkInterface>
-    ObtainInterface(InterfaceInfo info) override
+    ObtainInterface(InterfaceInfo info, AbstractRouter*) override
     {
       return std::make_shared<AndroidInterface>(std::move(info), fd);
     }

--- a/llarp/vpn/linux.hpp
+++ b/llarp/vpn/linux.hpp
@@ -448,7 +448,7 @@ namespace llarp::vpn
 
    public:
     std::shared_ptr<NetworkInterface>
-    ObtainInterface(InterfaceInfo info) override
+    ObtainInterface(InterfaceInfo info, AbstractRouter*) override
     {
       return std::make_shared<LinuxInterface>(std::move(info));
     };

--- a/pybind/llarp/config.cpp
+++ b/pybind/llarp/config.cpp
@@ -77,7 +77,7 @@ namespace llarp
             "setOutboundLink",
             [](LinksConfig& self, std::string interface, int family, uint16_t port) {
               LinksConfig::LinkInfo info;
-              info.interface = std::move(interface);
+              info.m_interface = std::move(interface);
               info.addressFamily = family;
               info.port = port;
               self.m_OutboundLink = std::move(info);
@@ -86,7 +86,7 @@ namespace llarp
             "addInboundLink",
             [](LinksConfig& self, std::string interface, int family, uint16_t port) {
               LinksConfig::LinkInfo info;
-              info.interface = std::move(interface);
+              info.m_interface = std::move(interface);
               info.addressFamily = family;
               info.port = port;
               self.m_InboundLinks.push_back(info);


### PR DESCRIPTION
on win32/apple reading packets from the interface does not count as an io operation.
manually trigger pump on win32/apple to pretend that it is an io event.
add platform quark function MaybeWakeUpperLayers on vpn::Interface to manaully wake up the other components on platforms that need that (ones on which packet io is not done via io events).
on non linux platforms, use uv_prepare_t instead of uv_check_t as the former triggers before blocking for io, instead of after. this better matches linux's order of operations in libuv.