### PR TITLE
CLI Fixes

### DIFF
--- a/daemon/lokinet-vpn.cpp
+++ b/daemon/lokinet-vpn.cpp
@@ -108,11 +108,11 @@ main(int argc, char* argv[])
   command_line_options options{};
 
   // flags: boolean values in command_line_options struct
-  cli.add_flag("v,--verbose", options.verbose, "Verbose");
+  cli.add_flag("-v,--verbose", options.verbose, "Verbose");
   cli.add_flag("--up", options.vpnUp, "Put VPN up");
   cli.add_flag("--down", options.vpnDown, "Put VPN down");
   cli.add_flag("--status", options.printStatus, "Print VPN status and exit");
-  cli.add_flag("k,--kill", options.killDaemon, "Kill lokinet daemon");
+  cli.add_flag("-k,--kill", options.killDaemon, "Kill lokinet daemon");
 
   // options: string values in command_line_options struct
   cli.add_option("--exit", options.exitAddress, "Specify exit node address")->capture_default_str();
@@ -156,6 +156,10 @@ main(int argc, char* argv[])
     case 0:
       return exit_error(3, "One of --up/--down/--status/--kill must be specified");
     case 1:
+      break;
+    case 2:
+    case 3:
+    case 4:
       return exit_error(3, "Only one of --up/--down/--status/--kill may be specified");
     default:
       break;

--- a/daemon/lokinet-vpn.cpp
+++ b/daemon/lokinet-vpn.cpp
@@ -157,12 +157,8 @@ main(int argc, char* argv[])
       return exit_error(3, "One of --up/--down/--status/--kill must be specified");
     case 1:
       break;
-    case 2:
-    case 3:
-    case 4:
-      return exit_error(3, "Only one of --up/--down/--status/--kill may be specified");
     default:
-      break;
+      return exit_error(3, "Only one of --up/--down/--status/--kill may be specified");
   }
 
   if (options.vpnUp and options.exitAddress.empty())

--- a/daemon/lokinet.cpp
+++ b/daemon/lokinet.cpp
@@ -33,7 +33,6 @@ namespace
     bool version = false;
     bool generate = false;
     bool router = false;
-    bool force = false;
     bool config = false;
     bool configOnly = false;
     bool overwrite = false;
@@ -375,7 +374,7 @@ namespace
     cli.add_flag("-g,--generate", options.generate, "Generate default configuration and exit");
     cli.add_flag(
         "-r,--router", options.router, "Run lokinet in routing mode instead of client-only mode");
-    cli.add_flag("-f,--force", options.force, "Force writing config even if file exists");
+    cli.add_flag("-f,--force", options.overwrite, "Force writing config even if file exists");
 
     // options: string
     cli.add_option("--config", options.configPath, "Path to lokinet.ini configuration file")

--- a/daemon/lokinet.cpp
+++ b/daemon/lokinet.cpp
@@ -34,10 +34,13 @@ namespace
     bool generate = false;
     bool router = false;
     bool force = false;
+    bool config = false;
     bool configOnly = false;
     bool overwrite = false;
 
     // string options
+    // TODO: change this to use a std::filesystem::path once we stop using ghc::filesystem on some
+    // platforms
     std::string configPath;
 
     // windows options
@@ -369,10 +372,10 @@ namespace
 
     // flags: boolean values in command_line_options struct
     cli.add_flag("--version", options.version, "Lokinet version");
-    cli.add_flag("g,--generate", options.generate, "Generate default configuration and exit");
+    cli.add_flag("-g,--generate", options.generate, "Generate default configuration and exit");
     cli.add_flag(
-        "r,--router", options.router, "Run lokinet in routing mode instead of client-only mode");
-    cli.add_flag("f,--force", options.force, "Force writing config even if file exists");
+        "-r,--router", options.router, "Run lokinet in routing mode instead of client-only mode");
+    cli.add_flag("-f,--force", options.force, "Force writing config even if file exists");
 
     // options: string
     cli.add_option("--config", options.configPath, "Path to lokinet.ini configuration file")
@@ -417,7 +420,12 @@ namespace
         }
       }
 
-      if (options.configOnly)
+      if (options.generate)
+      {
+        options.configOnly = true;
+      }
+
+      if (not options.configPath.empty())
       {
         configFile = options.configPath;
       }


### PR DESCRIPTION
### CLI Flags

Single-letter flags (-v, -h), will sometimes flip CLI::IncorrectConstruction error. Documentation on git and gitbook have conflicting statements as to which of the following is preferable:

`cli.add_flag("v,--verbose", options.verbose, "Verbose");`

`cli.add_flag("-v,--verbose", options.verbose, "Verbose");`

The first triggers error, but the second does not. Going forward, the second convention will be followed.

### CLI Logic

Fixed error generating .ini configuration files and logic handling

### IPC Socket

Fixes: #2057 (pending reproduction)