### PR TITLE
IPC Socket Fixes

### DIFF
--- a/daemon/lokinet.cpp
+++ b/daemon/lokinet.cpp
@@ -588,6 +588,9 @@ namespace
         return;
       }
 
+      // change cwd to dataDir to support relative paths in config
+      fs::current_path(conf->router.m_dataDir);
+
       ctx = std::make_shared<llarp::Context>();
       ctx->Configure(std::move(conf));
 

--- a/include/llarp.hpp
+++ b/include/llarp.hpp
@@ -43,7 +43,6 @@ namespace llarp
     std::shared_ptr<AbstractRouter> router = nullptr;
     std::shared_ptr<EventLoop> loop = nullptr;
     std::shared_ptr<NodeDB> nodedb = nullptr;
-    std::string nodedb_dir;
 
     Context();
     virtual ~Context() = default;

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -1135,7 +1135,7 @@ namespace llarp
         "bind",
         DefaultRPCBind,
         MultiValue,
-        [=, first = true](std::string arg) mutable {
+        [this, first = true](std::string arg) mutable {
           if (first)
           {
             m_rpcBindAddresses.clear();

--- a/llarp/config/config.hpp
+++ b/llarp/config/config.hpp
@@ -189,7 +189,7 @@ namespace llarp
   struct ApiConfig
   {
     bool m_enableRPCServer = false;
-    std::string m_rpcBindAddr;
+    std::vector<oxenmq::address> m_rpcBindAddresses;
 
     void
     defineConfigOptions(ConfigDefinition& conf, const ConfigGenParameters& params);

--- a/llarp/context.cpp
+++ b/llarp/context.cpp
@@ -45,8 +45,6 @@ namespace llarp
       throw std::runtime_error("Config already exists");
 
     config = std::move(conf);
-
-    nodedb_dir = fs::path{config->router.m_dataDir / nodedb_dirname}.string();
   }
 
   bool
@@ -92,7 +90,7 @@ namespace llarp
   Context::makeNodeDB()
   {
     return std::make_shared<NodeDB>(
-        nodedb_dir, [r = router.get()](auto call) { r->QueueDiskIO(std::move(call)); });
+        nodedb_dirname, [r = router.get()](auto call) { r->QueueDiskIO(std::move(call)); });
   }
 
   std::shared_ptr<AbstractRouter>

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -413,10 +413,8 @@ namespace llarp
     log::clear_sinks();
     log::add_sink(log_type, conf.logging.m_logFile);
 
-    enableRPCServer = conf.api.m_enableRPCServer;
-
     // re-add rpc log sink if rpc enabled, else free it
-    if (enableRPCServer and llarp::logRingBuffer)
+    if (m_Config->api.m_enableRPCServer and llarp::logRingBuffer)
       log::add_sink(llarp::logRingBuffer, llarp::log::DEFAULT_PATTERN_MONO);
     else
       llarp::logRingBuffer = nullptr;
@@ -429,9 +427,6 @@ namespace llarp
       lokidRPCAddr = oxenmq::address(conf.lokid.lokidRPCAddr);
       m_lokidRpcClient = std::make_shared<rpc::LokidRpcClient>(m_lmq, weak_from_this());
     }
-
-    if (enableRPCServer)
-      rpcBindAddr = oxenmq::address(conf.api.m_rpcBindAddr);
 
     log::debug(logcat, "Starting RPC server");
     if (not StartRpcServer())
@@ -1260,12 +1255,8 @@ namespace llarp
   bool
   Router::StartRpcServer()
   {
-    if (enableRPCServer)
-    {
-      m_RPCServer.reset(new rpc::RpcServer{m_lmq, this});
-      m_RPCServer->AsyncServeRPC(rpcBindAddr);
-      LogInfo("Bound RPC server to ", rpcBindAddr.full_address());
-    }
+    if (m_Config->api.m_enableRPCServer)
+      m_RPCServer = std::make_unique<rpc::RpcServer>(m_lmq, this);
 
     return true;
   }

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -298,9 +298,6 @@ namespace llarp
     void
     PumpLL();
 
-    const oxenmq::address DefaultRPCBindAddr = oxenmq::address::tcp("127.0.0.1", 1190);
-    bool enableRPCServer = false;
-    oxenmq::address rpcBindAddr = DefaultRPCBindAddr;
     std::unique_ptr<rpc::RpcServer> m_RPCServer;
 
     const llarp_time_t _randomStartDelay;

--- a/llarp/rpc/rpc_server.cpp
+++ b/llarp/rpc/rpc_server.cpp
@@ -25,13 +25,13 @@ namespace llarp::rpc
   RpcServer::RpcServer(LMQ_ptr lmq, AbstractRouter* r)
       : m_LMQ{std::move(lmq)}, m_Router{r}, log_subs{*m_LMQ, llarp::logRingBuffer}
   {
-    for (auto addr : r->GetConfig()->api.m_rpcBindAddresses)
+    for (const auto& addr : r->GetConfig()->api.m_rpcBindAddresses)
     {
       m_LMQ->listen_plain(addr.zmq_address());
       LogInfo("Bound RPC server to ", addr.full_address());
     }
 
-    this->AddRPCCats();
+    this->AddRPCCategories();
   }
 
   /// maybe parse json from message paramter at index
@@ -150,7 +150,7 @@ namespace llarp::rpc
   }
 
   void
-  RpcServer::AddRPCCats()
+  RpcServer::AddRPCCategories()
   {
     m_LMQ->add_category("llarp", oxenmq::AuthLevel::none)
         .add_request_command("logs", [this](oxenmq::Message& msg) { HandleLogsSubRequest(msg); })

--- a/llarp/rpc/rpc_server.cpp
+++ b/llarp/rpc/rpc_server.cpp
@@ -1,5 +1,6 @@
 #include "rpc_server.hpp"
 #include <llarp/router/route_poker.hpp>
+#include <llarp/config/config.hpp>
 #include <llarp/constants/platform.hpp>
 #include <llarp/constants/version.hpp>
 #include <nlohmann/json.hpp>
@@ -23,7 +24,15 @@ namespace llarp::rpc
 {
   RpcServer::RpcServer(LMQ_ptr lmq, AbstractRouter* r)
       : m_LMQ{std::move(lmq)}, m_Router{r}, log_subs{*m_LMQ, llarp::logRingBuffer}
-  {}
+  {
+    for (auto addr : r->GetConfig()->api.m_rpcBindAddresses)
+    {
+      m_LMQ->listen_plain(addr.zmq_address());
+      LogInfo("Bound RPC server to ", addr.full_address());
+    }
+
+    this->AddRPCCats();
+  }
 
   /// maybe parse json from message paramter at index
   std::optional<nlohmann::json>
@@ -141,9 +150,8 @@ namespace llarp::rpc
   }
 
   void
-  RpcServer::AsyncServeRPC(oxenmq::address url)
+  RpcServer::AddRPCCats()
   {
-    m_LMQ->listen_plain(url.zmq_address());
     m_LMQ->add_category("llarp", oxenmq::AuthLevel::none)
         .add_request_command("logs", [this](oxenmq::Message& msg) { HandleLogsSubRequest(msg); })
         .add_request_command(

--- a/llarp/rpc/rpc_server.hpp
+++ b/llarp/rpc/rpc_server.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include <llarp/config/config.hpp>
 #include <oxenmq/oxenmq.h>
 #include <oxenmq/address.h>
 #include <oxen/log/omq_logger.hpp>
@@ -18,8 +19,9 @@ namespace llarp::rpc
   {
     explicit RpcServer(LMQ_ptr, AbstractRouter*);
     ~RpcServer() = default;
+
     void
-    AsyncServeRPC(oxenmq::address addr);
+    AddRPCCats();
 
    private:
     void

--- a/llarp/rpc/rpc_server.hpp
+++ b/llarp/rpc/rpc_server.hpp
@@ -21,7 +21,7 @@ namespace llarp::rpc
     ~RpcServer() = default;
 
     void
-    AddRPCCats();
+    AddRPCCategories();
 
    private:
     void

--- a/pybind/llarp/config.cpp
+++ b/pybind/llarp/config.cpp
@@ -80,7 +80,7 @@ namespace llarp
     py::class_<ApiConfig>(mod, "ApiConfig")
         .def(py::init<>())
         .def_readwrite("enableRPCServer", &ApiConfig::m_enableRPCServer)
-        .def_readwrite("rpcBindAddr", &ApiConfig::m_rpcBindAddr);
+        .def_readwrite("rpcBindAddresses", &ApiConfig::m_rpcBindAddresses);
 
     py::class_<LokidConfig>(mod, "LokidConfig")
         .def(py::init<>())


### PR DESCRIPTION
Currently, lokinet.ini (under the [api] section) defaults to `bind=tcp://127.0.0.1:1190`

#2057 adds the ability to access an IPC socket by changing the line to `bind=ipc:///some/path/my.sock`

Lokinet should be able to bind to multiple listening addresses instead of one, by repeating the `bind=...` line such as

> bind=tcp://127.0.0.1:1190
> bind=ipc:///some/path/my.sock

Fixes: #2110 