### PR TITLE
RC and RouterID fetching

### DIFF
--- a/llarp/link/link_manager.cpp
+++ b/llarp/link/link_manager.cpp
@@ -500,8 +500,7 @@ namespace llarp
       {
         log::info(
             link_cat, "Remote requested too many relay IDs (greater than 1/4 of what we have).");
-        m.respond(
-            serialize_response({{messages::STATUS_KEY, RCFetchMessage::INVALID_REQUEST}}));
+        m.respond(serialize_response({{messages::STATUS_KEY, RCFetchMessage::INVALID_REQUEST}}));
         return;
       }
 
@@ -510,8 +509,7 @@ namespace llarp
       {
         if (sv.size() != RouterID::SIZE)
         {
-          m.respond(serialize_response(
-              {{messages::STATUS_KEY, RCFetchMessage::INVALID_REQUEST}}));
+          m.respond(serialize_response({{messages::STATUS_KEY, RCFetchMessage::INVALID_REQUEST}}));
           return;
         }
         explicit_relays.emplace(reinterpret_cast<const byte_t*>(sv.data()));

--- a/llarp/link/link_manager.hpp
+++ b/llarp/link/link_manager.hpp
@@ -226,6 +226,12 @@ namespace llarp
     void
     handle_gossip_rc(oxen::quic::message m);
 
+    void
+    fetch_rcs(const RouterID& source, rc_time since, const std::vector<RouterID>& explicit_ids);
+
+    void
+    handle_fetch_rcs(oxen::quic::message m);
+
     bool
     have_connection_to(const RouterID& remote, bool client_only = false) const;
 

--- a/llarp/link/link_manager.hpp
+++ b/llarp/link/link_manager.hpp
@@ -232,6 +232,12 @@ namespace llarp
     void
     handle_fetch_rcs(oxen::quic::message m);
 
+    void
+    fetch_router_ids(const RouterID& source);
+
+    void
+    handle_fetch_router_ids(oxen::quic::message m);
+
     bool
     have_connection_to(const RouterID& remote, bool client_only = false) const;
 

--- a/llarp/messages/dht.hpp
+++ b/llarp/messages/dht.hpp
@@ -4,51 +4,6 @@
 
 namespace llarp
 {
-  namespace FindRouterMessage
-  {
-    inline auto RETRY_EXP = "RETRY AS EXPLORATORY"sv;
-    inline auto RETRY_ITER = "RETRY AS ITERATIVE"sv;
-    inline auto RETRY_NEW = "RETRY WITH NEW RECIPIENT"sv;
-
-    inline static std::string
-    serialize(const RouterID& rid, bool is_iterative, bool is_exploratory)
-    {
-      oxenc::bt_dict_producer btdp;
-
-      try
-      {
-        btdp.append("E", is_exploratory ? 1 : 0);
-        btdp.append("I", is_iterative ? 1 : 0);
-        btdp.append("K", rid.ToView());
-      }
-      catch (...)
-      {
-        log::error(link_cat, "Error: FindRouterMessage failed to bt encode contents!");
-      }
-
-      return std::move(btdp).str();
-    }
-
-    inline static std::string
-    serialize(const std::string& rid, bool is_iterative, bool is_exploratory)
-    {
-      oxenc::bt_dict_producer btdp;
-
-      try
-      {
-        btdp.append("E", is_exploratory ? 1 : 0);
-        btdp.append("I", is_iterative ? 1 : 0);
-        btdp.append("K", std::move(rid));
-      }
-      catch (...)
-      {
-        log::error(link_cat, "Error: FindRouterMessage failed to bt encode contents!");
-      }
-
-      return std::move(btdp).str();
-    }
-  }  // namespace FindRouterMessage
-
   namespace FindIntroMessage
   {
     inline auto NOT_FOUND = "NOT FOUND"sv;

--- a/llarp/messages/rc.hpp
+++ b/llarp/messages/rc.hpp
@@ -14,9 +14,11 @@ namespace llarp::RCFetchMessage
     try
     {
       btdp.append("since", since.time_since_epoch() / 1s);
-      auto id_list = btdp.append_list("explicit_ids");
-      for (const auto& rid : explicit_ids)
-        id_list.append(rid.ToView());
+      {
+        auto id_list = btdp.append_list("explicit_ids");
+        for (const auto& rid : explicit_ids)
+          id_list.append(rid.ToView());
+      }
     }
     catch (...)
     {

--- a/llarp/messages/rc.hpp
+++ b/llarp/messages/rc.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "common.hpp"
+
+namespace llarp::RCFetchMessage
+{
+  inline constexpr auto INVALID_REQUEST = "Invalid relay ID requested."sv;
+
+  inline static std::string
+  serialize(std::chrono::system_clock::time_point since, const std::vector<RouterID>& explicit_ids)
+  {
+    oxenc::bt_dict_producer btdp;
+
+    try
+    {
+      btdp.append("since", since.time_since_epoch() / 1s);
+      auto id_list = btdp.append_list("explicit_ids");
+      for (const auto& rid : explicit_ids)
+        id_list.append(rid.ToView());
+    }
+    catch (...)
+    {
+      log::error(link_cat, "Error: RCFetchMessage failed to bt encode contents!");
+    }
+
+    return std::move(btdp).str();
+  }
+}  // namespace llarp::RCFetchMessage

--- a/llarp/messages/router_id.hpp
+++ b/llarp/messages/router_id.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "common.hpp"
+
+namespace llarp::RouterIDFetch
+{
+  inline constexpr auto INVALID_REQUEST = "Invalid relay ID requested to relay response from."sv;
+
+  inline static std::string
+  serialize(const RouterID& source)
+  {
+    // serialize_response is a bit weird here, and perhaps could have a sister function
+    // with the same purpose but as a request, but...it works.
+    return messages::serialize_response({{"source", source.ToView()}});
+  }
+
+}  // namespace llarp::RouterIDFetch

--- a/llarp/nodedb.cpp
+++ b/llarp/nodedb.cpp
@@ -203,7 +203,7 @@ namespace llarp
     if (router_id_fetch_in_progress)
       return;
     if (router_id_fetch_sources.empty())
-      select_router_id_sources({});
+      select_router_id_sources();
 
     // if we *still* don't have fetch sources, we can't exactly fetch...
     if (router_id_fetch_sources.empty())

--- a/llarp/nodedb.cpp
+++ b/llarp/nodedb.cpp
@@ -181,7 +181,7 @@ namespace llarp
   }
 
   void
-  NodeDB::update_rcs()
+  NodeDB::fetch_rcs()
   {
     std::vector<RouterID> needed;
 

--- a/llarp/nodedb.hpp
+++ b/llarp/nodedb.hpp
@@ -26,7 +26,7 @@ namespace llarp
   {
     std::unordered_map<RouterID, RemoteRC> known_rcs;
 
-    const Router& router;
+    Router& router;
     const fs::path m_Root;
     const std::function<void(std::function<void()>)> disk;
 
@@ -42,18 +42,30 @@ namespace llarp
 
     std::unordered_map<RouterID, RemoteRC> bootstraps;
 
+    // Router lists for snodes
     // whitelist = active routers
     std::unordered_set<RouterID> router_whitelist;
     // greylist = fully funded, but decommissioned routers
     std::unordered_set<RouterID> router_greylist;
     // greenlist = registered but not fully-staked routers
     std::unordered_set<RouterID> router_greenlist;
-
     // all registered relays (snodes)
     std::unordered_set<RouterID> registered_routers;
+    std::unordered_map<RouterID, rc_time> last_rc_update_times;
+
+    // Router list for clients
+    std::unordered_set<RouterID> client_known_rcs;
 
     // only ever use to specific edges as path first-hops
     std::unordered_set<RouterID> pinned_edges;
+
+    // rc update info
+    RouterID rc_fetch_source;
+    rc_time last_rc_update_relay_timestamp;
+    std::unordered_set<RouterID> router_id_fetch_sources;
+    std::unordered_map<RouterID, std::vector<RouterID>> router_id_fetch_responses;
+    // process responses once all are received (or failed/timed out)
+    size_t router_id_response_count{0};
 
     bool
     want_rc(const RouterID& rid) const;
@@ -79,6 +91,38 @@ namespace llarp
     {
       return registered_routers;
     }
+
+    const std::unordered_map<RouterID, RemoteRC>&
+    get_rcs() const
+    {
+      return known_rcs;
+    }
+
+    const std::unordered_map<RouterID, rc_time>&
+    get_last_rc_update_times() const
+    {
+      return last_rc_update_times;
+    }
+
+    // If we receive a set of RCs from our current RC source relay, we consider
+    // that relay to be a bad source of RCs and we randomly choose a new one.
+    //
+    // When using a new RC fetch relay, we first re-fetch the full RC list and, if
+    // that aligns with our RouterID list, we go back to periodic updates from that relay.
+    //
+    // This will respect edge-pinning and attempt to use a relay we already have
+    // a connection with.
+    void
+    rotate_rc_source();
+
+    void
+    ingest_rcs(RouterID source, std::vector<RemoteRC> rcs, rc_time timestamp);
+
+    void
+    ingest_router_ids(RouterID source, std::vector<RouterID> ids);
+
+    void
+    update_rcs();
 
     void
     set_router_whitelist(
@@ -225,12 +269,18 @@ namespace llarp
 
     /// put (or replace) the RC if we consider it valid (want_rc).  returns true if put.
     bool
-    put_rc(RemoteRC rc);
+    put_rc(
+        RemoteRC rc,
+        rc_time now =
+            std::chrono::time_point_cast<std::chrono::seconds>(std::chrono::system_clock::now()));
 
     /// if we consider it valid (want_rc),
     /// put this rc into the cache if it is not there or is newer than the one there already
     /// returns true if the rc was inserted
     bool
-    put_rc_if_newer(RemoteRC rc);
+    put_rc_if_newer(
+        RemoteRC rc,
+        rc_time now =
+            std::chrono::time_point_cast<std::chrono::seconds>(std::chrono::system_clock::now()));
   };
 }  // namespace llarp

--- a/llarp/nodedb.hpp
+++ b/llarp/nodedb.hpp
@@ -271,9 +271,12 @@ namespace llarp
       });
     }
 
-    /// remove rcs that are not in keep and have been inserted before cutoff
+    /// remove rcs that are older than we want to keep.  For relays, this is when
+    /// they  become "outdated" (i.e. 12hrs).  Clients will hang on to them until
+    /// they are fully "expired" (i.e. 30 days), as the client may go offline for
+    /// some time and can still try to use those RCs to re-learn the network.
     void
-    remove_stale_rcs(std::unordered_set<RouterID> keep, llarp_time_t cutoff);
+    remove_stale_rcs();
 
     /// put (or replace) the RC if we consider it valid (want_rc).  returns true if put.
     bool

--- a/llarp/nodedb.hpp
+++ b/llarp/nodedb.hpp
@@ -130,7 +130,7 @@ namespace llarp
     fetch_router_ids();
 
     void
-    select_router_id_sources(std::unordered_set<RouterID> excluded);
+    select_router_id_sources(std::unordered_set<RouterID> excluded = {});
 
     void
     set_router_whitelist(

--- a/llarp/nodedb.hpp
+++ b/llarp/nodedb.hpp
@@ -54,7 +54,7 @@ namespace llarp
     std::unordered_map<RouterID, rc_time> last_rc_update_times;
 
     // Router list for clients
-    std::unordered_set<RouterID> client_known_rcs;
+    std::unordered_set<RouterID> client_known_routers;
 
     // only ever use to specific edges as path first-hops
     std::unordered_set<RouterID> pinned_edges;
@@ -62,10 +62,12 @@ namespace llarp
     // rc update info
     RouterID rc_fetch_source;
     rc_time last_rc_update_relay_timestamp;
+    static constexpr auto ROUTER_ID_SOURCE_COUNT = 12;
     std::unordered_set<RouterID> router_id_fetch_sources;
     std::unordered_map<RouterID, std::vector<RouterID>> router_id_fetch_responses;
     // process responses once all are received (or failed/timed out)
     size_t router_id_response_count{0};
+    bool router_id_fetch_in_progress{false};
 
     bool
     want_rc(const RouterID& rid) const;
@@ -104,7 +106,7 @@ namespace llarp
       return last_rc_update_times;
     }
 
-    // If we receive a set of RCs from our current RC source relay, we consider
+    // If we receive a bad set of RCs from our current RC source relay, we consider
     // that relay to be a bad source of RCs and we randomly choose a new one.
     //
     // When using a new RC fetch relay, we first re-fetch the full RC list and, if
@@ -123,6 +125,12 @@ namespace llarp
 
     void
     update_rcs();
+
+    void
+    fetch_router_ids();
+
+    void
+    select_router_id_sources(std::unordered_set<RouterID> excluded);
 
     void
     set_router_whitelist(

--- a/llarp/nodedb.hpp
+++ b/llarp/nodedb.hpp
@@ -124,7 +124,7 @@ namespace llarp
     ingest_router_ids(RouterID source, std::vector<RouterID> ids);
 
     void
-    update_rcs();
+    fetch_rcs();
 
     void
     fetch_router_ids();

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -835,6 +835,13 @@ namespace llarp
       next_rc_gossip = now_timepoint + RouterContact::STALE_AGE - random_delta;
     }
 
+    // (client-only) periodically fetch updated RCs
+    if (now_timepoint - last_rc_fetch > RC_UPDATE_INTERVAL)
+    {
+      node_db()->update_rcs();
+      last_rc_fetch = now_timepoint;
+    }
+
     // remove RCs for nodes that are no longer allowed by network policy
     node_db()->RemoveIf([&](const RemoteRC& rc) -> bool {
       // don't purge bootstrap nodes from nodedb

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -835,11 +835,21 @@ namespace llarp
       next_rc_gossip = now_timepoint + RouterContact::STALE_AGE - random_delta;
     }
 
-    // (client-only) periodically fetch updated RCs
-    if (now_timepoint - last_rc_fetch > RC_UPDATE_INTERVAL)
+    if (not is_snode)
     {
-      node_db()->update_rcs();
-      last_rc_fetch = now_timepoint;
+      // (client-only) periodically fetch updated RCs
+      if (now_timepoint - last_rc_fetch > RC_UPDATE_INTERVAL)
+      {
+        node_db()->fetch_rcs();
+        last_rc_fetch = now_timepoint;
+      }
+
+      // (client-only) periodically fetch updated RouterID list
+      if (now_timepoint - last_routerid_fetch > ROUTERID_UPDATE_INTERVAL)
+      {
+        node_db()->fetch_router_ids();
+        last_routerid_fetch = now_timepoint;
+      }
     }
 
     // remove RCs for nodes that are no longer allowed by network policy

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -57,6 +57,8 @@ namespace llarp
   static constexpr size_t INTROSET_STORAGE_REDUNDANCY =
       (INTROSET_RELAY_REDUNDANCY * INTROSET_REQS_PER_RELAY);
 
+  static const std::chrono::seconds RC_UPDATE_INTERVAL = 5min;
+
   struct Contacts;
 
   struct Router : std::enable_shared_from_this<Router>
@@ -127,6 +129,9 @@ namespace llarp
     std::chrono::system_clock::time_point last_rc_gossip{
         std::chrono::system_clock::time_point::min()};
     std::chrono::system_clock::time_point next_rc_gossip{
+        std::chrono::system_clock::time_point::min()};
+
+    std::chrono::system_clock::time_point last_rc_fetch{
         std::chrono::system_clock::time_point::min()};
 
     // should we be sending padded messages every interval?

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -58,6 +58,7 @@ namespace llarp
       (INTROSET_RELAY_REDUNDANCY * INTROSET_REQS_PER_RELAY);
 
   static const std::chrono::seconds RC_UPDATE_INTERVAL = 5min;
+  static const std::chrono::seconds ROUTERID_UPDATE_INTERVAL = 1h;
 
   struct Contacts;
 
@@ -132,6 +133,8 @@ namespace llarp
         std::chrono::system_clock::time_point::min()};
 
     std::chrono::system_clock::time_point last_rc_fetch{
+        std::chrono::system_clock::time_point::min()};
+    std::chrono::system_clock::time_point last_routerid_fetch{
         std::chrono::system_clock::time_point::min()};
 
     // should we be sending padded messages every interval?


### PR DESCRIPTION
Implements the mechanisms by which a client will fetch the current list of RouterIDs and RCs from the network.  Relays will use the latter on bootstrap as well, confirming registration against the RouterIDs they get from oxend.

TODO: RouterIDs are fetched from 12 different relays (if possible); the logic to wait for all the responses is in place, but the logic to reconcile them is not.

TODO: RCs are fetched from a connected edge.  The logic to distrust this edge if its RC list deviates too far from our known RouterID list is not yet implemented.

Depends #2224