### PR TITLE
make clients with strict-connect option explicitly connect to provided snode.

### DIFF
--- a/llarp/CMakeLists.txt
+++ b/llarp/CMakeLists.txt
@@ -145,6 +145,7 @@ add_library(lokinet-config
 # lokinet-consensus is for deriving and tracking network consensus state for both service nodes and clients
 add_library(lokinet-consensus
   STATIC
+  consensus/edge_selector.cpp
   consensus/reachability_testing.cpp
 )
 

--- a/llarp/consensus/edge_selector.cpp
+++ b/llarp/consensus/edge_selector.cpp
@@ -1,0 +1,71 @@
+#include "edge_selector.hpp"
+
+#include <llarp/router/abstractrouter.hpp>
+#include <llarp/crypto/crypto.hpp>
+#include <llarp/nodedb.hpp>
+#include <llarp/profiling.hpp>
+
+namespace llarp::consensus
+{
+
+  EdgeSelector::EdgeSelector(AbstractRouter& r) : _router{r}
+  {}
+
+  std::optional<RouterContact>
+  EdgeSelector::select_path_edge(const std::unordered_set<RouterID>& connected_now) const
+  {
+    auto conf = _router.GetConfig();
+    auto nodedb = _router.nodedb();
+
+    const auto& _keys = conf->network.m_strictConnect;
+    // no strict hops. select a random good snode.
+    if (_keys.empty())
+    {
+      return nodedb->GetRandom([&connected_now, this](const auto& rc) {
+        return connected_now.count(rc.pubkey) == 0
+            and not _router.routerProfiling().IsBadForConnect(rc.pubkey)
+            and not _router.IsBootstrapNode(rc.pubkey);
+      });
+    }
+
+    // select random from strict connections.
+    std::vector<RouterID> keys{_keys.begin(), _keys.end()};
+
+    std::shuffle(keys.begin(), keys.end(), llarp::CSRNG{});
+
+    for (const auto& pk : keys)
+    {
+      if (_router.routerProfiling().IsBadForConnect(pk))
+        continue;
+      if (connected_now.count(pk))
+        continue;
+      if (auto maybe = nodedb->Get(pk))
+        return maybe;
+    }
+    return std::nullopt;
+  }
+
+  std::optional<RouterContact>
+  EdgeSelector::select_bootstrap(const std::unordered_set<RouterID>& connected_now) const
+  {
+    auto conf = _router.GetConfig();
+    auto nodedb = _router.nodedb();
+    if (const auto& _keys = conf->network.m_strictConnect; not _keys.empty())
+    {
+      // try bootstrapping off strict connections first if we have any.
+      std::vector<RouterID> keys{_keys.begin(), _keys.end()};
+      std::shuffle(keys.begin(), keys.end(), llarp::CSRNG{});
+      for (const auto& pk : keys)
+      {
+        if (connected_now.count(pk))
+          continue;
+        if (auto maybe = nodedb->Get(pk))
+          return maybe;
+      }
+    }
+    // if we cant use a strict connection we'll just use one of our bootstrap nodes.
+    return nodedb->GetRandom([&connected_now, this](const auto& rc) {
+      return connected_now.count(rc.pubkey) == 0 and _router.IsBootstrapNode(rc.pubkey);
+    });
+  }
+}  // namespace llarp::consensus

--- a/llarp/consensus/edge_selector.hpp
+++ b/llarp/consensus/edge_selector.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <optional>
+#include <unordered_set>
+#include <llarp/router_id.hpp>
+
+namespace llarp
+{
+  struct AbstractRouter;
+  struct RouterContact;
+}  // namespace llarp
+
+namespace llarp::consensus
+{
+  /// when we want to connect to and edge when we are a client, an instance of EdgeSelector acts as
+  /// a stateless selection algorith for router contacts for each attempt at connecting out we make.
+  class EdgeSelector
+  {
+    AbstractRouter& _router;
+
+   public:
+    explicit EdgeSelector(AbstractRouter& router);
+
+    /// select a candidate for connecting out to the network when we need more connections to do a
+    /// path build. pass in an unordered set of the snode pubkeys we are currently connected to.
+    std::optional<RouterContact>
+    select_path_edge(const std::unordered_set<RouterID>& connected_now = {}) const;
+
+    /// get a router contact of a bootstrap snode to bootstrap with if we are in need of
+    /// bootstrapping more peers. pass in an unodereed set of bootstrap router pubkeys we are
+    /// currently connected to.
+    std::optional<RouterContact>
+    select_bootstrap(const std::unordered_set<RouterID>& connected_now = {}) const;
+  };
+}  // namespace llarp::consensus

--- a/llarp/router/abstractrouter.hpp
+++ b/llarp/router/abstractrouter.hpp
@@ -45,6 +45,11 @@ namespace llarp
   struct I_RCLookupHandler;
   struct RoutePoker;
 
+  namespace consensus
+  {
+    class EdgeSelector;
+  }
+
   namespace dns
   {
     class I_SystemSettings;
@@ -129,6 +134,9 @@ namespace llarp
 
     virtual const RouterContact&
     rc() const = 0;
+
+    virtual const consensus::EdgeSelector&
+    edge_selector() const = 0;
 
     /// modify our rc
     /// modify returns nullopt if unmodified otherwise it returns the new rc to be sigend and

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -3,6 +3,7 @@
 #include "abstractrouter.hpp"
 
 #include <llarp/bootstrap.hpp>
+#include <llarp/consensus/edge_selector.hpp>
 #include <llarp/config/config.hpp>
 #include <llarp/config/key_manager.hpp>
 #include <llarp/constants/link_layer.hpp>
@@ -79,6 +80,8 @@ namespace llarp
 
     std::shared_ptr<EventLoopWakeup> m_Pump;
 
+    consensus::EdgeSelector _edge_selector;
+
     path::BuildLimiter&
     pathBuildLimiter() override
     {
@@ -147,6 +150,9 @@ namespace llarp
         const std::vector<RouterID>& whitelist,
         const std::vector<RouterID>& greylist,
         const std::vector<RouterID>& unfunded) override;
+
+    const consensus::EdgeSelector&
+    edge_selector() const override;
 
     std::unordered_set<RouterID>
     GetRouterWhitelist() const override


### PR DESCRIPTION
make lokinet client with strict-connect option provided explicitly connect out to snodes provided. before it was just randomly chugging through peer selection until it found one we explicitly pinned. this rarely works.

* create new component for selecting edge snodes as client (llarp::consensus::EdgeSelector)
* require llarp::AbstractRouter own a llarp::consensus::EdgeSelector
* make outbound_session_maker.cpp use llarp::consensus::EdgeSelector owned by llarp::AbstractRouter


fixes #2169 