### PR TITLE
state machine fix for link layer

### DIFF
--- a/llarp/iwp/linklayer.cpp
+++ b/llarp/iwp/linklayer.cpp
@@ -83,21 +83,6 @@ namespace llarp::iwp
     }
   }
 
-  bool
-  LinkLayer::MapAddr(const RouterID& r, ILinkSession* s)
-  {
-    if (not ILinkLayer::MapAddr(r, s))
-      return false;
-    m_AuthedAddrs.emplace(s->GetRemoteEndpoint(), r);
-    return true;
-  }
-
-  void
-  LinkLayer::UnmapAddr(const SockAddr& addr)
-  {
-    m_AuthedAddrs.erase(addr);
-  }
-
   std::shared_ptr<ILinkSession>
   LinkLayer::NewOutboundSession(const RouterContact& rc, const AddressInfo& ai)
   {

--- a/llarp/iwp/linklayer.hpp
+++ b/llarp/iwp/linklayer.hpp
@@ -44,12 +44,6 @@ namespace llarp::iwp
     void
     RecvFrom(const SockAddr& from, ILinkSession::Packet_t pkt) override;
 
-    bool
-    MapAddr(const RouterID& pk, ILinkSession* s) override;
-
-    void
-    UnmapAddr(const SockAddr& addr);
-
     void
     WakeupPlaintext();
 
@@ -61,7 +55,6 @@ namespace llarp::iwp
     HandleWakeupPlaintext();
 
     const std::shared_ptr<EventLoopWakeup> m_Wakeup;
-    std::unordered_map<SockAddr, RouterID> m_AuthedAddrs;
     std::vector<ILinkSession*> m_WakingUp;
     const bool m_Inbound;
   };

--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -175,8 +175,7 @@ namespace llarp
       if (m_State == State::Closed)
         return;
       auto close_msg = CreatePacket(Command::eCLOS, 0, 16, 16);
-      if (m_State == State::Ready)
-        m_Parent->UnmapAddr(m_RemoteAddr);
+      m_Parent->UnmapAddr(m_RemoteAddr);
       m_State = State::Closed;
       if (m_SentClosed.test_and_set())
         return;

--- a/llarp/link/server.hpp
+++ b/llarp/link/server.hpp
@@ -102,6 +102,9 @@ namespace llarp
     ForEachSession(std::function<void(ILinkSession*)> visit) EXCLUDES(m_AuthedLinksMutex);
 
     void
+    UnmapAddr(const SockAddr& addr);
+
+    void
     SendTo_LL(const SockAddr& to, const llarp_buffer_t& pkt);
 
     virtual bool
@@ -183,7 +186,7 @@ namespace llarp
       return false;
     }
 
-    virtual bool
+    bool
     MapAddr(const RouterID& pk, ILinkSession* s);
 
     void
@@ -255,7 +258,7 @@ namespace llarp
     AuthedLinks m_AuthedLinks GUARDED_BY(m_AuthedLinksMutex);
     mutable DECLARE_LOCK(Mutex_t, m_PendingMutex, ACQUIRED_AFTER(m_AuthedLinksMutex));
     Pending m_Pending GUARDED_BY(m_PendingMutex);
-
+    std::unordered_map<SockAddr, RouterID> m_AuthedAddrs;
     std::unordered_map<SockAddr, llarp_time_t> m_RecentlyClosed;
 
    private:


### PR DESCRIPTION
if a pending inbound session did not complete a handshake after an unclean close from a previous session the
remote udp endpoint would remain stuck mapped as authed and thus any further attempts from the remote would
be silently dropped as it entered a stuck state in the state machine. this was happening as a small part
of the state machine was hidden in the implementation details of iwp, but instead should be in the super type
as it is logic exclusively outside the details which every dialect would have regardless of its details.

this commit will unmap the udp endpoint every time it needs to in the link layer state machine, independat of
the implementation details of the diact.