### PR TITLE
Add Support for Encrypted/Authenticated Listeners

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -3,6 +3,7 @@
 #include "ini.hpp"
 
 #include <oxenmq/address.h>
+#include <oxenmq/oxenmq.h>
 #include <llarp/constants/files.hpp>
 #include <llarp/constants/platform.hpp>
 #include <llarp/constants/version.hpp>
@@ -1174,9 +1175,10 @@ namespace llarp
             key = "tcp://" + key;
 
           auto pubkeys = split(values, ",", true);
+          oxenmq::address key_addr{key};
 
           for (auto& pk : pubkeys)
-            m_rpcEncryptedAddresses[oxenmq::address{key}].emplace(pk);
+            m_rpcEncryptedAddresses[key_addr].emplace(pk);
         },
         Comment{
             "Specify encrypted listener addresses and comma-delimited public keys to be accepted ",

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -2,6 +2,7 @@
 #include "definition.hpp"
 #include "ini.hpp"
 
+#include <oxenmq/address.h>
 #include <llarp/constants/files.hpp>
 #include <llarp/constants/platform.hpp>
 #include <llarp/constants/version.hpp>
@@ -1152,10 +1153,45 @@ namespace llarp
             "Recommend localhost-only for security purposes.",
         });
 
-    conf.defineOption<std::string>("api", "authkey", Deprecated);
+    conf.defineOption<std::string>(
+        "api",
+        "bind_curve",
+        Default{""},
+        MultiValue,
+        [this](std::string arg) mutable {
+          if (arg.empty())
+            return;
 
-    // TODO: this was from pre-refactor:
-    // TODO: add pubkey to whitelist
+          auto pipe = arg.find("|");
+
+          if (pipe == arg.npos)
+            throw std::invalid_argument(
+                "Addresses and whitelisted pubkeys must be pipe-delimited key:value pairs");
+
+          auto key = arg.substr(0, pipe), values = arg.substr(pipe + 1, arg.npos);
+
+          if (not starts_with(key, "tcp://"))
+            key = "tcp://" + key;
+
+          auto pubkeys = split(values, ",", true);
+
+          for (auto& pk : pubkeys)
+            m_rpcEncryptedAddresses[oxenmq::address{key}].emplace(pk);
+        },
+        Comment{
+            "Specify encrypted listener addresses and comma-delimited public keys to be accepted ",
+            "by exposed encrypted listener. Keys must be attached to a listener address.",
+            "",
+            "Example: ",
+            "   bind_curve=tcp://0.0.0.0:1234|pubkeyA,pubkeyB",
+            "   bind_curve=tcp://0.0.0.0:5678|pubkeyC,pubkeyD",
+            "",
+            "In the given example above, port 1234 is only accessible by whitelisted ",
+            "pubkeys A and B, while 5678 is accessible by C and D.",
+            "",
+            "Note: tcp addresses passed without \"tcp://\" prefix will have it prepended"});
+
+    conf.defineOption<std::string>("api", "authkey", Deprecated);
   }
 
   void

--- a/llarp/config/config.hpp
+++ b/llarp/config/config.hpp
@@ -2,8 +2,8 @@
 #include "ini.hpp"
 #include "definition.hpp"
 
+#include <oxenmq/auth.h>
 #include <chrono>
-
 #include <llarp/bootstrap.hpp>
 #include <llarp/crypto/types.hpp>
 #include <llarp/router_contact.hpp>
@@ -26,6 +26,7 @@
 #include <utility>
 #include <vector>
 #include <unordered_set>
+#include <unordered_map>
 
 #include <oxenmq/address.h>
 
@@ -190,6 +191,7 @@ namespace llarp
   {
     bool m_enableRPCServer = false;
     std::vector<oxenmq::address> m_rpcBindAddresses;
+    std::unordered_map<oxenmq::address, std::unordered_set<std::string>> m_rpcEncryptedAddresses;
 
     void
     defineConfigOptions(ConfigDefinition& conf, const ConfigGenParameters& params);

--- a/llarp/rpc/rpc_server.cpp
+++ b/llarp/rpc/rpc_server.cpp
@@ -1,5 +1,7 @@
 #include "rpc_server.hpp"
 #include "llarp/rpc/rpc_request_definitions.hpp"
+#include "llarp/util/logging.hpp"
+#include "oxen/log.hpp"
 #include "rpc_request.hpp"
 #include "llarp/service/address.hpp"
 #include <cmath>
@@ -106,18 +108,22 @@ namespace llarp::rpc
     for (const auto& addr : r.GetConfig()->api.m_rpcBindAddresses)
     {
       m_LMQ->listen_plain(addr.zmq_address());
-      LogInfo("Bound RPC server to ", addr.full_address());
+      log::info(logcat, "Bound RPC server to {}", addr.full_address());
     }
 
-    for (const auto& [address, allowed_keys] : r->GetConfig()->api.m_rpcEncryptedAddresses)
+    for (const auto& [address, allowed_keys] : r.GetConfig()->api.m_rpcEncryptedAddresses)
     {
-      m_LMQ->listen_curve(address.zmq_address(), [allowed_keys = allowed_keys](auto pk, ...) {
-        if (std::find(allowed_keys.begin(), allowed_keys.end(), pk) != allowed_keys.end())
-          return oxenmq::AuthLevel::admin;
+      m_LMQ->listen_curve(
+          address.zmq_address(), [allowed_keys = allowed_keys](auto addr, auto pk, ...) {
+            if (allowed_keys.count(std::string{pk}))
+              return oxenmq::AuthLevel::admin;
 
-        LogInfo("Curve pubkey not found in whitelist");
-        return oxenmq::AuthLevel::denied;
-      });
+            log::warning(
+                logcat,
+                "Curve pubkey not in whitelist, denying incoming RPC connection from {}",
+                addr);
+            return oxenmq::AuthLevel::denied;
+          });
     }
 
     AddCategories();

--- a/llarp/rpc/rpc_server.cpp
+++ b/llarp/rpc/rpc_server.cpp
@@ -109,6 +109,17 @@ namespace llarp::rpc
       LogInfo("Bound RPC server to ", addr.full_address());
     }
 
+    for (const auto& [address, allowed_keys] : r->GetConfig()->api.m_rpcEncryptedAddresses)
+    {
+      m_LMQ->listen_curve(address.zmq_address(), [allowed_keys = allowed_keys](auto pk, ...) {
+        if (std::find(allowed_keys.begin(), allowed_keys.end(), pk) != allowed_keys.end())
+          return oxenmq::AuthLevel::admin;
+
+        LogInfo("Curve pubkey not found in whitelist");
+        return oxenmq::AuthLevel::denied;
+      });
+    }
+
     AddCategories();
   }
 


### PR DESCRIPTION
User can specify encrypted listener addresses and comma-delimited public keys to be accepted by exposed encrypted listener. Keys must be attached to a listener address.

Example: 

`bind_curve=tcp://0.0.0.0:1234|pubkeyA,pubkeyB`
`bind_curve=tcp://0.0.0.0:5678|pubkeyC,pubkeyD`
 
In the given example above, port 1234 is only accessible by whitelisted pubkeys A and B, while 5678 is accessible by C and D.

Fixes: #2122 