### PR TITLE
wire up sigusr1 to trigger a network thaw on non win32 platforms

### DIFF
--- a/llarp/constants/time.hpp
+++ b/llarp/constants/time.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <chrono>
+
+namespace llarp
+{
+  using namespace std::literals;
+  /// how big of a time skip before we reset network state
+  constexpr auto TimeskipDetectedDuration = 1min;
+}  // namespace llarp

--- a/llarp/context.cpp
+++ b/llarp/context.cpp
@@ -166,6 +166,14 @@ namespace llarp
       SigINT();
     }
 #ifndef _WIN32
+    if (sig == SIGUSR1)
+    {
+      if (router and not router->IsServiceNode())
+      {
+        LogInfo("SIGUSR1: resetting network state");
+        router->Thaw();
+      }
+    }
     if (sig == SIGHUP)
     {
       Reload();

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -4,6 +4,7 @@
 #include <llarp/config/config.hpp>
 #include <llarp/constants/proto.hpp>
 #include <llarp/constants/files.hpp>
+#include <llarp/constants/time.hpp>
 #include <llarp/crypto/crypto_libsodium.hpp>
 #include <llarp/crypto/crypto.hpp>
 #include <llarp/dht/context.hpp>
@@ -807,7 +808,6 @@ namespace llarp
       return;
     // LogDebug("tick router");
     const auto now = Now();
-    constexpr auto TimeskipDetectedDuration = 1min;
     if (const auto delta = now - _lastTick; _lastTick != 0s and delta > TimeskipDetectedDuration)
     {
       // we detected a time skip into the futre, thaw the network

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -807,6 +807,13 @@ namespace llarp
       return;
     // LogDebug("tick router");
     const auto now = Now();
+    constexpr auto TimeskipDetectedDuration = 1min;
+    if (const auto delta = now - _lastTick; _lastTick != 0s and delta > TimeskipDetectedDuration)
+    {
+      // we detected a time skip into the futre, thaw the network
+      LogWarn("Timeskip of ", delta, " detected. Resetting network state");
+      Thaw();
+    }
 
 #if defined(WITH_SYSTEMD)
     {


### PR DESCRIPTION
add signal handling for lokinet clients that will reset network state on sigusr1, this can be used to manually get out of a weird state. 