### PR TITLE
reduce excess path builds

### DIFF
--- a/llarp/path/path.cpp
+++ b/llarp/path/path.cpp
@@ -472,6 +472,11 @@ namespace llarp
           EnterState(ePathTimeout, now);
         }
       }
+      if (_status == ePathIgnore and now - m_LastRecvMessage >= path::alive_timeout)
+      {
+        // clean up this path as we dont use it anymore
+        EnterState(ePathExpired, now);
+      }
     }
 
     void

--- a/llarp/service/outbound_context.cpp
+++ b/llarp/service/outbound_context.cpp
@@ -479,7 +479,8 @@ namespace llarp
     {
       if (markedBad or path::Builder::BuildCooldownHit(now))
         return false;
-      if (NumInStatus(path::ePathBuilding) >= numDesiredPaths)
+
+      if (NumInStatus(path::ePathBuilding) >= std::max(numDesiredPaths / size_t{2}, size_t{1}))
         return false;
 
       size_t numValidPaths = 0;


### PR DESCRIPTION
* prevent outbound context from spamming path builds.
* remove inactive paths from pool to reduce heap memory usage.