### PR TITLE
consoldiate replay filter

### DIFF
--- a/llarp/path/ihophandler.cpp
+++ b/llarp/path/ihophandler.cpp
@@ -9,10 +9,13 @@ namespace llarp
     bool
     IHopHandler::HandleUpstream(const llarp_buffer_t& X, const TunnelNonce& Y, AbstractRouter* r)
     {
-      auto& pkt = m_UpstreamQueue.emplace_back();
-      pkt.first.resize(X.sz);
-      std::copy_n(X.base, X.sz, pkt.first.begin());
-      pkt.second = Y;
+      if (r->replayFilter().Insert(Y, r->Now()))
+      {
+        auto& pkt = m_UpstreamQueue.emplace_back();
+        pkt.first.resize(X.sz);
+        std::copy_n(X.base, X.sz, pkt.first.begin());
+        pkt.second = Y;
+      }
       r->TriggerPump();
       return true;
     }
@@ -21,19 +24,16 @@ namespace llarp
     bool
     IHopHandler::HandleDownstream(const llarp_buffer_t& X, const TunnelNonce& Y, AbstractRouter* r)
     {
-      auto& pkt = m_DownstreamQueue.emplace_back();
-      pkt.first.resize(X.sz);
-      std::copy_n(X.base, X.sz, pkt.first.begin());
-      pkt.second = Y;
+      if (r->replayFilter().Insert(Y, r->Now()))
+      {
+        auto& pkt = m_DownstreamQueue.emplace_back();
+        pkt.first.resize(X.sz);
+        std::copy_n(X.base, X.sz, pkt.first.begin());
+        pkt.second = Y;
+      }
       r->TriggerPump();
       return true;
     }
 
-    void
-    IHopHandler::DecayFilters(llarp_time_t now)
-    {
-      m_UpstreamReplayFilter.Decay(now);
-      m_DownstreamReplayFilter.Decay(now);
-    }
   }  // namespace path
 }  // namespace llarp

--- a/llarp/path/ihophandler.hpp
+++ b/llarp/path/ihophandler.hpp
@@ -32,9 +32,6 @@ namespace llarp
       virtual PathID_t
       RXID() const = 0;
 
-      void
-      DecayFilters(llarp_time_t now);
-
       virtual bool
       Expired(llarp_time_t now) const = 0;
 
@@ -75,8 +72,6 @@ namespace llarp
       uint64_t m_SequenceNum = 0;
       TrafficQueue_t m_UpstreamQueue;
       TrafficQueue_t m_DownstreamQueue;
-      util::DecayingHashSet<TunnelNonce> m_UpstreamReplayFilter;
-      util::DecayingHashSet<TunnelNonce> m_DownstreamReplayFilter;
 
       virtual void
       UpstreamWork(TrafficQueue_t queue, AbstractRouter* r) = 0;

--- a/llarp/path/path.cpp
+++ b/llarp/path/path.cpp
@@ -66,22 +66,6 @@ namespace llarp
       m_BuiltHook = func;
     }
 
-    bool
-    Path::HandleUpstream(const llarp_buffer_t& X, const TunnelNonce& Y, AbstractRouter* r)
-    {
-      if (not m_UpstreamReplayFilter.Insert(Y))
-        return false;
-      return IHopHandler::HandleUpstream(X, Y, r);
-    }
-
-    bool
-    Path::HandleDownstream(const llarp_buffer_t& X, const TunnelNonce& Y, AbstractRouter* r)
-    {
-      if (not m_DownstreamReplayFilter.Insert(Y))
-        return false;
-      return IHopHandler::HandleDownstream(X, Y, r);
-    }
-
     RouterID
     Path::Endpoint() const
     {
@@ -359,8 +343,6 @@ namespace llarp
           {"ready", IsReady()},
           {"txRateCurrent", m_LastTXRate},
           {"rxRateCurrent", m_LastRXRate},
-          {"replayTX", m_UpstreamReplayFilter.Size()},
-          {"replayRX", m_DownstreamReplayFilter.Size()},
           {"hasExit", SupportsAnyRoles(ePathRoleExit)}};
 
       std::vector<util::StatusObject> hopsObj;

--- a/llarp/path/path.hpp
+++ b/llarp/path/path.hpp
@@ -201,14 +201,6 @@ namespace llarp
         return _status;
       }
 
-      // handle data in upstream direction
-      bool
-      HandleUpstream(const llarp_buffer_t& X, const TunnelNonce& Y, AbstractRouter*) override;
-      // handle data in downstream direction
-
-      bool
-      HandleDownstream(const llarp_buffer_t& X, const TunnelNonce& Y, AbstractRouter*) override;
-
       const std::string&
       ShortName() const;
 

--- a/llarp/path/path_context.cpp
+++ b/llarp/path/path_context.cpp
@@ -362,10 +362,7 @@ namespace llarp
             itr = map.erase(itr);
           }
           else
-          {
-            itr->second->DecayFilters(now);
             ++itr;
-          }
         }
       }
       {
@@ -379,10 +376,7 @@ namespace llarp
             itr = map.erase(itr);
           }
           else
-          {
-            itr->second->DecayFilters(now);
             ++itr;
-          }
         }
       }
     }

--- a/llarp/router/abstractrouter.hpp
+++ b/llarp/router/abstractrouter.hpp
@@ -182,6 +182,9 @@ namespace llarp
     virtual I_RCLookupHandler&
     rcLookupHandler() = 0;
 
+    virtual util::DecayingHashSet<TunnelNonce>&
+    replayFilter() = 0;
+
     virtual std::shared_ptr<PeerDb>
     peerDb() = 0;
 

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -1101,6 +1101,8 @@ namespace llarp
         [&peersWeHave](const dht::Key_t& k) -> bool { return peersWeHave.count(k) == 0; });
     // expire paths
     paths.ExpirePaths(now);
+    // clear replay filter
+    _replayFilter.Decay(now);
     // update tick timestamp
     _lastTick = llarp::time_now_ms();
   }
@@ -1259,6 +1261,10 @@ namespace llarp
         _rc.addrs.push_back(ai);
       }
     });
+
+    // if we are a service node we will not use a replay filter for path traffic to reduce memory
+    // usage on runtime
+    _replayFilter.nop = IsServiceNode();
 
     if (ExitEnabled() and IsServiceNode())
     {

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -277,6 +277,14 @@ namespace llarp
     /// bootstrap RCs
     BootstrapList bootstrapRCList;
 
+    util::DecayingHashSet<TunnelNonce> _replayFilter{500ms};
+
+    util::DecayingHashSet<TunnelNonce>&
+    replayFilter() override
+    {
+      return _replayFilter;
+    }
+
     bool
     ExitEnabled() const
     {

--- a/llarp/util/decaying_hashset.hpp
+++ b/llarp/util/decaying_hashset.hpp
@@ -12,6 +12,8 @@ namespace llarp
     {
       using Time_t = std::chrono::milliseconds;
 
+      bool nop{false};
+
       DecayingHashSet(Time_t cacheInterval = 1s) : m_CacheInterval(cacheInterval)
       {}
 
@@ -33,6 +35,8 @@ namespace llarp
       bool
       Insert(const Val_t& v, Time_t now = 0s)
       {
+        if (nop)
+          return true;
         if (now == 0s)
           now = llarp::time_now_ms();
         return m_Values.try_emplace(v, now).second;

--- a/llarp/util/decaying_hashset.hpp
+++ b/llarp/util/decaying_hashset.hpp
@@ -55,7 +55,11 @@ namespace llarp
       {
         if (now == 0s)
           now = llarp::time_now_ms();
+        auto before = m_Values.size();
         EraseIf([&](const auto& item) { return (m_CacheInterval + item.second) <= now; });
+        auto after = m_Values.size();
+        if(before > after)
+            m_Values.reserve(after);
       }
 
       Time_t

--- a/llarp/util/time.hpp
+++ b/llarp/util/time.hpp
@@ -29,6 +29,13 @@ namespace llarp
   struct time_delta
   {
     const TimePoint_t at;
+
+    /// get the time delta between this time point and now
+    auto
+    delta() const
+    {
+      return std::chrono::duration_cast<Time_Duration>(llarp::TimePoint_t::clock::now() - at);
+    }
   };
 }  // namespace llarp
 
@@ -41,8 +48,7 @@ namespace fmt
     auto
     format(const llarp::time_delta<Time_Duration>& td, FormatContext& ctx)
     {
-      const auto dlt =
-          std::chrono::duration_cast<llarp::Duration_t>(llarp::TimePoint_t::clock::now() - td.at);
+      const auto dlt = td.delta();
       using Parent = formatter<std::string>;
       if (dlt > 0s)
         return Parent::format(fmt::format("{} ago", dlt), ctx);


### PR DESCRIPTION
use one per context replay filter for path traffic instead of every path having its own replay filter

reduces memory usage, and heap thrashing, and cpu.
