### PR TITLE
Fix Windows DNS issues

### DIFF
--- a/llarp/dns/server.cpp
+++ b/llarp/dns/server.cpp
@@ -455,20 +455,6 @@ namespace llarp::dns
         Up(m_conf);
       }
 
-      bool
-      WouldLoop(const SockAddr& to, const SockAddr& from) const override
-      {
-#if defined(ANDROID)
-        (void)to;
-        (void)from;
-        return false;
-#else
-        const auto& vec = m_conf.m_upstreamDNS;
-        return std::find(vec.begin(), vec.end(), to) != std::end(vec)
-            or std::find(vec.begin(), vec.end(), from) != std::end(vec);
-#endif
-      }
-
       template <typename Callable>
       void
       call(Callable&& f)
@@ -486,9 +472,6 @@ namespace llarp::dns
           const SockAddr& to,
           const SockAddr& from) override
       {
-        if (WouldLoop(to, from))
-          return false;
-
         auto tmp = std::make_shared<Query>(weak_from_this(), query, source, to, from);
         // no questions, send fail
         if (query.questions.empty())

--- a/llarp/dns/server.hpp
+++ b/llarp/dns/server.hpp
@@ -197,16 +197,6 @@ namespace llarp::dns
         const Message& query,
         const SockAddr& to,
         const SockAddr& from) = 0;
-
-    /// Returns true if a packet with to and from addresses is something that would cause a
-    /// resolution loop and thus should not be used on this resolver
-    virtual bool
-    WouldLoop(const SockAddr& to, const SockAddr& from) const
-    {
-      (void)to;
-      (void)from;
-      return false;
-    }
   };
 
   // Base class for DNS proxy

--- a/llarp/win32/windivert.cpp
+++ b/llarp/win32/windivert.cpp
@@ -201,7 +201,7 @@ namespace llarp::win32
       }
 
       void
-      send_packet(Packet&& w_pkt) const
+      send_packet(Packet w_pkt) const
       {
         auto& pkt = w_pkt.pkt;
         auto* addr = &w_pkt.addr;

--- a/llarp/win32/windivert.cpp
+++ b/llarp/win32/windivert.cpp
@@ -14,6 +14,8 @@ extern "C"
 
 namespace
 {
+  using namespace oxen::log::literals;
+
   std::string
   windivert_addr_to_string(const WINDIVERT_ADDRESS& addr)
   {

--- a/llarp/win32/windivert.cpp
+++ b/llarp/win32/windivert.cpp
@@ -206,6 +206,8 @@ namespace llarp::win32
         auto& pkt = w_pkt.pkt;
         auto* addr = &w_pkt.addr;
 
+        addr->Outbound = !addr->Outbound;  // re-used from recv, so invert direction
+
         log::trace(logcat, "send dns packet of size {}B", pkt.size());
         log_windivert_addr(w_pkt.addr);
 

--- a/llarp/win32/windivert.cpp
+++ b/llarp/win32/windivert.cpp
@@ -12,6 +12,92 @@ extern "C"
 #include <windivert.h>
 }
 
+namespace
+{
+  std::string
+  windivert_addr_to_string(const WINDIVERT_ADDRESS& addr)
+  {
+    std::string layer_str{};
+    std::string ifidx_str{};
+    switch (addr.Layer)
+    {
+      case WINDIVERT_LAYER_NETWORK:
+        layer_str = "WINDIVERT_LAYER_NETWORK";
+        ifidx_str = "Network: [IfIdx: {}, SubIfIdx: {}]"_format(
+            addr.Network.IfIdx, addr.Network.SubIfIdx);
+        break;
+      case WINDIVERT_LAYER_NETWORK_FORWARD:
+        layer_str = "WINDIVERT_LAYER_NETWORK_FORWARD";
+        break;
+      case WINDIVERT_LAYER_FLOW:
+        layer_str = "WINDIVERT_LAYER_FLOW";
+        break;
+      case WINDIVERT_LAYER_SOCKET:
+        layer_str = "WINDIVERT_LAYER_SOCKET";
+        break;
+      case WINDIVERT_LAYER_REFLECT:
+        layer_str = "WINDIVERT_LAYER_REFLECT";
+        break;
+      default:
+        layer_str = "unknown";
+    }
+
+    std::string event_str{};
+    switch (addr.Event)
+    {
+      case WINDIVERT_EVENT_NETWORK_PACKET:
+        event_str = "WINDIVERT_EVENT_NETWORK_PACKET";
+        break;
+      case WINDIVERT_EVENT_FLOW_ESTABLISHED:
+        event_str = "WINDIVERT_EVENT_FLOW_ESTABLISHED";
+        break;
+      case WINDIVERT_EVENT_FLOW_DELETED:
+        event_str = "WINDIVERT_EVENT_FLOW_DELETED";
+        break;
+      case WINDIVERT_EVENT_SOCKET_BIND:
+        event_str = "WINDIVERT_EVENT_SOCKET_BIND";
+        break;
+      case WINDIVERT_EVENT_SOCKET_CONNECT:
+        event_str = "WINDIVERT_EVENT_SOCKET_CONNECT";
+        break;
+      case WINDIVERT_EVENT_SOCKET_LISTEN:
+        event_str = "WINDIVERT_EVENT_SOCKET_LISTEN";
+        break;
+      case WINDIVERT_EVENT_SOCKET_ACCEPT:
+        event_str = "WINDIVERT_EVENT_SOCKET_ACCEPT";
+        break;
+      case WINDIVERT_EVENT_SOCKET_CLOSE:
+        event_str = "WINDIVERT_EVENT_SOCKET_CLOSE";
+        break;
+      case WINDIVERT_EVENT_REFLECT_OPEN:
+        event_str = "WINDIVERT_EVENT_REFLECT_OPEN";
+        break;
+      case WINDIVERT_EVENT_REFLECT_CLOSE:
+        event_str = "WINDIVERT_EVENT_REFLECT_CLOSE";
+        break;
+      default:
+        event_str = "unknown";
+    }
+
+    return fmt::format(
+        "Windivert WINDIVERT_ADDRESS -- Timestamp: {}, Layer: {}, Event: {}, Sniffed: {}, "
+        "Outbound: {}, Loopback: {}, Imposter: {}, IPv6: {}, IPChecksum: {}, TCPChecksum: {}, "
+        "UDPChecksum: {}, {}",
+        addr.Timestamp,
+        layer_str,
+        event_str,
+        addr.Sniffed ? "true" : "false",
+        addr.Outbound ? "true" : "false",
+        addr.Loopback ? "true" : "false",
+        addr.Impostor ? "true" : "false",
+        addr.IPv6 ? "true" : "false",
+        addr.IPChecksum ? "true" : "false",
+        addr.TCPChecksum ? "true" : "false",
+        addr.UDPChecksum ? "true" : "false",
+        ifidx_str);
+  }
+}
+
 namespace llarp::win32
 {
   static auto logcat = log::Cat("windivert");
@@ -56,90 +142,6 @@ namespace llarp::win32
       std::vector<byte_t> pkt;
       WINDIVERT_ADDRESS addr;
     };
-
-    void
-    log_windivert_addr(const WINDIVERT_ADDRESS& addr)
-    {
-      std::string layer_str{};
-      std::string ifidx_str{};
-      switch (addr.Layer)
-      {
-        case WINDIVERT_LAYER_NETWORK:
-          layer_str = "WINDIVERT_LAYER_NETWORK";
-          ifidx_str = "Network: [IfIdx: {}, SubIfIdx: {}]"_format(
-              addr.Network.IfIdx, addr.Network.SubIfIdx);
-          break;
-        case WINDIVERT_LAYER_NETWORK_FORWARD:
-          layer_str = "WINDIVERT_LAYER_NETWORK_FORWARD";
-          break;
-        case WINDIVERT_LAYER_FLOW:
-          layer_str = "WINDIVERT_LAYER_FLOW";
-          break;
-        case WINDIVERT_LAYER_SOCKET:
-          layer_str = "WINDIVERT_LAYER_SOCKET";
-          break;
-        case WINDIVERT_LAYER_REFLECT:
-          layer_str = "WINDIVERT_LAYER_REFLECT";
-          break;
-        default:
-          layer_str = "unknown";
-      }
-
-      std::string event_str{};
-      switch (addr.Event)
-      {
-        case WINDIVERT_EVENT_NETWORK_PACKET:
-          event_str = "WINDIVERT_EVENT_NETWORK_PACKET";
-          break;
-        case WINDIVERT_EVENT_FLOW_ESTABLISHED:
-          event_str = "WINDIVERT_EVENT_FLOW_ESTABLISHED";
-          break;
-        case WINDIVERT_EVENT_FLOW_DELETED:
-          event_str = "WINDIVERT_EVENT_FLOW_DELETED";
-          break;
-        case WINDIVERT_EVENT_SOCKET_BIND:
-          event_str = "WINDIVERT_EVENT_SOCKET_BIND";
-          break;
-        case WINDIVERT_EVENT_SOCKET_CONNECT:
-          event_str = "WINDIVERT_EVENT_SOCKET_CONNECT";
-          break;
-        case WINDIVERT_EVENT_SOCKET_LISTEN:
-          event_str = "WINDIVERT_EVENT_SOCKET_LISTEN";
-          break;
-        case WINDIVERT_EVENT_SOCKET_ACCEPT:
-          event_str = "WINDIVERT_EVENT_SOCKET_ACCEPT";
-          break;
-        case WINDIVERT_EVENT_SOCKET_CLOSE:
-          event_str = "WINDIVERT_EVENT_SOCKET_CLOSE";
-          break;
-        case WINDIVERT_EVENT_REFLECT_OPEN:
-          event_str = "WINDIVERT_EVENT_REFLECT_OPEN";
-          break;
-        case WINDIVERT_EVENT_REFLECT_CLOSE:
-          event_str = "WINDIVERT_EVENT_REFLECT_CLOSE";
-          break;
-        default:
-          event_str = "unknown";
-      }
-
-      log::trace(
-          logcat,
-          "Windivert WINDIVERT_ADDRESS -- Timestamp: {}, Layer: {}, Event: {}, Sniffed: {}, "
-          "Outbound: {}, Loopback: {}, Imposter: {}, IPv6: {}, IPChecksum: {}, TCPChecksum: {}, "
-          "UDPChecksum: {}, {}",
-          addr.Timestamp,
-          layer_str,
-          event_str,
-          addr.Sniffed ? "true" : "false",
-          addr.Outbound ? "true" : "false",
-          addr.Loopback ? "true" : "false",
-          addr.Impostor ? "true" : "false",
-          addr.IPv6 ? "true" : "false",
-          addr.IPChecksum ? "true" : "false",
-          addr.TCPChecksum ? "true" : "false",
-          addr.UDPChecksum ? "true" : "false",
-          ifidx_str);
-    }
 
     class IO : public llarp::vpn::I_Packet_IO
     {
@@ -195,8 +197,7 @@ namespace llarp::win32
         pkt.resize(sz);
 
         log::trace(logcat, "got packet of size {}B", sz);
-        log_windivert_addr(addr);
-
+        log::trace(logcat, "{}", windivert_addr_to_string(addr));
         return Packet{std::move(pkt), std::move(addr)};
       }
 
@@ -209,7 +210,7 @@ namespace llarp::win32
         addr->Outbound = !addr->Outbound;  // re-used from recv, so invert direction
 
         log::trace(logcat, "send dns packet of size {}B", pkt.size());
-        log_windivert_addr(w_pkt.addr);
+        log::trace(logcat, "{}", windivert_addr_to_string(w_pkt.addr));
 
         UINT sz{};
         // recalc IP packet checksum in case it needs it

--- a/llarp/win32/windivert.cpp
+++ b/llarp/win32/windivert.cpp
@@ -23,8 +23,8 @@ namespace
     {
       case WINDIVERT_LAYER_NETWORK:
         layer_str = "WINDIVERT_LAYER_NETWORK";
-        ifidx_str = "Network: [IfIdx: {}, SubIfIdx: {}]"_format(
-            addr.Network.IfIdx, addr.Network.SubIfIdx);
+        ifidx_str =
+            "Network: [IfIdx: {}, SubIfIdx: {}]"_format(addr.Network.IfIdx, addr.Network.SubIfIdx);
         break;
       case WINDIVERT_LAYER_NETWORK_FORWARD:
         layer_str = "WINDIVERT_LAYER_NETWORK_FORWARD";
@@ -96,7 +96,7 @@ namespace
         addr.UDPChecksum ? "true" : "false",
         ifidx_str);
   }
-}
+}  // namespace
 
 namespace llarp::win32
 {

--- a/llarp/win32/windivert.cpp
+++ b/llarp/win32/windivert.cpp
@@ -55,6 +55,90 @@ namespace llarp::win32
       WINDIVERT_ADDRESS addr;
     };
 
+    void
+    log_windivert_addr(const WINDIVERT_ADDRESS& addr)
+    {
+      std::string layer_str{};
+      std::string ifidx_str{};
+      switch (addr.Layer)
+      {
+        case WINDIVERT_LAYER_NETWORK:
+          layer_str = "WINDIVERT_LAYER_NETWORK";
+          ifidx_str = "Network: [IfIdx: {}, SubIfIdx: {}]"_format(
+              addr.Network.IfIdx, addr.Network.SubIfIdx);
+          break;
+        case WINDIVERT_LAYER_NETWORK_FORWARD:
+          layer_str = "WINDIVERT_LAYER_NETWORK_FORWARD";
+          break;
+        case WINDIVERT_LAYER_FLOW:
+          layer_str = "WINDIVERT_LAYER_FLOW";
+          break;
+        case WINDIVERT_LAYER_SOCKET:
+          layer_str = "WINDIVERT_LAYER_SOCKET";
+          break;
+        case WINDIVERT_LAYER_REFLECT:
+          layer_str = "WINDIVERT_LAYER_REFLECT";
+          break;
+        default:
+          layer_str = "unknown";
+      }
+
+      std::string event_str{};
+      switch (addr.Event)
+      {
+        case WINDIVERT_EVENT_NETWORK_PACKET:
+          event_str = "WINDIVERT_EVENT_NETWORK_PACKET";
+          break;
+        case WINDIVERT_EVENT_FLOW_ESTABLISHED:
+          event_str = "WINDIVERT_EVENT_FLOW_ESTABLISHED";
+          break;
+        case WINDIVERT_EVENT_FLOW_DELETED:
+          event_str = "WINDIVERT_EVENT_FLOW_DELETED";
+          break;
+        case WINDIVERT_EVENT_SOCKET_BIND:
+          event_str = "WINDIVERT_EVENT_SOCKET_BIND";
+          break;
+        case WINDIVERT_EVENT_SOCKET_CONNECT:
+          event_str = "WINDIVERT_EVENT_SOCKET_CONNECT";
+          break;
+        case WINDIVERT_EVENT_SOCKET_LISTEN:
+          event_str = "WINDIVERT_EVENT_SOCKET_LISTEN";
+          break;
+        case WINDIVERT_EVENT_SOCKET_ACCEPT:
+          event_str = "WINDIVERT_EVENT_SOCKET_ACCEPT";
+          break;
+        case WINDIVERT_EVENT_SOCKET_CLOSE:
+          event_str = "WINDIVERT_EVENT_SOCKET_CLOSE";
+          break;
+        case WINDIVERT_EVENT_REFLECT_OPEN:
+          event_str = "WINDIVERT_EVENT_REFLECT_OPEN";
+          break;
+        case WINDIVERT_EVENT_REFLECT_CLOSE:
+          event_str = "WINDIVERT_EVENT_REFLECT_CLOSE";
+          break;
+        default:
+          event_str = "unknown";
+      }
+
+      log::trace(
+          logcat,
+          "Windivert WINDIVERT_ADDRESS -- Timestamp: {}, Layer: {}, Event: {}, Sniffed: {}, "
+          "Outbound: {}, Loopback: {}, Imposter: {}, IPv6: {}, IPChecksum: {}, TCPChecksum: {}, "
+          "UDPChecksum: {}, {}",
+          addr.Timestamp,
+          layer_str,
+          event_str,
+          addr.Sniffed ? "true" : "false",
+          addr.Outbound ? "true" : "false",
+          addr.Loopback ? "true" : "false",
+          addr.Impostor ? "true" : "false",
+          addr.IPv6 ? "true" : "false",
+          addr.IPChecksum ? "true" : "false",
+          addr.TCPChecksum ? "true" : "false",
+          addr.UDPChecksum ? "true" : "false",
+          ifidx_str);
+    }
+
     class IO : public llarp::vpn::I_Packet_IO
     {
       std::function<void(void)> m_Wake;
@@ -106,8 +190,11 @@ namespace llarp::win32
           throw win32::error{
               err, fmt::format("failed to receive packet from windivert (code={})", err)};
         }
-        log::trace(logcat, "got packet of size {}B", sz);
         pkt.resize(sz);
+
+        log::trace(logcat, "got packet of size {}B", sz);
+        log_windivert_addr(addr);
+
         return Packet{std::move(pkt), std::move(addr)};
       }
 
@@ -117,6 +204,8 @@ namespace llarp::win32
         const auto& pkt = w_pkt.pkt;
         const auto* addr = &w_pkt.addr;
         log::trace(logcat, "send dns packet of size {}B", pkt.size());
+        log_windivert_addr(w_pkt.addr);
+
         UINT sz{};
         if (!wd::send(m_Handle, pkt.data(), pkt.size(), &sz, addr))
           throw win32::error{"windivert send failed"};


### PR DESCRIPTION
Fixes a couple of bugs with Windows DNS handling:

- OS DNS config matching lokinet upstream config will work now

- Windivert `WINDIVERT_ADDRESS.Outbound` flag will now be set correctly, i.e. packet injection will be in the correct direction.

These two points together should fix #2073

Also adds a bunch of debug logging