### PR TITLE
simplify llarp::service::Endpoint::ReadyToDoLookup()

### DIFF
--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -972,7 +972,7 @@ namespace llarp
     bool
     Endpoint::ReadyToDoLookup(size_t num_paths) const
     {
-      // Currently just checks the number of paths, but could do more checks in the future. (jason)
+      // Currently just checks the number of paths, but could do more checks in the future.
       return num_paths >= MIN_ENDPOINTS_FOR_LNS_LOOKUP;
     }
 

--- a/llarp/service/endpoint.cpp
+++ b/llarp/service/endpoint.cpp
@@ -40,16 +40,10 @@
 #include <uvw.hpp>
 #include <variant>
 
-namespace
-{
-  constexpr size_t MIN_ENDPOINTS_FOR_LNS_LOOKUP = 2;
-}  // namespace
-
 namespace llarp
 {
   namespace service
   {
-
     static auto logcat = log::Cat("endpoint");
 
     Endpoint::Endpoint(AbstractRouter* r, Context* parent)
@@ -317,7 +311,7 @@ namespace llarp
       auto obj = path::Builder::ExtractStatus();
       obj["exitMap"] = m_ExitMap.ExtractStatus();
       obj["identity"] = m_Identity.pub.Addr().ToString();
-      obj["networkReady"] = ReadyToDoLookup();
+      obj["networkReady"] = ReadyForNetwork();
 
       util::StatusObject authCodes;
       for (const auto& [service, info] : m_RemoteAuthInfos)
@@ -958,20 +952,28 @@ namespace llarp
       return not m_ExitMap.Empty();
     }
 
-    bool
-    Endpoint::ReadyToDoLookup(std::optional<uint64_t> numPaths) const
+    path::Path::UniqueEndpointSet_t
+    Endpoint::GetUniqueEndpointsForLookup() const
     {
-      if (not numPaths)
-      {
-        path::Path::UniqueEndpointSet_t paths;
-        ForEachPath([&paths](auto path) {
-          if (path and path->IsReady())
-            paths.insert(path);
-        });
-        numPaths = paths.size();
-      }
+      path::Path::UniqueEndpointSet_t paths;
+      ForEachPath([&paths](auto path) {
+        if (path and path->IsReady())
+          paths.insert(path);
+      });
+      return paths;
+    }
 
-      return numPaths >= MIN_ENDPOINTS_FOR_LNS_LOOKUP;
+    bool
+    Endpoint::ReadyForNetwork() const
+    {
+      return IsReady() and ReadyToDoLookup(GetUniqueEndpointsForLookup().size());
+    }
+
+    bool
+    Endpoint::ReadyToDoLookup(size_t num_paths) const
+    {
+      // Currently just checks the number of paths, but could do more checks in the future. (jason)
+      return num_paths >= MIN_ENDPOINTS_FOR_LNS_LOOKUP;
     }
 
     void
@@ -992,12 +994,7 @@ namespace llarp
         return;
       }
       LogInfo(Name(), " looking up LNS name: ", name);
-      path::Path::UniqueEndpointSet_t paths;
-      ForEachPath([&paths](auto path) {
-        if (path and path->IsReady())
-          paths.insert(path);
-      });
-
+      auto paths = GetUniqueEndpointsForLookup();
       // not enough paths
       if (not ReadyToDoLookup(paths.size()))
       {


### PR DESCRIPTION
previously we had a checking style function that passes in an optional defaulting to nullopt as a micro optimzation, this makes the code unnessarily obtuse.

simplify this by splitting up into 2 functions,
one for getting the unique endpoints and one for checking if the number of them is above the minimum.