### PR TITLE
Cache best paths determined by GetPathByRouter to reduce cpu usage

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -367,7 +367,7 @@ local docs_pipeline(name, image, extra_cmds=[], allow_fail=false) = {
                               '-DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8 ' +
                               '-DCMAKE_CXX_FLAGS="-march=x86-64 -mtune=haswell" ' +
                               '-DCMAKE_C_FLAGS="-march=x86-64 -mtune=haswell" ' +
-                              '-DNATIVE_BUILD=OFF -DWITH_SYSTEMD=OFF -DWITH_BOOTSTRAP=OFF',
+                              '-DNATIVE_BUILD=OFF -DWITH_SYSTEMD=OFF -DWITH_BOOTSTRAP=OFF -DBUILD_LIBLOKINET=OFF',
                   extra_cmds=[
                     '../contrib/ci/drone-check-static-libs.sh',
                     '../contrib/ci/drone-static-upload.sh',

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -393,11 +393,11 @@ local docs_pipeline(name, image, extra_cmds=[], allow_fail=false) = {
                   cmake_extra='-DWITH_HIVE=ON'),
 
   // Deb builds:
-  deb_builder(docker_base + 'debian-sid-debhelper', 'sid', 'debian/sid'),
-  deb_builder(docker_base + 'debian-bullseye-debhelper', 'bullseye', 'debian/bullseye'),
-  deb_builder(docker_base + 'ubuntu-impish-debhelper', 'impish', 'ubuntu/impish'),
-  deb_builder(docker_base + 'ubuntu-focal-debhelper', 'focal', 'ubuntu/focal'),
-  deb_builder(docker_base + 'debian-sid-debhelper', 'sid', 'debian/sid', arch='arm64'),
+  deb_builder(docker_base + 'debian-sid-builder', 'sid', 'debian/sid'),
+  deb_builder(docker_base + 'debian-bullseye-builder', 'bullseye', 'debian/bullseye'),
+  deb_builder(docker_base + 'ubuntu-impish-builder', 'impish', 'ubuntu/impish'),
+  deb_builder(docker_base + 'ubuntu-focal-builder', 'focal', 'ubuntu/focal'),
+  deb_builder(docker_base + 'debian-sid-builder', 'sid', 'debian/sid', arch='arm64'),
 
   // Macos builds:
   mac_builder('macOS (Release)'),

--- a/llarp/path/pathbuilder.cpp
+++ b/llarp/path/pathbuilder.cpp
@@ -191,10 +191,11 @@ namespace llarp
       lastBuild = 0s;
     }
 
-    void Builder::Tick(llarp_time_t)
+    void
+    Builder::Tick(llarp_time_t now)
     {
-      const auto now = llarp::time_now_ms();
-
+      PathSet::Tick(now);
+      now = llarp::time_now_ms();
       m_router->pathBuildLimiter().Decay(now);
 
       ExpirePaths(now, m_router);

--- a/llarp/path/pathset.hpp
+++ b/llarp/path/pathset.hpp
@@ -130,7 +130,7 @@ namespace llarp
 
       /// tick owned paths
       virtual void
-      Tick(llarp_time_t now) = 0;
+      Tick(llarp_time_t now);
 
       /// count the number of paths that will exist at this timestamp in future
       size_t
@@ -320,6 +320,9 @@ namespace llarp
       using PathMap_t = std::unordered_map<std::pair<RouterID, PathID_t>, Path_ptr>;
       mutable Mtx_t m_PathsMutex;
       PathMap_t m_Paths;
+
+     private:
+      std::unordered_map<RouterID, std::weak_ptr<path::Path>> m_PathCache;
     };
 
   }  // namespace path


### PR DESCRIPTION
GetPathByRouter is called a lot and is linear in cpu time given the number of paths. we do not need to recompute it each call and caching best paths and recomputing such infrequently helps reduce a LOT of cpu usage.