### PR TITLE
bundle consensus info into RC

### DIFF
--- a/llarp/constants/proto.hpp
+++ b/llarp/constants/proto.hpp
@@ -1,9 +1,16 @@
 #pragma once
+#include <chrono>
 
 namespace llarp::constants
 {
   /// current network wide protocol version
   // TODO: enum class
   constexpr auto proto_version = 0;
+
+  /// current router contact format version
+  constexpr auto rc_version = 1;
+
+  /// average time between blocks from backend
+  constexpr auto block_interval = std::chrono::minutes{2};
 
 }  // namespace llarp::constants

--- a/llarp/crypto/crypto.hpp
+++ b/llarp/crypto/crypto.hpp
@@ -142,15 +142,7 @@ namespace llarp
     static Crypto*
     instance()
     {
-#ifdef NDEBUG
       return m_crypto;
-#else
-      if (m_crypto)
-        return m_crypto;
-
-      assert(false && "Cryptomanager::instance() was undefined");
-      abort();
-#endif
     }
   };
 

--- a/llarp/router/abstractrouter.hpp
+++ b/llarp/router/abstractrouter.hpp
@@ -3,7 +3,7 @@
 #include <llarp/config/config.hpp>
 #include <llarp/config/key_manager.hpp>
 #include <memory>
-#include <llarp/util/types.hpp>
+#include <llarp/util/time.hpp>
 #include <llarp/util/status.hpp>
 #include "i_outbound_message_handler.hpp"
 #include <vector>
@@ -130,6 +130,10 @@ namespace llarp
     /// published out
     virtual void
     ModifyOurRC(std::function<std::optional<RouterContact>(RouterContact)> modify) = 0;
+
+    /// mark that think we will be invalid in the future, or nullopt to reset this to normal
+    virtual void
+    InvalidAt(std::optional<llarp::TimePoint_t> maybe_future_time) = 0;
 
     virtual exit::Context&
     exitContext() = 0;

--- a/llarp/router/i_rc_lookup_handler.hpp
+++ b/llarp/router/i_rc_lookup_handler.hpp
@@ -68,6 +68,9 @@ namespace llarp
 
     virtual bool
     HaveReceivedWhitelist() const = 0;
+
+    virtual bool
+    UseWhitelist() const = 0;
   };
 
 }  // namespace llarp

--- a/llarp/router/rc_lookup_handler.cpp
+++ b/llarp/router/rc_lookup_handler.cpp
@@ -124,6 +124,12 @@ namespace llarp
   }
 
   bool
+  RCLookupHandler::UseWhitelist() const
+  {
+    return useWhitelist;
+  }
+
+  bool
   RCLookupHandler::IsGreylisted(const RouterID& remote) const
   {
     if (_strictConnectPubkeys.size() && _strictConnectPubkeys.count(remote) == 0

--- a/llarp/router/rc_lookup_handler.hpp
+++ b/llarp/router/rc_lookup_handler.hpp
@@ -48,6 +48,9 @@ namespace llarp
     bool
     HaveReceivedWhitelist() const override;
 
+    bool
+    UseWhitelist() const override;
+
     void
     GetRC(const RouterID& router, RCRequestCallback callback, bool forceLookup = false) override
         EXCLUDES(_mutex);

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -142,6 +142,9 @@ namespace llarp
     ModifyOurRC(std::function<std::optional<RouterContact>(RouterContact)> modify) override;
 
     void
+    InvalidAt(std::optional<llarp::TimePoint_t> maybe_future_time) override;
+
+    void
     SetRouterWhitelist(
         const std::vector<RouterID>& whitelist, const std::vector<RouterID>& greylist) override;
 
@@ -323,10 +326,7 @@ namespace llarp
     RCLookupHandler _rcLookupHandler;
     RCGossiper _rcGossiper;
 
-    using Clock_t = std::chrono::steady_clock;
-    using TimePoint_t = Clock_t::time_point;
-
-    TimePoint_t m_NextExploreAt;
+    std::chrono::steady_clock::time_point m_NextExploreAt;
 
     IOutboundMessageHandler&
     outboundMessageHandler() override

--- a/llarp/router_contact.hpp
+++ b/llarp/router_contact.hpp
@@ -7,6 +7,7 @@
 #include "llarp/util/aligned.hpp"
 #include "llarp/util/bencode.hpp"
 #include "llarp/util/status.hpp"
+#include "llarp/util/time.hpp"
 #include "router_version.hpp"
 
 #include "llarp/dns/srv_data.hpp"
@@ -87,7 +88,11 @@ namespace llarp
     llarp::AlignedBuffer<NICKLEN> nickname;
 
     llarp_time_t last_updated = 0s;
-    uint64_t version = llarp::constants::proto_version;
+
+    /// an optional time point they think they will be invalid at
+    std::optional<TimePoint_t> invalid_at;
+
+    uint64_t version = llarp::constants::rc_version;
     std::optional<RouterVersion> routerVersion;
     /// should we serialize the exit info?
     const static bool serializeExit = true;
@@ -98,6 +103,14 @@ namespace llarp
 
     util::StatusObject
     ExtractStatus() const;
+
+    /// get the time this was last updated as a time point
+    template <typename resolution_t = std::chrono::milliseconds>
+    auto
+    last_updated_at() const
+    {
+      return to_time_point<resolution_t>(last_updated);
+    }
 
     nlohmann::json
     ToJson() const

--- a/llarp/rpc/lokid_rpc_client.hpp
+++ b/llarp/rpc/lokid_rpc_client.hpp
@@ -58,6 +58,9 @@ namespace llarp
       void
       UpdateServiceNodeList();
 
+      void
+      UpdateSelfInfo();
+
       template <typename HandlerFunc_t, typename Args_t>
       void
       Request(std::string_view cmd, HandlerFunc_t func, const Args_t& args)
@@ -88,6 +91,7 @@ namespace llarp
 
       std::weak_ptr<AbstractRouter> m_Router;
       std::atomic<bool> m_UpdatingList;
+      std::atomic<bool> m_UpdatingSelfInfo;
 
       std::unordered_map<RouterID, PubKey> m_KeyMap;
 

--- a/llarp/util/buffer.hpp
+++ b/llarp/util/buffer.hpp
@@ -129,6 +129,14 @@ struct llarp_buffer_t
     return base + sz;
   }
 
+  inline void
+  advance(size_t n)
+  {
+    if (size_left() < n)
+      throw std::range_error{"cannot advance buffer out of range"};
+    cur += n;
+  }
+
   size_t
   size_left() const;
 

--- a/llarp/util/time.cpp
+++ b/llarp/util/time.cpp
@@ -6,24 +6,20 @@ namespace llarp
 {
   namespace
   {
-    using Clock_t = std::chrono::system_clock;
-
-    template <typename Res, typename Clock>
-    static Duration_t
-    time_since_epoch(std::chrono::time_point<Clock> point)
-    {
-      return std::chrono::duration_cast<Res>(point.time_since_epoch());
-    }
-
-    const static auto started_at_system = Clock_t::now();
-
     const static auto started_at_steady = std::chrono::steady_clock::now();
+    const static auto started_at_system = DateClock_t::now();
   }  // namespace
 
   uint64_t
   ToMS(Duration_t ms)
   {
     return ms.count();
+  }
+
+  uint64_t
+  to_unix_stamp(const TimePoint_t& t)
+  {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(t.time_since_epoch()).count();
   }
 
   /// get our uptime in ms
@@ -34,14 +30,10 @@ namespace llarp
         std::chrono::steady_clock::now() - started_at_steady);
   }
 
-  Duration_t
-  time_now_ms()
+  TimePoint_t
+  started_at()
   {
-    auto t = uptime();
-#ifdef TESTNET_SPEED
-    t /= uint64_t{TESTNET_SPEED};
-#endif
-    return t + time_since_epoch<Duration_t, Clock_t>(started_at_system);
+    return started_at_system;
   }
 
   nlohmann::json

--- a/llarp/util/types.hpp
+++ b/llarp/util/types.hpp
@@ -11,10 +11,6 @@ namespace llarp
   using Duration_t = std::chrono::milliseconds;
   using namespace std::literals;
 
-  /// convert to milliseconds
-  uint64_t
-  ToMS(Duration_t duration);
-
   using DateClock_t = std::chrono::system_clock;
   using TimePoint_t = DateClock_t::time_point;
 }  // namespace llarp

--- a/test/test_llarp_router_contact.cpp
+++ b/test/test_llarp_router_contact.cpp
@@ -9,118 +9,124 @@
 namespace
 {
   llarp::sodium::CryptoLibSodium crypto;
-  llarp::CryptoManager cmanager(&crypto);
 }
 
 namespace llarp
 {
+  TEST_CASE("RouterContact Sign and Verify", "[RC][RouterContact][signature][sign][verify]")
+  {
+    llarp::CryptoManager _m{&crypto};
+    auto* m = llarp::CryptoManager::instance();
+    RouterContact rc;
 
-TEST_CASE("RouterContact Sign and Verify", "[RC][RouterContact][signature][sign][verify]")
-{
-  RouterContact rc;
+    SecretKey sign;
+    m->identity_keygen(sign);
 
-  SecretKey sign;
-  cmanager.instance()->identity_keygen(sign);
+    SecretKey encr;
+    m->encryption_keygen(encr);
 
-  SecretKey encr;
-  cmanager.instance()->encryption_keygen(encr);
+    rc.enckey = encr.toPublic();
+    rc.pubkey = sign.toPublic();
 
-  rc.enckey = encr.toPublic();
-  rc.pubkey = sign.toPublic();
+    REQUIRE(rc.Sign(sign));
+    REQUIRE(rc.Verify(time_now_ms()));
+  }
 
-  REQUIRE(rc.Sign(sign));
-  REQUIRE(rc.Verify(time_now_ms()));
-}
+  TEST_CASE("RouterContact Decode Version 1", "[RC][RouterContact][V1]")
+  {
+    llarp::CryptoManager _m{&crypto};
+    auto* m = llarp::CryptoManager::instance();
 
-TEST_CASE("RouterContact Decode Version 1", "[RC][RouterContact][V1]")
-{
-  RouterContact rc;
+    RouterContact rc;
 
-  SecretKey sign;
-  cmanager.instance()->identity_keygen(sign);
+    SecretKey sign;
+    m->identity_keygen(sign);
 
-  SecretKey encr;
-  cmanager.instance()->encryption_keygen(encr);
+    SecretKey encr;
+    m->encryption_keygen(encr);
 
-  rc.version = 1;
+    rc.version = 1;
 
-  rc.enckey = encr.toPublic();
-  rc.pubkey = sign.toPublic();
+    rc.enckey = encr.toPublic();
+    rc.pubkey = sign.toPublic();
 
-  REQUIRE(rc.Sign(sign));
+    REQUIRE(rc.Sign(sign));
 
-  std::array<byte_t, 5000> encoded_buffer;
-  llarp_buffer_t encoded_llarp(encoded_buffer);
+    std::array<byte_t, 5000> encoded_buffer;
+    llarp_buffer_t encoded_llarp(encoded_buffer);
 
-  rc.BEncode(&encoded_llarp);
+    rc.BEncode(&encoded_llarp);
 
-  encoded_llarp.sz = encoded_llarp.cur - encoded_llarp.base;
-  encoded_llarp.cur = encoded_llarp.base;
+    encoded_llarp.sz = encoded_llarp.cur - encoded_llarp.base;
+    encoded_llarp.cur = encoded_llarp.base;
 
-  RouterContact decoded_rc;
+    RouterContact decoded_rc{};
 
-  REQUIRE(decoded_rc.BDecode(&encoded_llarp));
+    REQUIRE(decoded_rc.BDecode(&encoded_llarp));
 
-  REQUIRE(decoded_rc.Verify(time_now_ms()));
+    REQUIRE(decoded_rc.Verify(time_now_ms()));
 
-  REQUIRE(decoded_rc == rc);
-}
+    REQUIRE(decoded_rc == rc);
+  }
 
-TEST_CASE("RouterContact Decode Mixed Versions", "[RC][RouterContact]")
-{
-  RouterContact rc1, rc2, rc3, rc4;
+  TEST_CASE("RouterContact Decode Mixed Versions", "[RC][RouterContact]")
+  {
+    llarp::CryptoManager _m{&crypto};
+    auto* m = llarp::CryptoManager::instance();
 
-  rc1.version = 0;
-  rc2.version = 1;
-  rc3.version = 0;
-  rc4.version = 1;
+    RouterContact rc1, rc2, rc3, rc4;
 
-  SecretKey sign1, sign2, sign3, sign4;
-  cmanager.instance()->identity_keygen(sign1);
-  cmanager.instance()->identity_keygen(sign2);
-  cmanager.instance()->identity_keygen(sign3);
-  cmanager.instance()->identity_keygen(sign4);
+    rc1.version = 0;
+    rc2.version = 1;
+    rc3.version = 0;
+    rc4.version = 1;
 
-  SecretKey encr1, encr2, encr3, encr4;
-  cmanager.instance()->encryption_keygen(encr1);
-  cmanager.instance()->encryption_keygen(encr2);
-  cmanager.instance()->encryption_keygen(encr3);
-  cmanager.instance()->encryption_keygen(encr4);
+    SecretKey sign1, sign2, sign3, sign4;
+    m->identity_keygen(sign1);
+    m->identity_keygen(sign2);
+    m->identity_keygen(sign3);
+    m->identity_keygen(sign4);
 
-  rc1.enckey = encr1.toPublic();
-  rc2.enckey = encr2.toPublic();
-  rc3.enckey = encr3.toPublic();
-  rc4.enckey = encr4.toPublic();
-  rc1.pubkey = sign1.toPublic();
-  rc2.pubkey = sign2.toPublic();
-  rc3.pubkey = sign3.toPublic();
-  rc4.pubkey = sign4.toPublic();
+    SecretKey encr1, encr2, encr3, encr4;
+    m->encryption_keygen(encr1);
+    m->encryption_keygen(encr2);
+    m->encryption_keygen(encr3);
+    m->encryption_keygen(encr4);
 
-  REQUIRE(rc1.Sign(sign1));
-  REQUIRE(rc2.Sign(sign2));
-  REQUIRE(rc3.Sign(sign3));
-  REQUIRE(rc4.Sign(sign4));
+    rc1.enckey = encr1.toPublic();
+    rc2.enckey = encr2.toPublic();
+    rc3.enckey = encr3.toPublic();
+    rc4.enckey = encr4.toPublic();
+    rc1.pubkey = sign1.toPublic();
+    rc2.pubkey = sign2.toPublic();
+    rc3.pubkey = sign3.toPublic();
+    rc4.pubkey = sign4.toPublic();
 
-  std::vector<RouterContact> rc_vec;
-  rc_vec.push_back(rc1);
-  rc_vec.push_back(rc2);
-  rc_vec.push_back(rc3);
-  rc_vec.push_back(rc4);
+    REQUIRE(rc1.Sign(sign1));
+    REQUIRE(rc2.Sign(sign2));
+    REQUIRE(rc3.Sign(sign3));
+    REQUIRE(rc4.Sign(sign4));
 
-  std::array<byte_t, 20000> encoded_buffer;
-  llarp_buffer_t encoded_llarp(encoded_buffer);
+    std::vector<RouterContact> rc_vec;
+    rc_vec.push_back(rc1);
+    rc_vec.push_back(rc2);
+    rc_vec.push_back(rc3);
+    rc_vec.push_back(rc4);
 
-  BEncodeWriteList(rc_vec.begin(), rc_vec.end(), &encoded_llarp);
-  encoded_llarp.sz = encoded_llarp.cur - encoded_llarp.base;
-  encoded_llarp.cur = encoded_llarp.base;
+    std::array<byte_t, 20000> encoded_buffer;
+    llarp_buffer_t encoded_llarp(encoded_buffer);
 
-  std::vector<RouterContact> rc_vec_out;
+    BEncodeWriteList(rc_vec.begin(), rc_vec.end(), &encoded_llarp);
+    encoded_llarp.sz = encoded_llarp.cur - encoded_llarp.base;
+    encoded_llarp.cur = encoded_llarp.base;
 
-  BEncodeReadList(rc_vec_out, &encoded_llarp);
+    std::vector<RouterContact> rc_vec_out;
 
-  REQUIRE(rc_vec.size() == rc_vec_out.size());
-  for (size_t i=0; i<4; i++)
-    REQUIRE(rc_vec[i] == rc_vec_out[i]);
-}
+    BEncodeReadList(rc_vec_out, &encoded_llarp);
 
-} // namespace llarp
+    REQUIRE(rc_vec.size() == rc_vec_out.size());
+    for (size_t i = 0; i < 4; i++)
+      REQUIRE(rc_vec[i] == rc_vec_out[i]);
+  }
+
+}  // namespace llarp


### PR DESCRIPTION
when we think we are going to become an invalid service node (e.g. stake unlock) put the estimated timestamp of when when think it will happen into the RC.

* add time and duration helpers
* make time interally use time points not unix stamps
* fix up unit tests to be a bit cleaner when using cryptomanager
* Router::ModifyOurRC able to be called from any thread by making it interally use EventLoop::call
* add AbstractRouter::InvalidAt to set and unset when our RC is going to be invalid and republish as needed


fixes #1960 