### PR TITLE
Lokinet vpn cleanups

### DIFF
--- a/llarp/nodedb.cpp
+++ b/llarp/nodedb.cpp
@@ -21,6 +21,8 @@ static const std::string RC_FILE_EXT = ".signed";
 
 namespace llarp
 {
+  static auto logcat = log::Cat("nodedb");
+
   NodeDB::Entry::Entry(RouterContact value) : rc(std::move(value)), insertedAt(llarp::time_now_ms())
   {}
 
@@ -160,7 +162,7 @@ namespace llarp
 
     if (not purge.empty())
     {
-      LogWarn("removing {} invalid RC from disk", purge.size());
+      log::warning(logcat, "removing {} invalid RCs from disk", purge.size());
 
       for (const auto& fpath : purge)
         fs::remove(fpath);

--- a/llarp/rpc/rpc_server.cpp
+++ b/llarp/rpc/rpc_server.cpp
@@ -469,7 +469,7 @@ namespace llarp::rpc
                   map = false;
                 }
                 const auto range_itr = obj.find("range");
-                if (range_itr == obj.end())
+                if (range_itr == obj.end() or range_itr->is_null())
                 {
                   // platforms without ipv6 support will shit themselves
                   // here if we give them an exit mapping that is ipv6
@@ -492,9 +492,9 @@ namespace llarp::rpc
                   reply(CreateJSONError("ipv6 ranges not supported on this platform"));
                   return;
                 }
-                std::optional<std::string> token;
+                std::string token;
                 const auto token_itr = obj.find("token");
-                if (token_itr != obj.end())
+                if (token_itr != obj.end() and not token_itr->is_null())
                 {
                   token = token_itr->get<std::string>();
                 }
@@ -518,10 +518,10 @@ namespace llarp::rpc
                       ep->MapExitRange(range, addr);
 
                       bool shouldSendAuth = false;
-                      if (token.has_value())
+                      if (not token.empty())
                       {
                         shouldSendAuth = true;
-                        ep->SetAuthInfoForEndpoint(*exit, service::AuthInfo{*token});
+                        ep->SetAuthInfoForEndpoint(*exit, service::AuthInfo{token});
                       }
                       auto onGoodResult = [r, reply](std::string reason) {
                         if (r->HasClientExit())


### PR DESCRIPTION
Relax rpc handling of token and range:
- Accept empty string or `null` for token to mean "no token."
- Accept `null` for range to mean "default range."
- Don't use a default range (::0/0) in lokinet-vpn because this will fail if IPv6 ranges aren't supported on the platform (e.g. on Windows), and isn't necessary: if we omit it then the rpc code already uses ::0/0 or 0.0.0.0/0 by default, as needed.

Various lokinet-vpn cleanups:
- rename LMQ to OMQ
- Add a function to extract a value from parsed options, to DRY out the argument parsing code a little bit.
- Add a exit_error function to format a message to stdout and then return the code, to simplify the repeated print-and-return code used when errors occur.
- Use fmt for output formatting
- Add an error if multiple modes are specified at once (--up/--down/--status/--exit)
- Add error printing around unmap RPC request