### PR TITLE
Added workflow to remove stale, incomplete issues

### DIFF
--- a/.github/workflows/clean_issues.yml
+++ b/.github/workflows/clean_issues.yml
@@ -1,0 +1,22 @@
+name: Close incomplete issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v4.1.1
+        with:
+          only-labels: incomplete
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been 'incomplete' for 14 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
New github workflow to remove incomplete issues that are abandoned by the submitting user.

To be deleted, an issue must be:

1. Tagged as "incomplete", request made for more information
2. No response after being tagged as incomplete for 14 days, issue is marked "stale"
3. After 7 more days of no response, issue is deleted