### PR TITLE
Show router pubkey at startup

### DIFF
--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -345,7 +345,8 @@ namespace llarp
         try
         {
           _identity = RpcClient()->ObtainIdentityKey();
-          LogWarn("Obtained lokid identity keys");
+          const RouterID pk{pubkey()};
+          LogWarn("Obtained lokid identity key: ", pk);
           break;
         }
         catch (const std::exception& e)


### PR DESCRIPTION
Can help diagnose lokinet/oxend sync issues when reviewing logs.