### PR TITLE
Add more logging around route poking conditions

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -13,7 +13,6 @@ local default_deps_base = [
 ];
 local default_deps_nocxx = ['libsodium-dev'] + default_deps_base;  // libsodium-dev needs to be >= 1.0.18
 local default_deps = ['g++'] + default_deps_nocxx;
-local default_windows_deps = ['mingw-w64', 'zip', 'nsis'];
 local docker_base = 'registry.oxen.rocks/lokinet-ci-';
 
 local submodule_commands = [
@@ -147,7 +146,7 @@ local windows_cross_pipeline(name,
         'echo "man-db man-db/auto-update boolean false" | debconf-set-selections',
         apt_get_quiet + ' update',
         apt_get_quiet + ' install -y eatmydata',
-        'eatmydata ' + apt_get_quiet + ' install --no-install-recommends -y p7zip-full build-essential cmake git pkg-config ccache g++-mingw-w64-x86-64-posix nsis zip automake libtool',
+        'eatmydata ' + apt_get_quiet + ' install --no-install-recommends -y p7zip-full build-essential cmake git pkg-config ccache g++-mingw-w64-x86-64-posix nsis zip icoutils automake libtool',
         'update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix',
         'update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix',
         'JOBS=' + jobs + ' VERBOSE=1 ./contrib/windows.sh -DSTRIP_SYMBOLS=ON ' +

--- a/cmake/macos.cmake
+++ b/cmake/macos.cmake
@@ -127,7 +127,7 @@ endif()
 set(mac_icon "${PROJECT_BINARY_DIR}/lokinet.icns")
 add_custom_command(OUTPUT "${mac_icon}"
   COMMAND ${PROJECT_SOURCE_DIR}/contrib/macos/mk-icns.sh ${PROJECT_SOURCE_DIR}/contrib/lokinet-mac.svg "${mac_icon}"
-  DEPENDS ${PROJECT_SOURCE_DIR}/contrib/lokinet.svg ${PROJECT_SOURCE_DIR}/contrib/macos/mk-icns.sh)
+  DEPENDS ${PROJECT_SOURCE_DIR}/contrib/lokinet-mac.svg ${PROJECT_SOURCE_DIR}/contrib/macos/mk-icns.sh)
 add_custom_target(icon DEPENDS "${mac_icon}")
 
 if(BUILD_PACKAGE)

--- a/cmake/win32_installer_deps.cmake
+++ b/cmake/win32_installer_deps.cmake
@@ -32,8 +32,14 @@ endif()
 set(BOOTSTRAP_FILE "${PROJECT_SOURCE_DIR}/contrib/bootstrap/mainnet.signed")
 install(FILES ${BOOTSTRAP_FILE} DESTINATION share COMPONENT lokinet RENAME bootstrap.signed)
 
+set(win_ico "${PROJECT_BINARY_DIR}/lokinet.ico")
+add_custom_command(OUTPUT "${win_ico}"
+  COMMAND ${PROJECT_SOURCE_DIR}/contrib/make-ico.sh ${PROJECT_SOURCE_DIR}/contrib/lokinet.svg "${win_ico}"
+  DEPENDS ${PROJECT_SOURCE_DIR}/contrib/lokinet.svg ${PROJECT_SOURCE_DIR}/contrib/make-ico.sh)
+add_custom_target(icon ALL DEPENDS "${win_ico}")
+
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "Lokinet")
-set(CPACK_NSIS_MUI_ICON "${CMAKE_SOURCE_DIR}/win32-setup/lokinet.ico")
+set(CPACK_NSIS_MUI_ICON "${PROJECT_BINARY_DIR}/lokinet.ico")
 set(CPACK_NSIS_DEFINES "RequestExecutionLevel admin")
 set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
 

--- a/contrib/lokinet-mac.svg
+++ b/contrib/lokinet-mac.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="-512px" y="-512px"
 	 viewBox="-512 -512 1024 1024" style="enable-background:new -512 -512 1024 1024;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#FFFFFF;}
+	.bg{fill:#FFFFFF;}
 </style>
 
 <!--
@@ -11,7 +11,7 @@
     (but not all the way to 512, because we want some padding around the outside.
 -->
 <g transform="scale(415)">
-    <path class="st0" d="
+    <path class="bg" d="
         M 0.5 1
         H -0.5
         C -0.81,1 -1,0.81 -1,0.5

--- a/contrib/lokinet.svg
+++ b/contrib/lokinet.svg
@@ -1,21 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 189.4 189.4" style="enable-background:new 0 0 189.4 189.4;" xml:space="preserve">
+<!-- our size/viewbox is positioned such that 0,0 is the center of the image (to simplify scaling and rotation). -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="-512px" y="-512px"
+	 viewBox="-512 -512 1024 1024" style="enable-background:new -512 -512 1024 1024;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#FFFFFF;}
+	.bg{fill:#FFFFFF;}
 </style>
-<g>
-	<polygon class="st0" points="113.6,132.6 94.7,151.5 75.8,132.6 56.8,151.5 94.7,189.4 132.6,151.5 	"/>
-	<polygon class="st0" points="132.6,113.6 151.5,94.7 132.6,75.8 151.5,56.8 189.4,94.7 151.5,132.6 	"/>
-	<polygon class="st0" points="56.8,75.8 37.9,94.7 56.8,113.6 37.9,132.6 0,94.7 37.9,56.8 	"/>
-	<polygon class="st0" points="75.8,56.8 94.7,37.9 113.6,56.8 132.6,37.9 94.7,0 56.8,37.9 	"/>
-	
-		<rect x="100.2" y="100.2" transform="matrix(0.7071 0.7071 -0.7071 0.7071 113.6329 -47.0683)" class="st0" width="26.8" height="26.8"/>
-	
-		<rect x="62.4" y="62.4" transform="matrix(0.7071 0.7071 -0.7071 0.7071 75.7552 -31.3789)" class="st0" width="26.8" height="26.8"/>
-	
-		<rect x="100.2" y="62.4" transform="matrix(0.7071 0.7071 -0.7071 0.7071 86.8493 -58.1624)" class="st0" width="26.8" height="26.8"/>
-	
-		<rect x="62.4" y="100.2" transform="matrix(0.7071 0.7071 -0.7071 0.7071 102.5388 -20.2848)" class="st0" width="26.8" height="26.8"/>
+
+<!--
+    Draw the background shape in a 2x2 box (from -1 to 1 in each dimension), then scale it up
+    (but not all the way to 512, because we want some padding around the outside.
+-->
+<g transform="scale(512)">
+  <circle r="1" class="bg"/>
 </g>
+
+<g id="shape0">
+  <!--
+    Start with a simple 3x2 shape, where each unit we draw corresponds to 1 block edge length in the
+    final diagram, and shift it so that 2.5x2.5 becomes the new origin (around which we will rotate).
+    Then we rotate and scale it to the desired size.
+
+    We can then copy that at 90, 180, 270 degree rotations to complete the logo.
+    -->
+  <g transform="rotate(45) scale(105) translate(-2.5, -2.5)">
+    <polygon points="0,0 2,0 2,1 1,1 1,2 0,2"/>
+    <rect x="1" y="2" width="1" height="1"/>
+  </g>
+</g>
+
+<use xlink:href="#shape0" transform="rotate(90)"/>
+<use xlink:href="#shape0" transform="rotate(180)"/>
+<use xlink:href="#shape0" transform="rotate(270)"/>
 </svg>

--- a/contrib/make-ico.sh
+++ b/contrib/make-ico.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Invoked from cmake as make-ico.sh /path/to/icon.svg /path/to/output.ico
+svg="$1"
+out="$2"
+outdir="$out.d"
+
+set -e
+
+sizes=(16 24 32 40 48 64 96 192 256)
+outs=""
+
+mkdir -p "${outdir}"
+for size in "${sizes[@]}"; do
+    outf="${outdir}/${size}x${size}.png"
+    if [ $size -lt 32 ]; then
+        # For 16x16 and 24x24 we crop the image to 3/4 of its regular size before resizing and make
+        # it all white (instead of transparent) which effectively zooms in on it a bit because if we
+        # resize the full icon it ends up a fuzzy mess, while the crop and resize lets us retain
+        # some detail of the logo.
+        convert -background white -resize 512x512 "$svg" -gravity Center -extent 320x320 -resize ${size}x${size} -strip "png32:$outf"
+    else
+        convert -background transparent -resize ${size}x${size} "$svg" -strip "png32:$outf"
+    fi
+    outs="-r $outf $outs"
+done
+
+icotool -c -b 32 -o "$out" $outs

--- a/llarp/CMakeLists.txt
+++ b/llarp/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(lokinet-platform
   # for networking
   ev/ev.cpp
   ev/libuv.cpp
+  net/interface_info.cpp
   net/ip.cpp
   net/ip_address.cpp
   net/ip_packet.cpp

--- a/llarp/net/interface_info.cpp
+++ b/llarp/net/interface_info.cpp
@@ -10,6 +10,6 @@ namespace llarp::net
         name,
         index,
         fmt::join(addrs, ","),
-        gateway ? fmt::format("{}", *gateway) : "none");
+        gateway ? net::ToString(*gateway) : "none");
   }
 }  // namespace llarp::net

--- a/llarp/net/interface_info.cpp
+++ b/llarp/net/interface_info.cpp
@@ -1,0 +1,15 @@
+#include "interface_info.hpp"
+
+namespace llarp::net
+{
+  std::string
+  InterfaceInfo::ToString() const
+  {
+    return fmt::format(
+        "{}[i={}; addrs={}; gw={}]",
+        name,
+        index,
+        fmt::join(addrs, ","),
+        gateway ? fmt::format("{}", *gateway) : "none");
+  }
+}  // namespace llarp::net

--- a/llarp/net/interface_info.hpp
+++ b/llarp/net/interface_info.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
+#include <llarp/util/formattable.hpp>
 #include "ip_range.hpp"
 
 namespace llarp::net
@@ -17,5 +19,11 @@ namespace llarp::net
     std::vector<IPRange> addrs;
     /// a gateway we can use if it exists
     std::optional<ipaddr_t> gateway;
+
+    std::string
+    ToString() const;
   };
 }  // namespace llarp::net
+
+template <>
+inline constexpr bool llarp::IsToStringFormattable<llarp::net::InterfaceInfo> = true;

--- a/llarp/net/ip_range.cpp
+++ b/llarp/net/ip_range.cpp
@@ -101,4 +101,25 @@ namespace llarp
     return netmask_bits.ToString();
   }
 
+  std::optional<IPRange>
+  IPRange::FindPrivateRange(const std::list<IPRange>& excluding)
+  {
+    auto good = [&excluding](const IPRange& range) -> bool {
+      for (const auto& ex : excluding)
+        if (ex * range)
+          return false;
+      return true;
+    };
+    for (int oct = 16; oct <= 31; ++oct)
+      if (auto range = IPRange::FromIPv4(172, oct, 0, 1, 16); good(range))
+        return range;
+    for (int oct = 0; oct <= 255; ++oct)
+      if (auto range = IPRange::FromIPv4(10, oct, 0, 1, 16); good(range))
+        return range;
+    for (int oct = 0; oct <= 255; ++oct)
+      if (auto range = IPRange::FromIPv4(192, 168, oct, 1, 24); good(range))
+        return range;
+    return std::nullopt;
+  }
+
 }  // namespace llarp

--- a/llarp/net/ip_range.hpp
+++ b/llarp/net/ip_range.hpp
@@ -1,10 +1,13 @@
 #pragma once
-#include <ostream>
+
 #include "ip.hpp"
 #include "net_bits.hpp"
 #include <llarp/util/bits.hpp>
 #include <llarp/util/buffer.hpp>
 #include <llarp/util/types.hpp>
+
+#include <list>
+#include <optional>
 #include <string>
 
 namespace llarp
@@ -144,6 +147,10 @@ namespace llarp
 
     bool
     BDecode(llarp_buffer_t* buf);
+
+    /// Finds a free private use range not overlapping the given ranges.
+    static std::optional<IPRange>
+    FindPrivateRange(const std::list<IPRange>& excluding);
   };
 
   template <>

--- a/llarp/net/net_int.cpp
+++ b/llarp/net/net_int.cpp
@@ -1,6 +1,7 @@
 #include "net_int.hpp"
 #include "ip.hpp"
 #include <string>
+#include <variant>
 
 #include <oxenc/endian.h>
 
@@ -155,4 +156,11 @@ namespace llarp
   {
     return std::to_string(ntohs(n));
   }
+
+  std::string
+  net::ToString(const ipaddr_t& ipaddr)
+  {
+    return std::visit([](const auto& ip) { return ip.ToString(); }, ipaddr);
+  }
+
 }  // namespace llarp

--- a/llarp/net/net_int.hpp
+++ b/llarp/net/net_int.hpp
@@ -230,6 +230,9 @@ namespace llarp
     using ipv6addr_t = n_uint128_t;
     using ipaddr_t = std::variant<ipv4addr_t, ipv6addr_t>;
 
+    std::string
+    ToString(const ipaddr_t& ip);
+
     huint16_t ToHost(port_t);
     huint32_t ToHost(ipv4addr_t);
     huint128_t ToHost(ipv6addr_t);

--- a/llarp/net/posix.cpp
+++ b/llarp/net/posix.cpp
@@ -90,35 +90,7 @@ namespace llarp::net
         }
       });
 
-      auto ownsRange = [&currentRanges](const IPRange& range) -> bool {
-        for (const auto& ownRange : currentRanges)
-        {
-          if (ownRange * range)
-            return true;
-        }
-        return false;
-      };
-      // generate possible ranges to in order of attempts
-      std::list<IPRange> possibleRanges;
-      for (byte_t oct = 16; oct < 32; ++oct)
-      {
-        possibleRanges.emplace_back(IPRange::FromIPv4(172, oct, 0, 1, 16));
-      }
-      for (byte_t oct = 0; oct < 255; ++oct)
-      {
-        possibleRanges.emplace_back(IPRange::FromIPv4(10, oct, 0, 1, 16));
-      }
-      for (byte_t oct = 0; oct < 255; ++oct)
-      {
-        possibleRanges.emplace_back(IPRange::FromIPv4(192, 168, oct, 1, 24));
-      }
-      // for each possible range pick the first one we don't own
-      for (const auto& range : possibleRanges)
-      {
-        if (not ownsRange(range))
-          return range;
-      }
-      return std::nullopt;
+      return IPRange::FindPrivateRange(currentRanges);
     }
 
     std::optional<int> GetInterfaceIndex(ipaddr_t) const override

--- a/llarp/net/posix.cpp
+++ b/llarp/net/posix.cpp
@@ -32,7 +32,7 @@ namespace llarp::net
       if (getifaddrs(&addrs))
         throw std::runtime_error{fmt::format("getifaddrs(): {}", strerror(errno))};
 
-      for (auto next = addrs; next and next->ifa_next; next = next->ifa_next)
+      for (auto next = addrs; next; next = next->ifa_next)
         visit(next);
 
       freeifaddrs(addrs);

--- a/llarp/net/win32.cpp
+++ b/llarp/net/win32.cpp
@@ -151,35 +151,7 @@ namespace llarp::net
         }
       });
 
-      auto ownsRange = [&currentRanges](const IPRange& range) -> bool {
-        for (const auto& ownRange : currentRanges)
-        {
-          if (ownRange * range)
-            return true;
-        }
-        return false;
-      };
-      // generate possible ranges to in order of attempts
-      std::list<IPRange> possibleRanges;
-      for (byte_t oct = 16; oct < 32; ++oct)
-      {
-        possibleRanges.emplace_back(IPRange::FromIPv4(172, oct, 0, 1, 16));
-      }
-      for (byte_t oct = 0; oct < 255; ++oct)
-      {
-        possibleRanges.emplace_back(IPRange::FromIPv4(10, oct, 0, 1, 16));
-      }
-      for (byte_t oct = 0; oct < 255; ++oct)
-      {
-        possibleRanges.emplace_back(IPRange::FromIPv4(192, 168, oct, 1, 24));
-      }
-      // for each possible range pick the first one we don't own
-      for (const auto& range : possibleRanges)
-      {
-        if (not ownsRange(range))
-          return range;
-      }
-      return std::nullopt;
+      return IPRange::FindPrivateRange(currentRanges);
     }
 
     std::string

--- a/llarp/win32/windivert.cpp
+++ b/llarp/win32/windivert.cpp
@@ -102,7 +102,7 @@ namespace llarp::win32
             SetLastError(0);
           return std::nullopt;
         }
-        L::info(cat, "got packet of size {}B", sz);
+        L::trace(cat, "got packet of size {}B", sz);
         pkt.resize(sz);
         return Packet{std::move(pkt), std::move(addr)};
       }
@@ -112,7 +112,7 @@ namespace llarp::win32
       {
         const auto& pkt = w_pkt.pkt;
         const auto* addr = &w_pkt.addr;
-        L::info(cat, "send dns packet of size {}B", pkt.size());
+        L::trace(cat, "send dns packet of size {}B", pkt.size());
         UINT sz{};
         if (wd::send(m_Handle, pkt.data(), pkt.size(), &sz, addr))
           return;
@@ -151,7 +151,7 @@ namespace llarp::win32
           throw std::runtime_error{"windivert thread is already running"};
 
         auto read_loop = [this]() {
-          log::info(cat, "windivert read loop start");
+          log::debug(cat, "windivert read loop start");
           while (true)
           {
             // in the read loop, read packets until they stop coming in
@@ -165,7 +165,7 @@ namespace llarp::win32
             else  // leave loop on read fail
               break;
           }
-          log::info(cat, "windivert read loop end");
+          log::debug(cat, "windivert read loop end");
         };
 
         m_Runner = std::thread{std::move(read_loop)};


### PR DESCRIPTION
When we don't add a route for some reason we aren't printing the "some reason".  This fixes it.  (Also includes temp commits to dump win32 interface discovery).