### PR TITLE
libunbound ipv6 upstream dns syntax error

### DIFF
--- a/llarp/dns/server.cpp
+++ b/llarp/dns/server.cpp
@@ -177,10 +177,7 @@ namespace llarp::dns
       void
       AddUpstreamResolver(const SockAddr& dns)
       {
-        std::string str = dns.hostString();
-
-        if (const auto port = dns.getPort(); port != 53)
-          fmt::format_to(std::back_inserter(str), "@{}", port);
+        std::string str = fmt::format("{}@{}", dns.hostString(false), dns.getPort());
 
         if (auto err = ub_ctx_set_fwd(m_ctx, str.c_str()))
         {

--- a/llarp/ev/libuv.cpp
+++ b/llarp/ev/libuv.cpp
@@ -75,8 +75,11 @@ namespace llarp::uv
     std::optional<SockAddr>
     LocalAddr() const override
     {
-      auto addr = handle->sock<uvw::IPv4>();
-      return SockAddr{addr.ip, huint16_t{static_cast<uint16_t>(addr.port)}};
+      if (auto addr = handle->sock<uvw::IPv4>(); not addr.ip.empty())
+        return SockAddr{addr.ip, huint16_t{static_cast<uint16_t>(addr.port)}};
+      if (auto addr = handle->sock<uvw::IPv6>(); not addr.ip.empty())
+        return SockAddr{addr.ip, huint16_t{static_cast<uint16_t>(addr.port)}};
+      return std::nullopt;
     }
 
     std::optional<int>

--- a/llarp/net/sock_addr.cpp
+++ b/llarp/net/sock_addr.cpp
@@ -290,7 +290,7 @@ namespace llarp
   }
 
   std::string
-  SockAddr::hostString(bool add_braces) const
+  SockAddr::hostString(bool ipv6_brackets) const
   {
     std::array<char, 128> buf{};
     if (isIPv4())
@@ -301,7 +301,7 @@ namespace llarp
     }
 
     inet_ntop(AF_INET6, &m_addr.sin6_addr.s6_addr, buf.data(), buf.size());
-    if (not add_braces)
+    if (not ipv6_brackets)
       return buf.data();
 
     return fmt::format("[{}]", buf.data());

--- a/llarp/net/sock_addr.cpp
+++ b/llarp/net/sock_addr.cpp
@@ -290,25 +290,21 @@ namespace llarp
   }
 
   std::string
-  SockAddr::hostString() const
+  SockAddr::hostString(bool add_braces) const
   {
-    std::string str;
-    char buf[INET6_ADDRSTRLEN] = {0x0};
+    std::array<char, 128> buf{};
     if (isIPv4())
     {
-      // handle IPv4 mapped addrs
-      inet_ntop(AF_INET, &m_addr4.sin_addr.s_addr, buf, sizeof(buf));
-      str = buf;
+      // IPv4 mapped addrs
+      inet_ntop(AF_INET, &m_addr4.sin_addr.s_addr, buf.data(), buf.size());
+      return buf.data();
     }
-    else
-    {
-      inet_ntop(AF_INET6, &m_addr.sin6_addr.s6_addr, buf, sizeof(buf));
-      str.reserve(std::strlen(buf) + 2);
-      str.append("[");
-      str.append(buf);
-      str.append("]");
-    }
-    return str;
+
+    inet_ntop(AF_INET6, &m_addr.sin6_addr.s6_addr, buf.data(), buf.size());
+    if (not add_braces)
+      return buf.data();
+
+    return fmt::format("[{}]", buf.data());
   }
 
   bool

--- a/llarp/net/sock_addr.hpp
+++ b/llarp/net/sock_addr.hpp
@@ -86,8 +86,10 @@ namespace llarp
     std::string
     ToString() const;
 
+    /// convert ip address to string; ipv6_brackets - if true or omitted we add [...] around the
+    /// IPv6 address, otherwise we return it bare.
     std::string
-    hostString(bool add_braces = true) const;
+    hostString(bool ipv6_brackets = true) const;
 
     inline int
     Family() const

--- a/llarp/net/sock_addr.hpp
+++ b/llarp/net/sock_addr.hpp
@@ -87,7 +87,7 @@ namespace llarp
     ToString() const;
 
     std::string
-    hostString() const;
+    hostString(bool add_braces = true) const;
 
     inline int
     Family() const


### PR DESCRIPTION
when setting libunbound's upstream dns, we need to not pass in the square braces of an ipv6 address. we also net udp handles have ipv6 address for the local ip.

fixes issue #2179