### PR TITLE
select gateway with lowest metric

### DIFF
--- a/llarp/router/route_poker.cpp
+++ b/llarp/router/route_poker.cpp
@@ -147,13 +147,16 @@ namespace llarp
 
     auto& route = platform->RouteManager();
 
-    // find current gateways
+    // get current gateways, assume sorted by lowest metric first
     auto gateways = route.GetGatewaysNotOnInterface(*vpn);
     std::optional<net::ipv4addr_t> next_gw;
     for (auto& gateway : gateways)
     {
       if (auto* gw_ptr = std::get_if<net::ipv4addr_t>(&gateway))
+      {
         next_gw = *gw_ptr;
+        break;
+      }
     }
 
     // update current gateway and apply state changes as needed


### PR DESCRIPTION
We were unintentionally selecting the last "usable" gateway rather than the one with the lowest metric, resulting in us sometimes using the wrong gateway to route internet traffic in exit mode.

Addresses #2020