### PR TITLE
Disable unit tests by default (to avoid trigger gcc lto test suite issues)

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -72,7 +72,7 @@ local debian_pipeline(name,
                   'cmake .. -DWITH_SETCAP=OFF -DCMAKE_CXX_FLAGS=-fdiagnostics-color=always -DCMAKE_BUILD_TYPE=' + build_type + ' ' +
                   (if werror then '-DWARNINGS_AS_ERRORS=ON ' else '') +
                   '-DWITH_LTO=' + (if lto then 'ON ' else 'OFF ') +
-                  (if tests then '' else '-DWITH_TESTS=OFF ') +
+                  '-DWITH_TESTS=' + (if tests then 'ON ' else 'OFF ') +
                   cmake_extra,
                   'VERBOSE=1 make -j' + jobs,
                 ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ option(WITH_COVERAGE "generate coverage data" OFF)
 option(USE_SHELLHOOKS "enable shell hooks on compile time (dangerous)" OFF)
 option(WARNINGS_AS_ERRORS "treat all warnings as errors. turn off for development, on for release" OFF)
 option(TRACY_ROOT "include tracy profiler source" OFF)
-option(WITH_TESTS "build unit tests" ON)
+option(WITH_TESTS "build unit tests" OFF)
 option(WITH_HIVE "build simulation stubs" OFF)
 option(BUILD_PACKAGE "builds extra components for making an installer (with 'make package')" OFF)
 


### PR DESCRIPTION
~~on super old broken versions of gcc compiling unit tests make gcc segfault becuase of a bug in gcc
disable unit tests by default on these targets for users who do not know how to disable building unit tests~~