### PR TITLE
clarify strict-connect usage and enforce minimum of 2 nodes

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -300,9 +300,9 @@ namespace llarp
             throw std::invalid_argument{"duplicate strict connect snode: " + value};
         },
         Comment{
-            "Public key of a router which will act as a pinned first-hop. This may be used to",
+            "Public keys of routers which will act as pinned first-hops. This may be used to",
             "provide a trusted router (consider that you are not fully anonymous with your",
-            "first hop).",
+            "first hop).  This REQUIRES two or more nodes to be specified.",
         });
 
     conf.defineOption<std::string>(

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -653,14 +653,15 @@ namespace llarp
     auto& networkConfig = conf.network;
 
     /// build a set of  strictConnectPubkeys (
-    /// TODO: make this consistent with config -- do we support multiple strict connections
-    //        or not?
     std::unordered_set<RouterID> strictConnectPubkeys;
     if (not networkConfig.m_strictConnect.empty())
     {
       const auto& val = networkConfig.m_strictConnect;
       if (IsServiceNode())
         throw std::runtime_error("cannot use strict-connect option as service node");
+      if (val.size() < 2)
+        throw std::runtime_error(
+            "Must specify more than one strict-connect router if using strict-connect");
       strictConnectPubkeys.insert(val.begin(), val.end());
     }
 


### PR DESCRIPTION
Lokinet connectivity...just doesn't work if you only have one edge relay, so this aims to clarify the `strict-connect` config option as well as enforce that if you use it you specify more than one.