### PR TITLE
Redo wire protocol race condition fix.

### DIFF
--- a/llarp/iwp/session.cpp
+++ b/llarp/iwp/session.cpp
@@ -141,6 +141,8 @@ namespace llarp
     void
     Session::EncryptAndSend(ILinkSession::Packet_t data)
     {
+      if (m_State == State::Closed)
+        return;
       m_EncryptNext.emplace_back(std::move(data));
       TriggerPump();
       if (!IsEstablished())
@@ -176,12 +178,9 @@ namespace llarp
         return;
       auto close_msg = CreatePacket(Command::eCLOS, 0, 16, 16);
       m_Parent->UnmapAddr(m_RemoteAddr);
-      m_State = State::Closed;
-      if (m_SentClosed.test_and_set())
-        return;
       EncryptAndSend(std::move(close_msg));
-
       LogInfo(m_Parent->PrintableName(), " closing connection to ", m_RemoteAddr);
+      m_State = State::Closed;
     }
 
     bool
@@ -352,7 +351,7 @@ namespace llarp
     bool
     Session::TimedOut(llarp_time_t now) const
     {
-      if (m_State == State::Ready)
+      if (m_State == State::Ready || m_State == State::LinkIntro)
       {
         return now > m_LastRX
             && now - m_LastRX

--- a/llarp/iwp/session.hpp
+++ b/llarp/iwp/session.hpp
@@ -206,7 +206,6 @@ namespace llarp
 
       std::atomic_flag m_PlaintextEmpty;
       llarp::thread::Queue<CryptoQueue_t> m_PlaintextRecv;
-      std::atomic_flag m_SentClosed;
 
       void
       EncryptWorker(CryptoQueue_t msgs);

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -482,8 +482,8 @@ namespace llarp
       LogError("RC is invalid, not saving");
       return false;
     }
-    if (m_isServiceNode)
-      _nodedb->Put(_rc);
+    if (IsServiceNode())
+      _nodedb->Put(rc());
     QueueDiskIO([&]() { HandleSaveRC(); });
     return true;
   }


### PR DESCRIPTION
In commit a76acd49560f9845c2ad9a839364f2834afc7756 we attempted to fix issues on service nodes that related to spamming service nodes with traffc, but this caused a regression where clients could not connect to the network.

However, we also did something idiotic with the protocol handshake. The handshake logic was modified and caused client connections to fail. This was due to a change in how we decided what a timed out session is. We redo the close bug and revert the change to the protocol handshake.