### PR TITLE
plug LRSM infoleak and queue flushing

### DIFF
--- a/llarp/messages/relay_commit.cpp
+++ b/llarp/messages/relay_commit.cpp
@@ -319,6 +319,8 @@ namespace llarp
         self->hop = nullptr;
       };
       self->context->ForwardLRCM(self->hop->info.upstream, self->frames, func);
+      // trigger idempotent pump to ensure that the build messages propagate
+      self->context->Router()->TriggerPump();
     }
 
     // this is called from the logic thread

--- a/llarp/messages/relay_status.cpp
+++ b/llarp/messages/relay_status.cpp
@@ -145,8 +145,8 @@ namespace llarp
   void
   LR_StatusMessage::SetDummyFrames()
   {
-    // TODO
-    return;
+    for (auto& f : frames)
+      f.Randomize();
   }
 
   // call this from a worker thread


### PR DESCRIPTION
* lsrm frames were not randomized on creation and thus leaked hop length.
* add extra queue flush to make sure build messages get sent.