### PR TITLE
document behavior of dns section.

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -783,6 +783,11 @@ namespace llarp
   DnsConfig::defineConfigOptions(ConfigDefinition& conf, const ConfigGenParameters& params)
   {
     (void)params;
+    conf.addSectionComments(
+        "dns",
+        {"This section is responsible for setting up dns subsystem."
+         "Any config items suffixed with a key suffixed with ':' (e.g. dns-cache-max:= 6000) are "
+         "forwarded to libunbound when it is configured on startup."});
 
     // Most non-linux platforms have loopback as 127.0.0.1/32, but linux uses 127.0.0.1/8 so that we
     // can bind to other 127.* IPs to avoid conflicting with something else that may be listening on
@@ -893,6 +898,9 @@ namespace llarp
 
     // forward the rest to libunbound
     conf.addUndeclaredHandler("dns", [this](auto, std::string_view key, std::string_view val) {
+      if (not ends_with(key, ":"))
+        throw std::invalid_argument{"Invalid option provided in dns config: '{}'"_format(key)};
+
       m_ExtraOpts.emplace(key, val);
     });
   }


### PR DESCRIPTION
Before we were just shoving all options into libunbound and assume they end with a ':', now we ensure they do and throw if they do not.

This adds a check and documents this behavior in config section.