### PR TITLE
Don't build empty cpp files

### DIFF
--- a/llarp/CMakeLists.txt
+++ b/llarp/CMakeLists.txt
@@ -7,7 +7,6 @@ add_library(lokinet-util
   util/buffer.cpp
   util/fs.cpp
   util/json.cpp
-  util/logging/android_logger.cpp
   util/logging/buffer.cpp
   util/logging/file_logger.cpp
   util/logging/logger.cpp
@@ -15,7 +14,6 @@ add_library(lokinet-util
   util/logging/loglevel.cpp
   util/logging/ostream_logger.cpp
   util/logging/syslog_logger.cpp
-  util/logging/win32_logger.cpp
   util/lokinet_init.c
   util/mem.cpp
   util/printer.cpp
@@ -38,7 +36,10 @@ target_link_libraries(lokinet-util PUBLIC
 )
 
 if(ANDROID)
+  target_sources(lokinet-util PRIVATE util/logging/android_logger.cpp)
   target_link_libraries(lokinet-util PUBLIC log)
+elseif(WIN32)
+  target_sources(lokinet-util PRIVATE util/logging/win32_logger.cpp)
 endif()
 
 add_library(lokinet-platform

--- a/llarp/util/logging/android_logger.cpp
+++ b/llarp/util/logging/android_logger.cpp
@@ -1,5 +1,3 @@
-#if defined(ANDROID)
-
 #include "android_logger.hpp"
 #include "logger_internal.hpp"
 
@@ -69,4 +67,3 @@ namespace llarp
 
   }  // namespace llarp
 }  // namespace llarp
-#endif

--- a/llarp/util/logging/win32_logger.cpp
+++ b/llarp/util/logging/win32_logger.cpp
@@ -1,4 +1,3 @@
-#if defined(_WIN32)
 #include "win32_logger.hpp"
 #include "logger_internal.hpp"
 
@@ -113,4 +112,3 @@ namespace llarp
   }
 
 }  // namespace llarp
-#endif


### PR DESCRIPTION
We shouldn't be compiling these .cpp files at all on other platforms,
rather than compiling empty .cpp files (which later results in "... has
no symbols" warnings).