### PR TITLE
reduce number of jobs pushed through omq proxy thread.

### DIFF
--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -78,6 +78,12 @@ namespace llarp
     path::BuildLimiter m_PathBuildLimiter;
 
     std::shared_ptr<EventLoopWakeup> m_Pump;
+    std::shared_ptr<EventLoopWakeup> m_Work;
+    std::vector<std::function<void()>> m_WorkJobs;
+
+    /// submits cpu heavy work from last event loop tick cycle to worker threads.
+    void
+    submit_work();
 
     path::BuildLimiter&
     pathBuildLimiter() override
@@ -196,9 +202,11 @@ namespace llarp
       return _vpnPlatform.get();
     }
 
+    /// queue functionally pure cpu heavy work to be done in another thread.
     void
     QueueWork(std::function<void(void)> func) override;
 
+    /// queue disk io bound work to be done in the disk io thread.
     void
     QueueDiskIO(std::function<void(void)> func) override;
 


### PR DESCRIPTION
when we queue cpu heavy work in lokinet to worker threads we make 1 job per function call. we call a lot of jobs so this coleuses the jobs into 1 job that we push off at the end of the event loop cycle, reducing the number of jobs going across the omq proxy thread, in theory reducing cpu usage.

@jagerman 
i am curious how much perf increase we get on snodes, so i'd like to have this tested on testnet 