### PR TITLE
route poker: allow not blackholing routes.

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -546,6 +546,17 @@ namespace llarp
             "configuration manually."},
         AssignmentAcceptor(m_EnableRoutePoker));
 
+    conf.defineOption<bool>(
+        "network",
+        "blackhole-routes",
+        ClientOnly,
+        Default{true},
+        Comment{
+            "Enable / disable route configuration blackholes.",
+            "When enabled lokinet will drop ip4 and ip6 not included in exit config.",
+            "Enabled by default."},
+        AssignmentAcceptor(m_BlackholeRoutes));
+
     conf.defineOption<std::string>(
         "network",
         "ifname",

--- a/llarp/config/config.hpp
+++ b/llarp/config/config.hpp
@@ -130,6 +130,7 @@ namespace llarp
     std::optional<fs::path> m_AddrMapPersistFile;
 
     bool m_EnableRoutePoker;
+    bool m_BlackholeRoutes;
 
     void
     defineConfigOptions(ConfigDefinition& conf, const ConfigGenParameters& params);

--- a/llarp/router/route_poker.cpp
+++ b/llarp/router/route_poker.cpp
@@ -202,8 +202,10 @@ namespace llarp
 
     vpn::IRouteManager& route = m_Router->GetVPNPlatform()->RouteManager();
 
-    // black hole all routes by default
-    route.AddBlackhole();
+    // black hole all routes if enabled
+    if (m_Router->GetConfig()->network.m_BlackholeRoutes)
+      route.AddBlackhole();
+
     // explicit route pokes for first hops
     m_Router->ForEachPeer(
         [&](auto session, auto) mutable { AddRoute(session->GetRemoteEndpoint().asIPv4()); },


### PR DESCRIPTION
allow runtime configuration to disable ip blackholing. some other VPN tunnels that provide ip6 ranges are blocked by lokinet's vpn route poker. this adds a configuration option to toggle this, defaults remain unchanged.