### PR TITLE
Fix invalid oxend rpc call

### DIFF
--- a/llarp/rpc/lokid_rpc_client.cpp
+++ b/llarp/rpc/lokid_rpc_client.cpp
@@ -126,7 +126,7 @@ namespace llarp
            }},
       };
       if (!m_LastUpdateHash.empty())
-        request["fields"]["poll_block_hash"] = m_LastUpdateHash;
+        request["poll_block_hash"] = m_LastUpdateHash;
 
       Request(
           "rpc.get_service_nodes",


### PR DESCRIPTION
This call is wrong (and has always been wrong): the field should be set in the top-level parameters, not inside `fields`.

In current dev lokinet, however, the invalid field becomes an error, because dev tries to parse all `fields` keys with `bool` values, and this ends up returning an error to Lokinet instead of a response, which breaks Lokinet's service node updating code when used with oxend 11.