### PR TITLE
diversify intros in introset

### DIFF
--- a/llarp/crypto/crypto.hpp
+++ b/llarp/crypto/crypto.hpp
@@ -178,4 +178,15 @@ namespace llarp
     };
   };
 
+  namespace util
+  {
+    /// helper that shuffles a vector in place using secure random
+    template <typename T>
+    void
+    shuffle_all(std::vector<T>& c)
+    {
+      std::shuffle(c.begin(), c.end(), CSRNG{});
+    }
+  }  // namespace util
+
 }  // namespace llarp

--- a/llarp/path/pathset.cpp
+++ b/llarp/path/pathset.cpp
@@ -314,14 +314,13 @@ namespace llarp
     {
       std::set<service::Introduction> intros;
       Lock_t l{m_PathsMutex};
-      auto itr = m_Paths.begin();
-      while (itr != m_Paths.end())
+
+      for (const auto& [id, path] : m_Paths)
       {
-        if (itr->second->IsReady() and filter(itr->second->intro))
+        if (path->IsReady() and filter(path->intro))
         {
-          intros.insert(itr->second->intro);
+          intros.insert(path->intro);
         }
-        ++itr;
       }
       if (intros.empty())
         return std::nullopt;

--- a/llarp/service/endpoint.hpp
+++ b/llarp/service/endpoint.hpp
@@ -55,6 +55,8 @@ namespace llarp
 
     /// how aggressively should we retry looking up introsets
     static constexpr auto IntrosetLookupCooldown = 250ms;
+    /// limiter on how often we should regen our introset
+    static constexpr auto IntrosetRegenCooldown = 5s;
 
     struct Endpoint : public path::Builder,
                       public ILookupHolder,


### PR DESCRIPTION
when we generate a new introset before we were using the most recent intros deterministically, this means if we have more than the requested intros we will always use the same ones. there are cases in which the recipient does not put out their introset often enough as the intros remained unchanged.

this mixes which ones we publish so that each publish has a different set in each publish, the net effect being that we will never put out an introset with the same intros in it each time. 

this will permit traffic to spread out more instead of sticking to a deterministically selected set of intros.