### PR TITLE
Fix missing option names, make [lokid]:rpc required

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -1179,6 +1179,7 @@ namespace llarp
         "lokid",
         "rpc",
         RelayOnly,
+        Required,
         Comment{
             "oxenmq control address for for communicating with oxend. Depends on oxend's",
             "lmq-local-control configuration option. By default this value should be",

--- a/llarp/config/definition.hpp
+++ b/llarp/config/definition.hpp
@@ -202,6 +202,16 @@ namespace llarp
     OptionDefinition(std::string section_, std::string name_, Options&&... opts)
         : OptionDefinitionBase(section_, name_, opts...)
     {
+      constexpr bool has_default =
+          ((config::is_default_array<Options> || config::is_default<Options>) || ...);
+      constexpr bool has_required =
+          (std::is_same_v<config::remove_cvref_t<Options>, config::Required_t> || ...);
+      constexpr bool has_hidden =
+          (std::is_same_v<config::remove_cvref_t<Options>, config::Hidden_t> || ...);
+      static_assert(
+          not(has_default and has_required), "Default{...} and Required are mutually exclusive");
+      static_assert(not(has_hidden and has_required), "Hidden and Required are mutually exclusive");
+
       (extractDefault(std::forward<Options>(opts)), ...);
       (extractAcceptor(std::forward<Options>(opts)), ...);
       (extractComments(std::forward<Options>(opts)), ...);

--- a/test/config/test_llarp_config_definition.cpp
+++ b/test/config/test_llarp_config_definition.cpp
@@ -104,7 +104,7 @@ TEST_CASE("OptionDefinition acceptor throws test", "[config]")
 TEST_CASE("OptionDefinition tryAccept missing option test", "[config]")
 {
   int unset = -1;
-  llarp::OptionDefinition<int> def("foo", "bar", Required, Default{1}, [&](int arg) {
+  llarp::OptionDefinition<int> def("foo", "bar", Required, [&](int arg) {
     (void)arg;
     unset = 0; // should never be called
   });
@@ -170,7 +170,6 @@ TEST_CASE("ConfigDefinition required test", "[config]")
   config.defineOption(std::make_unique<llarp::OptionDefinition<int>>(
             "router",
             "threads",
-            Default{1},
             Required));
 
   CHECK_THROWS(config.validateRequiredFields());
@@ -186,13 +185,13 @@ TEST_CASE("ConfigDefinition section test", "[config]")
   config.defineOption(std::make_unique<llarp::OptionDefinition<int>>(
             "foo",
             "bar",
-            Required,
-            Default{1}));
+            Required
+            ));
   config.defineOption(std::make_unique<llarp::OptionDefinition<int>>(
             "goo",
             "bar",
-            Required,
-            Default{1}));
+            Required
+            ));
 
   CHECK_THROWS(config.validateRequiredFields());
 

--- a/test/config/test_llarp_config_values.cpp
+++ b/test/config/test_llarp_config_values.cpp
@@ -75,6 +75,8 @@ run_config_test(mocks::Network env, std::string_view ini_str)
     throw std::runtime_error{"non zero return"};
 }
 
+const std::string ini_minimal = "[lokid]\nrpc=ipc://dummy\n";
+
 TEST_CASE("service node bind section on valid network", "[config]")
 {
   std::unordered_multimap<std::string, llarp::IPRange> env{
@@ -92,15 +94,14 @@ TEST_CASE("service node bind section on valid network", "[config]")
     REQUIRE(not mock_net.IsBogon(*maybe_addr));
   }
 
-  SECTION("empty config")
+  SECTION("minimal config")
   {
-    std::string_view ini_str = "";
-    REQUIRE_NOTHROW(run_config_test(env, ini_str));
+    REQUIRE_NOTHROW(run_config_test(env, ini_minimal));
   }
 
   SECTION("explicit bind via ifname")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [bind]
 mock0=443
 )";
@@ -108,7 +109,7 @@ mock0=443
   }
   SECTION("explicit bind via ip address")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [bind]
 inbound=1.1.1.1:443
 )";
@@ -116,7 +117,7 @@ inbound=1.1.1.1:443
   }
   SECTION("explicit bind via ip address with old syntax")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [bind]
 1.1.1.1=443
 )";
@@ -125,7 +126,7 @@ inbound=1.1.1.1:443
   }
   SECTION("ip spoof fails")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [router]
 public-ip=8.8.8.8
 public-port=443
@@ -136,7 +137,7 @@ inbound=1.1.1.1:443
   }
   SECTION("explicit bind via ifname but fails from non existing ifname")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [bind]
 ligma0=443
 )";
@@ -145,7 +146,7 @@ ligma0=443
 
   SECTION("explicit bind via ifname but fails from using loopback")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [bind]
 lo=443
 )";
@@ -154,7 +155,7 @@ lo=443
 
   SECTION("explicit bind via explicit loopback")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [bind]
 inbound=127.0.0.1:443
 )";
@@ -162,7 +163,7 @@ inbound=127.0.0.1:443
   }
   SECTION("public ip provided but no bind section")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [router]
 public-ip=1.1.1.1
 public-port=443
@@ -171,7 +172,7 @@ public-port=443
   }
   SECTION("public ip provided with ip in bind section")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [router]
 public-ip=1.1.1.1
 public-port=443
@@ -196,7 +197,7 @@ TEST_CASE("service node bind section on nat network", "[config]")
 
   SECTION("public ip provided via inbound directive")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [router]
 public-ip=1.1.1.1
 public-port=443
@@ -209,7 +210,7 @@ inbound=10.1.1.1:443
 
   SECTION("public ip provided with bind via ifname")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [router]
 public-ip=1.1.1.1
 public-port=443
@@ -222,7 +223,7 @@ mock0=443
 
   SECTION("public ip provided bind via wildcard ip")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [router]
 public-ip=1.1.1.1
 public-port=443
@@ -232,7 +233,6 @@ inbound=0.0.0.0:443
 )";
     REQUIRE_THROWS(run_config_test(env, ini_str));
   }
-
 }
 
 TEST_CASE("service node bind section with multiple public ip", "[config]")
@@ -242,14 +242,9 @@ TEST_CASE("service node bind section with multiple public ip", "[config]")
       {"mock0", llarp::IPRange::FromIPv4(2, 1, 1, 1, 32)},
       {"lo", llarp::IPRange::FromIPv4(127, 0, 0, 1, 8)},
   };
-  SECTION("empty config")
-  {
-    std::string_view ini_str = "";
-    REQUIRE_NOTHROW(run_config_test(env, ini_str));
-  }
   SECTION("with old style wildcard for inbound and no public ip, fails")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [bind]
 0.0.0.0=443
 )";
@@ -257,7 +252,7 @@ TEST_CASE("service node bind section with multiple public ip", "[config]")
   }
   SECTION("with old style wildcard for outbound")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [bind]
 *=1443
 )";
@@ -265,7 +260,7 @@ TEST_CASE("service node bind section with multiple public ip", "[config]")
   }
   SECTION("with wildcard via inbound directive no public ip given, fails")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [bind]
 inbound=0.0.0.0:443
 )";
@@ -274,7 +269,7 @@ inbound=0.0.0.0:443
   }
   SECTION("with wildcard via inbound directive primary public ip given")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [router]
 public-ip=1.1.1.1
 public-port=443
@@ -286,7 +281,7 @@ inbound=0.0.0.0:443
   }
   SECTION("with wildcard via inbound directive secondary public ip given")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [router]
 public-ip=2.1.1.1
 public-port=443
@@ -298,7 +293,7 @@ inbound=0.0.0.0:443
   }
   SECTION("with bind via interface name")
   {
-    std::string_view ini_str = R"(
+    auto ini_str = ini_minimal + R"(
 [bind]
 mock0=443
 )";


### PR DESCRIPTION
Three changes:

1. At some point between 0.9.9 and 0.9.10 we removed the printing of option names when a value doesn't have a default, but this means the config is littered with things like:

    ```ini
        # This option sets the greater foo value.
    ```

    with no actual option name printed out when there is no default.

    This fixes it by always printing the option name in such a case, just with an empty value, e.g.:

    ```ini
        # This option sets the greater foo value.
        #big-foo=
    ```
    
2. This makes the `[lokid]:rpc` setting required, because we cannot actually start up in service node mode if it is missing.  The debs, which do have a sensible default, replace the rpc setting in the generated config in postinst (and broke because the commented-out field was missing, because of the above).

3. Default and Required don't make sense together, so we now fail to compile if used together.  Similarly for Required and Hidden.  The test code had a bunch of places that *did* use them together anyway: the behaviour of Default+Required was to write the uncommented default value into the config file, but we decided a long time ago that empty configs was our default so supporting that doesn't make sense.