### PR TITLE
split up window.sh like we do for android.sh

### DIFF
--- a/contrib/windows-configure.sh
+++ b/contrib/windows-configure.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# helper script for me for when i cross compile for windows
+# t. jeff
+#
+
+set -e
+set -x
+root="$(readlink -f $(dirname $0)/../)"
+mkdir -p build-windows
+cmake \
+    -S "$root" \
+    -B build-windows \
+    -G 'Unix Makefiles' \
+    -DCMAKE_EXE_LINKER_FLAGS=-fstack-protector \
+    -DCMAKE_CXX_FLAGS=-fdiagnostics-color=always\
+    -DCMAKE_TOOLCHAIN_FILE=$root/contrib/cross/mingw64.cmake\
+    -DBUILD_STATIC_DEPS=ON \
+    -DBUILD_PACKAGE=ON \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DBUILD_TESTING=OFF \
+    -DBUILD_LIBLOKINET=ON \
+    -DWITH_TESTS=OFF \
+    -DNATIVE_BUILD=OFF \
+    -DSTATIC_LINK=ON \
+    -DWITH_SYSTEMD=OFF \
+    -DFORCE_OXENMQ_SUBMODULE=ON \
+    -DFORCE_OXENC_SUBMODULE=ON \
+    -DSUBMODULE_CHECK=OFF \
+    -DWITH_LTO=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
+    $@

--- a/contrib/windows.sh
+++ b/contrib/windows.sh
@@ -6,26 +6,8 @@
 
 set -e
 set +x
-mkdir -p build-windows
-cd build-windows
-cmake \
-      -G 'Unix Makefiles' \
-      -DCMAKE_EXE_LINKER_FLAGS=-fstack-protector \
-      -DCMAKE_CXX_FLAGS=-fdiagnostics-color=always\
-      -DCMAKE_TOOLCHAIN_FILE=../contrib/cross/mingw64.cmake\
-      -DBUILD_STATIC_DEPS=ON \
-      -DBUILD_PACKAGE=ON \
-      -DBUILD_SHARED_LIBS=OFF \
-      -DBUILD_TESTING=OFF \
-      -DBUILD_LIBLOKINET=ON \
-      -DWITH_TESTS=OFF \
-      -DNATIVE_BUILD=OFF \
-      -DSTATIC_LINK=ON \
-      -DWITH_SYSTEMD=OFF \
-      -DFORCE_OXENMQ_SUBMODULE=ON \
-      -DFORCE_OXENC_SUBMODULE=ON \
-      -DSUBMODULE_CHECK=OFF \
-      -DWITH_LTO=OFF \
-      -DCMAKE_BUILD_TYPE=Release \
-      $@ ..
-make package -j${JOBS:-$(nproc)}
+
+root="$(readlink -f $(dirname $0)/../)"
+cd "$root"
+./contrib/windows-configure.sh $@
+make package -j${JOBS:-$(nproc)} -C build-windows


### PR DESCRIPTION
this makes it easier to build windows in a directory that isn't build-windows

i do this on my machine so i can exempt just one directory from my editor for all generated build files