### PR TITLE
wire up dns for .snode on service nodes

### DIFF
--- a/llarp/handlers/exit.cpp
+++ b/llarp/handlers/exit.cpp
@@ -480,8 +480,8 @@ namespace llarp
 #ifndef _WIN32
         m_Resolver = std::make_shared<dns::Server>(
             m_Router->loop(), m_DNSConf, if_nametoindex(m_ifname.c_str()));
+        m_Resolver->AddResolver(weak_from_this());
         m_Resolver->Start();
-
 #endif
       }
       return true;

--- a/llarp/handlers/exit.hpp
+++ b/llarp/handlers/exit.hpp
@@ -10,7 +10,9 @@ namespace llarp
   struct AbstractRouter;
   namespace handlers
   {
-    struct ExitEndpoint : public dns::Resolver_Base, public EndpointBase
+    struct ExitEndpoint : public dns::Resolver_Base,
+                          public EndpointBase,
+                          public std::enable_shared_from_this<ExitEndpoint>
     {
       int
       Rank() const override


### PR DESCRIPTION
dns on service nodes was not resolving .snode as we did not wire up the dns resolver for it.

this wires up the dns for service nodes.