### PR TITLE
Build less paths as to reduce idle cpu usage

### DIFF
--- a/llarp/path/pathbuilder.cpp
+++ b/llarp/path/pathbuilder.cpp
@@ -399,16 +399,14 @@ namespace llarp
       return hops;
     }
 
-    bool
+    void
     Builder::BuildOneAlignedTo(const RouterID remote)
     {
-      if (const auto maybe = GetHopsAlignedToForBuild(remote); maybe.has_value())
+      if (const auto maybe = GetHopsAlignedToForBuild(remote))
       {
         LogInfo(Name(), " building path to ", remote);
         Build(*maybe);
-        return true;
       }
-      return false;
     }
 
     llarp_time_t

--- a/llarp/path/pathbuilder.hpp
+++ b/llarp/path/pathbuilder.hpp
@@ -116,7 +116,7 @@ namespace llarp
       void
       BuildOne(PathRole roles = ePathRoleAny) override;
 
-      bool
+      void
       BuildOneAlignedTo(const RouterID endpoint) override;
 
       std::optional<std::vector<RouterContact>>

--- a/llarp/path/pathset.hpp
+++ b/llarp/path/pathset.hpp
@@ -280,7 +280,7 @@ namespace llarp
       virtual void
       ResetInternalState() = 0;
 
-      virtual bool
+      virtual void
       BuildOneAlignedTo(const RouterID endpoint) = 0;
 
       virtual void

--- a/llarp/service/outbound_context.cpp
+++ b/llarp/service/outbound_context.cpp
@@ -477,9 +477,7 @@ namespace llarp
     bool
     OutboundContext::ShouldBuildMore(llarp_time_t now) const
     {
-      if (markedBad or path::Builder::BuildCooldownHit(now))
-        return false;
-      if (NumInStatus(path::ePathBuilding) >= numDesiredPaths)
+      if (markedBad or not path::Builder::ShouldBuildMore(now))
         return false;
 
       size_t numValidPaths = 0;


### PR DESCRIPTION
we were building waaaaay too many paths (like 100+ per endpoint) when we dont need them. this prevents that.