### PR TITLE
Fix incorrect usage of oxen-logging syslog

### DIFF
--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -411,7 +411,7 @@ namespace llarp
     if (log::get_level_default() != log::Level::off)
       log::reset_level(conf.logging.m_logLevel);
     log::clear_sinks();
-    log::add_sink(log_type, conf.logging.m_logFile);
+    log::add_sink(log_type, log_type == log::Type::System ? "lokinet" : conf.logging.m_logFile);
 
     enableRPCServer = conf.api.m_enableRPCServer;
 


### PR DESCRIPTION
Previously oxen-logging was erroneously hard-coded to use the target "lokinet" for system logs.  Obviously this is wrong for anything else which uses oxen-logging and the system log.  This changes our call to add_sink to pass "lokinet" as the target rather than the config filename, and updates oxen-logging to use that argument correctly.