### PR TITLE
Use rsvg instead of imagemagick to make windows .ico; split up windows build

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -147,7 +147,7 @@ local windows_cross_pipeline(name,
         'echo "man-db man-db/auto-update boolean false" | debconf-set-selections',
         apt_get_quiet + ' update',
         apt_get_quiet + ' install -y eatmydata',
-        'eatmydata ' + apt_get_quiet + ' install --no-install-recommends -y p7zip-full build-essential cmake git pkg-config ccache g++-mingw-w64-x86-64-posix nsis zip icoutils automake libtool',
+        'eatmydata ' + apt_get_quiet + ' install --no-install-recommends -y p7zip-full build-essential cmake git pkg-config ccache g++-mingw-w64-x86-64-posix nsis zip icoutils automake libtool librsvg2-bin',
         'update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix',
         'update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix',
         'JOBS=' + jobs + ' VERBOSE=1 ./contrib/windows.sh -DSTRIP_SYMBOLS=ON ' +

--- a/cmake/gui-option.cmake
+++ b/cmake/gui-option.cmake
@@ -3,4 +3,15 @@ if(APPLE OR WIN32)
   set(default_build_gui ON)
 endif()
 
+if(WIN32)
+  set(GUI_EXE "" CACHE FILEPATH "path to a pre-built Windows GUI .exe to use (implies -DBUILD_GUI=OFF)")
+  if(GUI_EXE)
+    set(default_build_gui OFF)
+  endif()
+endif()
+
 option(BUILD_GUI "build electron gui from 'gui' submodule source" ${default_build_gui})
+
+if(BUILD_GUI AND GUI_EXE)
+  message(FATAL_ERROR "-DGUI_EXE=... and -DBUILD_GUI=ON are mutually exclusive")
+endif()

--- a/cmake/gui.cmake
+++ b/cmake/gui.cmake
@@ -1,23 +1,25 @@
 
-set(default_gui_target pack)
-if(APPLE)
-  set(default_gui_target macos:raw)
-elseif(WIN32)
-  set(default_gui_target win32)
-  set(GUI_EXE "" CACHE FILEPATH "path to an externally built lokinet gui.exe")
-endif()
+if(WIN32 AND GUI_EXE)
+  message(STATUS "using pre-built lokinet gui executable: ${GUI_EXE}")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different "${GUI_EXE}" "${PROJECT_BINARY_DIR}/gui/lokinet-gui.exe")
+elseif(BUILD_GUI)
+  message(STATUS "Building lokinet-gui from source")
 
-set(GUI_YARN_TARGET "${default_gui_target}" CACHE STRING "yarn target for building the GUI")
-set(GUI_YARN_EXTRA_OPTS "" CACHE STRING "extra options to pass into the yarn build command")
+  set(default_gui_target pack)
+  if(APPLE)
+    set(default_gui_target macos:raw)
+  elseif(WIN32)
+    set(default_gui_target win32)
+  endif()
 
-if (BUILD_GUI)
-  message(STATUS "Building lokinet-gui")
+  set(GUI_YARN_TARGET "${default_gui_target}" CACHE STRING "yarn target for building the GUI")
+  set(GUI_YARN_EXTRA_OPTS "" CACHE STRING "extra options to pass into the yarn build command")
+
   # allow manually specifying yarn with -DYARN=
   if(NOT YARN)
     find_program(YARN NAMES yarnpkg yarn REQUIRED)
   endif()
   message(STATUS "Building lokinet-gui with yarn ${YARN}, target ${GUI_YARN_TARGET}")
-
 
   if(NOT WIN32)
     add_custom_target(lokinet-gui
@@ -45,25 +47,13 @@ if (BUILD_GUI)
     )
   elseif(WIN32)
     file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/gui")
-    option(GUI_ZIP_FILE "custom lokinet gui for windows from zip file" OFF)
-    if(GUI_ZIP_FILE)
-      message(STATUS "using custom lokinet gui from ${GUI_ZIP_FILE}")
-      execute_process(COMMAND ${CMAKE_COMMAND} -E tar xf ${GUI_ZIP_FILE}
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
-      add_custom_target("${PROJECT_BINARY_DIR}/gui/lokinet-gui.exe" COMMAND "true")
-    elseif(GUI_EXE)
-      message(STATUS "using custom lokinet gui executable: ${GUI_EXE}")
-      execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different "${GUI_EXE}" "${PROJECT_BINARY_DIR}/gui/lokinet-gui.exe")
-      add_custom_target("${PROJECT_BINARY_DIR}/gui/lokinet-gui.exe" COMMAND "true")
-    else()
-      add_custom_command(OUTPUT "${PROJECT_BINARY_DIR}/gui/lokinet-gui.exe"
-        COMMAND ${YARN} install --frozen-lockfile &&
-        USE_SYSTEM_7ZA=true DISPLAY= WINEDEBUG=-all WINEPREFIX="${PROJECT_BINARY_DIR}/wineprefix" ${YARN} ${GUI_YARN_EXTRA_OPTS} ${GUI_YARN_TARGET}
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "${PROJECT_SOURCE_DIR}/gui/release/Lokinet-GUI_portable.exe"
-        "${PROJECT_BINARY_DIR}/gui/lokinet-gui.exe"
-        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/gui")
-    endif()
+    add_custom_command(OUTPUT "${PROJECT_BINARY_DIR}/gui/lokinet-gui.exe"
+      COMMAND ${YARN} install --frozen-lockfile &&
+      USE_SYSTEM_7ZA=true DISPLAY= WINEDEBUG=-all WINEPREFIX="${PROJECT_BINARY_DIR}/wineprefix" ${YARN} ${GUI_YARN_EXTRA_OPTS} ${GUI_YARN_TARGET}
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${PROJECT_SOURCE_DIR}/gui/release/Lokinet-GUI_portable.exe"
+      "${PROJECT_BINARY_DIR}/gui/lokinet-gui.exe"
+      WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/gui")
     add_custom_target(assemble_gui ALL COMMAND "true" DEPENDS "${PROJECT_BINARY_DIR}/gui/lokinet-gui.exe")
   else()
     message(FATAL_ERROR "Building/bundling the GUI from this repository is not supported on this platform")

--- a/cmake/win32_installer_deps.cmake
+++ b/cmake/win32_installer_deps.cmake
@@ -1,22 +1,3 @@
-if(NOT BUILD_GUI)
-  if(NOT GUI_ZIP_URL)
-    set(GUI_ZIP_URL "https://oxen.rocks/oxen-io/lokinet-gui/dev/lokinet-windows-x64-20220331T180338Z-569f90ad8.zip")
-    set(GUI_ZIP_HASH_OPTS EXPECTED_HASH SHA256=316f10489f5907bfa9c74b21f8ef2fdd7b7c7e6a0f5bcedaed2ee5f4004eab52)
-  endif()
-
-  file(DOWNLOAD
-    ${GUI_ZIP_URL}
-    ${CMAKE_BINARY_DIR}/lokinet-gui.zip
-    ${GUI_ZIP_HASH_OPTS})
-
-  # We expect the produced .zip file above to extract to ./gui/lokinet-gui.exe
-  execute_process(COMMAND ${CMAKE_COMMAND} -E tar xf ${CMAKE_BINARY_DIR}/lokinet-gui.zip
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-  if(NOT EXISTS ${CMAKE_BINARY_DIR}/gui/lokinet-gui.exe)
-    message(FATAL_ERROR "Downloaded gui archive from ${GUI_ZIP_URL} does not contain gui/lokinet-gui.exe!")
-  endif()
-endif()
 install(DIRECTORY ${CMAKE_BINARY_DIR}/gui DESTINATION share COMPONENT gui)
 
 if(WITH_WINDOWS_32)

--- a/contrib/make-ico.sh
+++ b/contrib/make-ico.sh
@@ -14,13 +14,16 @@ mkdir -p "${outdir}"
 for size in "${sizes[@]}"; do
     outf="${outdir}/${size}x${size}.png"
     if [ $size -lt 32 ]; then
-        # For 16x16 and 24x24 we crop the image to 3/4 of its regular size before resizing and make
-        # it all white (instead of transparent) which effectively zooms in on it a bit because if we
-        # resize the full icon it ends up a fuzzy mess, while the crop and resize lets us retain
-        # some detail of the logo.
-        convert -background white -resize 512x512 "$svg" -gravity Center -extent 320x320 -resize ${size}x${size} -strip "png32:$outf"
+        # For 16x16 and 24x24 we crop the image to 2/3 of its regular size make it all white
+        # (instead of transparent) to zoom in on it a bit because if we resize the full icon to the
+        # target size it ends up a fuzzy mess, while the crop and resize lets us retain some detail
+        # of the logo.
+        rsvg-convert -b white \
+            --page-height $size --page-width $size \
+            -w $(($size*3/2)) -h $(($size*3/2)) --left " -$(($size/4))" --top " -$(($size/4))" \
+            "$svg" >"$outf"
     else
-        convert -background transparent -resize ${size}x${size} "$svg" -strip "png32:$outf"
+        rsvg-convert -b transparent -w $size -h $size "$svg" >"$outf"
     fi
     outs="-r $outf $outs"
 done

--- a/docs/install.md
+++ b/docs/install.md
@@ -127,6 +127,7 @@ additional build requirements:
 
 * nsis
 * cpack
+* rsvg-convert (`librsvg2-bin` package on Debian/Ubuntu)
 
 setup:
 


### PR DESCRIPTION
imagemagick is messing up the conversion, so just avoid it entirely and use rsvg-convert directly to do it instead.