### PR TITLE
Remove the initial sink before reconfiguring logging

### DIFF
--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -777,6 +777,7 @@ namespace llarp
 
     if (log::get_level_default() != log::Level::off)
       log::reset_level(conf.logging.m_logLevel);
+    log::clear_sinks();
     log::add_sink(log_type, conf.logging.m_logFile);
 
     return true;


### PR DESCRIPTION
Without this, the original sink set up very early in daemon/lokinet.cpp
(which goes to stderr) is still around, and so we get double logging.