### PR TITLE
fix wire protocol race condition

### DIFF
--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -174,7 +174,10 @@ namespace llarp
       if (m_State == State::Ready)
         m_Parent->UnmapAddr(m_RemoteAddr);
       m_State = State::Closed;
+      if (m_SentClosed.test_and_set())
+        return;
       EncryptAndSend(std::move(close_msg));
+
       LogInfo(m_Parent->PrintableName(), " closing connection to ", m_RemoteAddr);
     }
 
@@ -338,7 +341,7 @@ namespace llarp
     bool
     Session::TimedOut(llarp_time_t now) const
     {
-      if (m_State == State::Ready || m_State == State::LinkIntro)
+      if (m_State == State::Ready)
       {
         return now > m_LastRX
             && now - m_LastRX

--- a/llarp/iwp/session.hpp
+++ b/llarp/iwp/session.hpp
@@ -203,6 +203,7 @@ namespace llarp
 
       std::atomic_flag m_PlaintextEmpty;
       llarp::thread::Queue<CryptoQueue_t> m_PlaintextRecv;
+      std::atomic_flag m_SentClosed;
 
       void
       EncryptWorker(CryptoQueue_t msgs);

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -443,6 +443,8 @@ namespace llarp
       LogError("RC is invalid, not saving");
       return false;
     }
+    if (m_isServiceNode)
+      _nodedb->Put(_rc);
     QueueDiskIO([&]() { HandleSaveRC(); });
     return true;
   }


### PR DESCRIPTION
only send close packet once, before we were sending a close after we got a close causing excess log spam.
include handshake phase when checking for connection timeouts.

when we change our rc make sure to put it into nodedb too when we are a service node to prevent weirdness in dht lookups.