### PR TITLE
Add -DLOKINET_VERSIONTAG to override version tag

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -1,26 +1,31 @@
 # We do this via a custom command that re-invokes a cmake script because we need the DEPENDS on .git/index so that we will re-run it (to regenerate the commit tag in the version) whenever the current commit changes. If we used a configure_file directly here, it would only re-run when something else causes cmake to re-run.
 
-set(VERSIONTAG "${GIT_VERSION}")
-set(GIT_INDEX_FILE "${PROJECT_SOURCE_DIR}/.git/index")
-find_package(Git)
-if(EXISTS "${GIT_INDEX_FILE}" AND ( GIT_FOUND OR Git_FOUND) )
-  message(STATUS "Found Git: ${GIT_EXECUTABLE}")
-  set(genversion_args "-DGIT=${GIT_EXECUTABLE}")
-  foreach(v lokinet_VERSION lokinet_VERSION_MAJOR lokinet_VERSION_MINOR lokinet_VERSION_PATCH RELEASE_MOTTO)
-    list(APPEND genversion_args "-D${v}=${${v}}")
-  endforeach()
-
-  add_custom_command(
-    OUTPUT            "${CMAKE_CURRENT_BINARY_DIR}/constants/version.cpp"
-    COMMAND           "${CMAKE_COMMAND}"
-                      ${genversion_args}
-                      "-D" "SRC=${CMAKE_CURRENT_SOURCE_DIR}/constants/version.cpp.in"
-                      "-D" "DEST=${CMAKE_CURRENT_BINARY_DIR}/constants/version.cpp"
-                      "-P" "${CMAKE_CURRENT_LIST_DIR}/GenVersion.cmake"
-    DEPENDS           "${CMAKE_CURRENT_SOURCE_DIR}/constants/version.cpp.in"
-                      "${GIT_INDEX_FILE}")
-else()
+if(LOKINET_VERSIONTAG)
+  set(VERSIONTAG "${LOKINET_VERSIONTAG}")
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/constants/version.cpp.in" "${CMAKE_CURRENT_BINARY_DIR}/constants/version.cpp" @ONLY)
+else()
+  set(VERSIONTAG "${GIT_VERSION}")
+  set(GIT_INDEX_FILE "${PROJECT_SOURCE_DIR}/.git/index")
+  find_package(Git)
+  if(EXISTS "${GIT_INDEX_FILE}" AND ( GIT_FOUND OR Git_FOUND) )
+      message(STATUS "Found Git: ${GIT_EXECUTABLE}")
+      set(genversion_args "-DGIT=${GIT_EXECUTABLE}")
+      foreach(v lokinet_VERSION lokinet_VERSION_MAJOR lokinet_VERSION_MINOR lokinet_VERSION_PATCH RELEASE_MOTTO)
+          list(APPEND genversion_args "-D${v}=${${v}}")
+      endforeach()
+
+      add_custom_command(
+          OUTPUT            "${CMAKE_CURRENT_BINARY_DIR}/constants/version.cpp"
+          COMMAND           "${CMAKE_COMMAND}"
+          ${genversion_args}
+          "-D" "SRC=${CMAKE_CURRENT_SOURCE_DIR}/constants/version.cpp.in"
+          "-D" "DEST=${CMAKE_CURRENT_BINARY_DIR}/constants/version.cpp"
+          "-P" "${CMAKE_CURRENT_LIST_DIR}/GenVersion.cmake"
+          DEPENDS           "${CMAKE_CURRENT_SOURCE_DIR}/constants/version.cpp.in"
+          "${GIT_INDEX_FILE}")
+  else()
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/constants/version.cpp.in" "${CMAKE_CURRENT_BINARY_DIR}/constants/version.cpp" @ONLY)
+  endif()
 endif()
 
 


### PR DESCRIPTION
Currently I maintain a patch in the debs to do the same thing here, but
it fails to apply often enough; this change makes the behaviour
consistent with oxen-core/oxen-ss and will let me drop that patch and
just pass in the cmake option.

(Recommend ignore-whitespace for viewing the diff)