### PR TITLE
synthesize tcp reject

### DIFF
--- a/llarp/handlers/tun.cpp
+++ b/llarp/handlers/tun.cpp
@@ -1079,9 +1079,9 @@ namespace llarp
           addr = *maybe;
         else
         {
-          // send icmp unreachable as we dont have any exits for this ip
-          if (const auto icmp = pkt.MakeICMPUnreachable())
-            HandleWriteIPPacket(icmp->ConstBuffer(), dst, src, 0);
+          // send rejection as we dont have any exits for this ip
+          if (const auto reply = pkt.MakeReject())
+            HandleWriteIPPacket(reply->ConstBuffer(), dst, src, 0);
 
           return;
         }

--- a/llarp/net/ip_packet.hpp
+++ b/llarp/net/ip_packet.hpp
@@ -253,9 +253,11 @@ namespace llarp::net
     void
     ZeroSourceAddress(std::optional<nuint32_t> flowlabel = std::nullopt);
 
-    /// make an icmp unreachable reply packet based of this ip packet
+    /// make an ip packet that will close or reject whatever upper layer sent it
+    /// makes a tcp rst packet for tcp, otherwise an icmp unreachble packet
+    /// returns nullopt if not implemented or applicable for this packet
     std::optional<IPPacket>
-    MakeICMPUnreachable() const;
+    MakeReject() const;
   };
 
   /// generate ip checksum

--- a/llarp/net/sock_addr.cpp
+++ b/llarp/net/sock_addr.cpp
@@ -16,6 +16,12 @@ namespace llarp
   {
     return memcmp(&lh, &rh, sizeof(in6_addr)) == 0;
   }
+
+  bool
+  operator<(const in6_addr& lh, const in6_addr& rh)
+  {
+    return memcmp(&lh, &rh, sizeof(in6_addr)) < 0;
+  }
   /// shared utility functions
   ///
 
@@ -209,7 +215,8 @@ namespace llarp
   bool
   SockAddr::operator<(const SockAddr& other) const
   {
-    return (m_addr.sin6_addr.s6_addr < other.m_addr.sin6_addr.s6_addr);
+    return (m_addr.sin6_addr < other.m_addr.sin6_addr)
+        or (m_addr.sin6_port < other.m_addr.sin6_port);
   }
 
   bool


### PR DESCRIPTION
send tcp reject for tcp packets when we have no mapped addresses so that the connections close.

when switching the exit on and off we want this to happen so that existing connections will be broken.