### PR TITLE
Fix backwards compatible config option handler

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -1413,6 +1413,7 @@ namespace llarp
     params->isRelay = isRelay;
     params->defaultDataDir = m_DataDir;
     ConfigDefinition conf{isRelay};
+    addBackwardsCompatibleConfigOptions(conf);
     initializeConfig(conf, *params);
 
     for (const auto& item : m_Additional)


### PR DESCRIPTION
Without this, old config (with now-irrelevant settings) won't work in newer lokinet, making lokinet fatal error on startup if one of the no-longer-used options is still present.