### PR TITLE
Crash fixes

### DIFF
--- a/llarp/link/link_manager.cpp
+++ b/llarp/link/link_manager.cpp
@@ -19,7 +19,7 @@
 
 namespace llarp
 {
-    static auto logcat = llarp::log::Cat("lquic");
+    static auto logcat = llarp::log::Cat("link_manager");
 
     static constexpr auto static_shared_key = "Lokinet static shared secret key"sv;
 
@@ -347,11 +347,11 @@ namespace llarp
         : _router{r},
           node_db{_router.node_db()},
           _is_service_node{_router.is_service_node()},
-          quic{std::make_unique<oxen::quic::Network>()},
+          quic_loop{std::make_unique<oxen::quic::Loop>()},
           tls_creds{oxen::quic::GNUTLSCreds::make_from_ed_keys(
               {reinterpret_cast<const char*>(_router.identity().data()), 32},
               {reinterpret_cast<const char*>(_router.local_rid().data()), 32})},
-          ep{_router.loop()->template make_shared<link::Endpoint>(startup_endpoint(), *this)},
+          ep{std::make_unique<link::Endpoint>(startup_endpoint(), *this)},
           is_stopping{false}
     {}
 
@@ -372,7 +372,8 @@ namespace llarp
                 - bt stream construction contains a stream close callback that shuts down the
                     connection if the btstream closes unexpectedly
         */
-        auto e = quic->endpoint(
+        auto e = oxen::quic::Endpoint::endpoint(
+            *quic_loop,
             _router.listen_addr(),
             make_static_secret(_router.identity()),
             [this](oxen::quic::Connection& conn) { return on_conn_open(conn); },
@@ -748,8 +749,8 @@ namespace llarp
 
         log::info(logcat, "stopping loop");
         is_stopping = true;
-        quic->set_shutdown_immediate();
-        quic.reset();
+        quic_loop->call([this] { ep.reset(); });
+        quic_loop.reset();
     }
 
     void LinkManager::set_conn_persist(const RouterID& remote, std::chrono::milliseconds until)

--- a/llarp/link/link_manager.hpp
+++ b/llarp/link/link_manager.hpp
@@ -13,8 +13,10 @@
 #include <llarp/util/decaying_hashset.hpp>
 #include <llarp/util/logging.hpp>
 
+#include <oxen/quic/endpoint.hpp>
 #include <oxen/quic/format.hpp>
 #include <oxen/quic/gnutls_crypto.hpp>
+#include <oxen/quic/loop.hpp>
 
 #include <atomic>
 #include <set>
@@ -141,12 +143,9 @@ namespace llarp
 
         const bool _is_service_node;
 
-        // NOTE: DO NOT CHANGE THE ORDER OF THESE THREE OBJECTS
-        // The quic Network must be created prior to the GNUTLS credentials, which are necessary for the creation of the
-        // quic endpoint. These are delegate initialized in the LinkManager constructor sequentially
-        std::unique_ptr<oxen::quic::Network> quic;
+        std::unique_ptr<oxen::quic::Loop> quic_loop;
         std::shared_ptr<oxen::quic::GNUTLSCreds> tls_creds;
-        std::shared_ptr<link::Endpoint> ep;
+        std::unique_ptr<link::Endpoint> ep;
 
         std::atomic<bool> is_stopping;
 

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -44,12 +44,12 @@ namespace llarp
     }
 
     Router::Router(std::shared_ptr<EventLoop> loop, std::shared_ptr<vpn::Platform> vpnPlatform, std::promise<void> p)
-        : _route_poker{std::make_shared<RoutePoker>(*this)},
-          _next_explore_at{std::chrono::steady_clock::now()},
+        : _next_explore_at{std::chrono::steady_clock::now()},
           _omq{std::make_shared<oxenmq::OxenMQ>()},
           _loop{std::move(loop)},
           _close_promise{std::make_unique<std::promise<void>>(std::move(p))},
           _vpn{std::move(vpnPlatform)},
+          _route_poker{std::make_shared<RoutePoker>(*this)},
           _disk_thread{_omq->add_tagged_thread("disk")},
           _last_tick{llarp::time_now_ms()}
     {

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -44,9 +44,9 @@ namespace llarp
     }
 
     Router::Router(std::shared_ptr<EventLoop> loop, std::shared_ptr<vpn::Platform> vpnPlatform, std::promise<void> p)
-        : _next_explore_at{std::chrono::steady_clock::now()},
+        : _loop{std::move(loop)},
+          _next_explore_at{std::chrono::steady_clock::now()},
           _omq{std::make_shared<oxenmq::OxenMQ>()},
-          _loop{std::move(loop)},
           _close_promise{std::make_unique<std::promise<void>>(std::move(p))},
           _vpn{std::move(vpnPlatform)},
           _route_poker{std::make_shared<RoutePoker>(*this)},

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -85,6 +85,7 @@ namespace llarp
         ~Router() = default;
 
       private:
+        std::shared_ptr<EventLoop> _loop;
         std::chrono::steady_clock::time_point _next_explore_at;
 
         // path to write our self signed rc to
@@ -125,7 +126,6 @@ namespace llarp
         // Only created in full client and relay instances (not embedded clients)
         std::shared_ptr<handlers::TunEndpoint> _tun;
 
-        std::shared_ptr<EventLoop> _loop;
         std::unique_ptr<std::promise<void>> _close_promise;
 
         std::shared_ptr<vpn::Platform> _vpn;

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -85,7 +85,6 @@ namespace llarp
         ~Router() = default;
 
       private:
-        std::shared_ptr<RoutePoker> _route_poker;
         std::chrono::steady_clock::time_point _next_explore_at;
 
         // path to write our self signed rc to
@@ -130,6 +129,7 @@ namespace llarp
         std::unique_ptr<std::promise<void>> _close_promise;
 
         std::shared_ptr<vpn::Platform> _vpn;
+        std::shared_ptr<RoutePoker> _route_poker;
 
         std::shared_ptr<path::PathContext> _path_context;
         std::shared_ptr<ContactDB> _contact_db;


### PR DESCRIPTION
fixes some crashes related to destructor order / object lifetime

also removes usage of quic::Network to just use quic::Loop directly, as quic::Network is unnecessary