### PR TITLE
Connected/disconnected hooks

### DIFF
--- a/contrib/liblokinet_jank_test.cpp
+++ b/contrib/liblokinet_jank_test.cpp
@@ -1,28 +1,55 @@
 #include <lokinet.hpp>
 
-#include <thread>
-#include <iostream>
-#include <cstdint>
+#include <exception>
 #include <filesystem>
+#include <future>
+#include <iostream>
+#include <thread>
 
 using namespace std::literals;
 
-int main(int argc, char** argv) {
-  lokinet::Lokinet loki{std::filesystem::path{"lokinet.ini"}};
-  //lokinet::Lokinet loki{lokinet::Network::TESTNET};
-  std::this_thread::sleep_for(5s);
-  std::string ignored;
-  if (argc > 1) {
-    std::string target{argv[1]};
-    std::cout << "\nPRESS ENTER TO START SESSION TO " << target << "\n";
-    std::getline(std::cin, ignored);
-    try {
-      auto udp_info = loki.establish_udp_blocking(target, 12345);
-      std::cout << "\nudp bound to port " << udp_info.local_port << "\n";
+int main(int argc, char** argv)
+{
+    if (argc <= 1)
+    {
+        std::cerr << "USAGE: " << argv[0] << " {WHATEVER.loki | WHATEVER.snode}\n";
+        return 1;
     }
-    catch (const std::exception& e) {
-      std::cerr << "\nError establishing session to " << target << ": " << e.what() << "\n";
-      return 1;
+
+    std::string target{argv[1]};
+
+    lokinet::Lokinet loki{std::filesystem::path{"lokinet.ini"}};
+
+    std::promise<void> prom;
+    loki.on_connected([&] {
+        std::cout << "\n\x1b[32;1mLokinet connected!\x1b[0m\n\n\x1b[33;1mINITIATING SESSION TO " << target
+                  << "\x1b[0m\n\n"
+                  << std::flush;
+        loki.establish_udp(
+            target,
+            12345,
+            [](auto udp_info) {
+                std::cout << "\n\x1b[32;1mUDP bound to port " << udp_info.local_port << "\x1b[0m\n\n" << std::flush;
+            },
+            [&prom](std::string_view fail_msg) {
+                try
+                {
+                    throw std::runtime_error{std::string{fail_msg}};
+                }
+                catch (...)
+                {
+                    prom.set_exception(std::current_exception());
+                }
+            });
+    });
+    try
+    {
+        prom.get_future().get();
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "\n\n\x1b[31;1mError establishing session to " << target << ": " << e.what() << "\x1b[0m\n\n";
+        return 1;
     }
 
     /*
@@ -34,8 +61,8 @@ int main(int argc, char** argv) {
           std::cerr << "\nTCP Tunnel map error: " << error_str << "\n";
         });
     */
-  }
-  std::cout << "\nPRESS ENTER TO EXIT\n";
-  std::getline(std::cin, ignored);
-  std::cout << "\nEXITING\n";
+    std::cout << "\nPRESS ENTER TO EXIT\n";
+    std::string ignored;
+    std::getline(std::cin, ignored);
+    std::cout << "\nEXITING\n";
 }

--- a/include/lokinet.hpp
+++ b/include/lokinet.hpp
@@ -80,7 +80,7 @@ namespace lokinet
         // Destructor stops the lokinet instance.  The destructor blocks until shutdown is complete.
         ~Lokinet();
 
-        // Schedules the given callback to be fired when Lokinet edge connections are fully
+        // Schedules the given callback to be fired when Lokinet edge connections are mostly
         // established (and thus Lokinet is ready to start building paths).  If lokinet is already
         // established, this will schedule an immediate invocation of the callback.
         //

--- a/include/lokinet.hpp
+++ b/include/lokinet.hpp
@@ -80,6 +80,21 @@ namespace lokinet
         // Destructor stops the lokinet instance.  The destructor blocks until shutdown is complete.
         ~Lokinet();
 
+        // Schedules the given callback to be fired when Lokinet edge connections are fully
+        // established (and thus Lokinet is ready to start building paths).  If lokinet is already
+        // established, this will schedule an immediate invocation of the callback.
+        //
+        // If persist is true then the callback will be stored and called *each* time Lokinet enters
+        // the connected state (i.e. it will be called again if Lokinet loses all connectivity and
+        // then regains connections).
+        void on_connected(std::function<void()> callback, bool persist = false);
+
+        // Schedules the given callback to be fired when Lokinet becomes fully disconnected, i.e.
+        // loses all established edge connections.  If persist is true then the callback will be
+        // fired *each* time Lokinet transitions from connected to disconnected state.  If Lokinet
+        // is not currently connected then the callback will be scheduled immediately.
+        void on_disconnected(std::function<void()> callback, bool persist = false);
+
         // Establishes a UDP session to the given remote (.loki or .snode) and port.  When the
         // lokinet session to the remote is established, the callback is invoked with the info
         // corresponding to the session and tunnel.  This call can happen instantly (before this

--- a/llarp/link/endpoint.cpp
+++ b/llarp/link/endpoint.cpp
@@ -310,7 +310,7 @@ namespace llarp::link
                 // We are a client, and so *all* connections are outbound to a relay that we
                 // initiated: Unlike the above, we would never initiate to an already pending or
                 // already connected node, so don't have to worry about duplicates.
-                c = static_cast<int>(client_conns.size() + pending_outbound.size());
+                c = static_cast<int>(client_conns.size() + (include_pending ? pending_outbound.size() : 0));
             }
             return c;
         });
@@ -570,6 +570,9 @@ namespace llarp::link
         }
 
         pending_outbound.erase(pit);
+
+        if (not router.is_service_node)
+            router.on_edge_conn_change();
     }
 
     void Endpoint::on_conn_established(quic::Connection& conn)
@@ -579,8 +582,9 @@ namespace llarp::link
         std::shared_ptr<quic::BTRequestStream> inbound_cstream;
         if (conn.is_inbound())
             // We have to set up the control stream here, before the router loop transfer below,
-            // because the stream must be queued before stream data gets processed which could
-            // happen immediately after this callback.
+            // because the stream must be queued before stream data gets processed (which could
+            // happen immediately after this method call returns) so that we don't accidentally end
+            // up with a plain Stream for the stream id rather than a BTRequestStream.
             inbound_cstream = make_control(conn, RouterID{conn.remote_key().first<32>()}, conn.selected_alpn());
 
         router.loop.call([this, weak = conn.weak_from_this(), inbound_cstream = std::move(inbound_cstream)]() {
@@ -595,18 +599,6 @@ namespace llarp::link
                 on_inbound_conn(std::move(conn), std::move(inbound_cstream));
             else
                 on_outbound_conn(std::move(conn));
-
-            if (not router.is_service_node and not _client_connected)
-                if (int n = num_relay_conns(/*include_pending=*/false); n >= router.client_target_outbounds())
-                {
-                    _client_connected = true;
-                    log::info(
-                        log_global,
-                        "Lokinet is now connected to the network ({}) with {} relay connections",
-                        router.config().network.is_reachable ? router.local_rid().to_network_address(false).to_string()
-                                                             : "outgoing-only",
-                        n);
-                }
         });
     }
 
@@ -687,17 +679,9 @@ namespace llarp::link
                     ref_id,
                     ec);
             }
-            if (not router.is_service_node and _client_connected and num_relay_conns(/*include_pending=*/false) == 0)
-            {
-                _client_connected = false;
-                log::warning(log_global, "Lokinet is no longer connected to the network!");
-            }
+            if (not router.is_service_node)
+                router.on_edge_conn_change();
         });
-    }
-
-    bool Endpoint::is_client_connected() const
-    {
-        return router.loop.call_get([this] { return _client_connected; });
     }
 
     std::pair<std::shared_ptr<quic::Connection>, std::shared_ptr<quic::BTRequestStream>> Endpoint::bootstrap_connect(

--- a/llarp/link/endpoint.hpp
+++ b/llarp/link/endpoint.hpp
@@ -102,11 +102,6 @@ namespace llarp::link
         std::shared_ptr<quic::Ticker> redundancy_ticker;
         std::shared_ptr<quic::GNUTLSCreds> tls_creds;
 
-        // Tracks client connectivity: a client becomes "connected" when it reaches the configured
-        // number of router connections, and becomes disconnected when it loses all connections.
-        // (And so in between could be in either state).
-        bool _client_connected{false};
-
       public:
         void start_tickers();
 
@@ -210,11 +205,6 @@ namespace llarp::link
 
         // Closes all connections and stops the network event loop
         void shutdown();
-
-        // Returns true if the endpoint is "connected", that is, has reached the target number of
-        // connections.  Once true, this value becomes false if all router connections are lost.  No
-        // meaningful value for service nodes.
-        bool is_client_connected() const;
 
         // Makes a new connection to the given relay as a Lokinet bootstrap client (i.e. using the
         // special bootstrapping ALPN, even if this node is a relay) *without* using an existing

--- a/llarp/lokinet.cpp
+++ b/llarp/lokinet.cpp
@@ -60,6 +60,14 @@ namespace lokinet
         context->wait();
     }
 
+    void Lokinet::on_connected(std::function<void()> callback, bool persist) {
+        context->router->on_connected(std::move(callback), persist);
+    }
+
+    void Lokinet::on_disconnected(std::function<void()> callback, bool persist) {
+        context->router->on_disconnected(std::move(callback), persist);
+    }
+
     void Lokinet::establish_udp(
         std::string_view remote,
         uint16_t port,

--- a/llarp/nodedb.cpp
+++ b/llarp/nodedb.cpp
@@ -80,9 +80,6 @@ namespace llarp
         if (auto& s = _router.config().paths.debug_path_seed)
         {
             auto admitted = debug_sort_admissable(known_rcs, predicate);
-            log::warning(logcat, "DPS mode with {}", admitted.size());
-            for (auto& a : admitted)
-                log::warning(logcat, "   - {}", a->first);
             std::mt19937_64 rng{*s};
             auto end = std::ranges::sample(
                 admitted | std::views::transform([](const auto* x) { return &x->second; }), rand.begin(), n, rng);

--- a/llarp/path/path_handler.cpp
+++ b/llarp/path/path_handler.cpp
@@ -112,7 +112,7 @@ namespace llarp::path
 
         expire_paths(now);
 
-        if (not router.is_service_node and not router.link_endpoint().is_client_connected())
+        if (not router.is_service_node and not router.is_connected())
             // If we are not yet fully connected then we can't initiate path builds.  (In theory we
             // could whe not yet fully connected, but don't want to because that would bias edge
             // router selection towards faster ones).

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -1006,6 +1006,99 @@ namespace llarp
         return 0s;
     }
 
+    bool Router::is_connected() const
+    {
+        return loop.call_get([this] { return _is_connected; });
+    }
+
+    void Router::on_connected(std::function<void()> callback, bool persistent)
+    {
+        if (!callback)
+            return;
+        loop.call([this, callback = std::move(callback), persistent] {
+            if (_is_connected)
+                try
+                {
+                    callback();
+                }
+                catch (const std::exception& e)
+                {
+                    log::error(logcat, "Uncaught exception calling on_connected callback: {}", e.what());
+                }
+
+            if (persistent or not _is_connected)
+                _on_connected.emplace_back(std::move(callback), persistent);
+        });
+    }
+
+    void Router::on_disconnected(std::function<void()> callback, bool persistent)
+    {
+        if (!callback)
+            return;
+        loop.call([this, callback = std::move(callback), persistent] {
+            if (not _is_connected)
+                try
+                {
+                    callback();
+                }
+                catch (const std::exception& e)
+                {
+                    log::error(logcat, "Uncaught exception calling on_disconnected callback: {}", e.what());
+                }
+
+            if (persistent or _is_connected)
+                _on_disconnected.emplace_back(std::move(callback), persistent);
+        });
+    }
+
+    static void process_on_conn_callbacks(
+        std::list<std::pair<std::function<void()>, bool>> callbacks, std::string_view type)
+    {
+        for (auto it = callbacks.begin(); it != callbacks.end();)
+        {
+            auto& [f, persist] = *it;
+            try
+            {
+                f();
+            }
+            catch (const std::exception& e)
+            {
+                log::error(logcat, "Uncaught exception calling {} callback: {}", type, e.what());
+            }
+            if (persist)
+                ++it;
+            else
+                it = callbacks.erase(it);
+        }
+    }
+
+    void Router::on_edge_conn_change()
+    {
+        assert(loop.inside());
+
+        int conns = link_endpoint().num_relay_conns();
+        if (conns == 0 and _is_connected)
+        {
+            _is_connected = false;
+
+            log::warning(log_global, "Lokinet is no longer connected to the network!");
+
+            process_on_conn_callbacks(_on_disconnected, "on_disconnected");
+        }
+        else if (not _is_connected and conns >= _client_target_outbounds)
+        {
+            _is_connected = true;
+
+            log::info(
+                log_global,
+                "Lokinet is now connected to the network ({}) with {} relay connections",
+                config().network.is_reachable ? local_rid().to_network_address(false).to_string() : "outgoing-only",
+                conns);
+
+            process_on_conn_callbacks(_on_connected, "on_connected");
+        }
+    }
+
     void Router::stop()
     {
         if (!_is_running)

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -1085,15 +1085,18 @@ namespace llarp
 
             process_on_conn_callbacks(_on_disconnected, "on_disconnected");
         }
-        else if (not _is_connected and conns >= _client_target_outbounds)
+        else if (
+            not _is_connected
+            and conns * CLIENT_CONNECTED_THRESHOLD::den >= _client_target_outbounds * CLIENT_CONNECTED_THRESHOLD::num)
         {
             _is_connected = true;
 
             log::info(
                 log_global,
-                "Lokinet is now connected to the network ({}) with {} relay connections",
+                "Lokinet is now connected to the network ({}) with {}/{} relay connections",
                 config().network.is_reachable ? local_rid().to_network_address(false).to_string() : "outgoing-only",
-                conns);
+                conns,
+                _client_target_outbounds);
 
             process_on_conn_callbacks(_on_connected, "on_connected");
         }

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -62,6 +62,13 @@ namespace llarp
 
     inline constexpr auto SERVICE_MANAGER_REPORT_INTERVAL{5s};
 
+    // The proportion of its target number of edge connections a client needs to have established
+    // connections with before we consider it "connected" to the network.  We allow less than full
+    // connectivity so that a single relay connection timeout doesn't stall connectivity for the
+    // full timeout duration, but generally want more than 1 so that we don't end up clustering all
+    // initial path builds through a single edge.
+    using CLIENT_CONNECTED_THRESHOLD = std::ratio<2, 3>;
+
     class ContactDB;
     class NodeDB;
 

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -73,7 +73,7 @@ namespace llarp
             Config conf,
             std::shared_ptr<quic::Loop> loop,
             std::shared_ptr<vpn::Platform> vpnPlatform,
-            std::promise<void> p);
+            std::promise<void> close_promise);
 
         ~Router();
 
@@ -136,6 +136,15 @@ namespace llarp
         std::chrono::milliseconds _next_dereg_warning{time_now_ms() + 15s};
 
         std::chrono::milliseconds _last_path_ping{0s};
+
+        // Application callback(s) to fire as soon as we reach "connected" or "disconnected" status,
+        // which means when we have established our target number of edge connections or lost all
+        // edge connections, respectively.  Typically used as a "ready-to-go" callback during
+        // initialization.  The bool value indicates whether the callback is persistent (true) or
+        // one-time (false).  Note that callbacks are only called when the connected state changes:
+        // that is when we were disconnected and became connected, or were connected and became
+        // disconnected.
+        std::list<std::pair<std::function<void()>, bool>> _on_connected, _on_disconnected;
 
         // These aren't actually shared, but we unique_ptr requires destructor visibility, which
         // embedded-only clients won't have as they don't compile any RPC code.
@@ -277,13 +286,24 @@ namespace llarp
 
         std::string status_line();
 
-        // Client connectivity status: we enter "client connected" state when we have reached our
-        // target number of router connections, and we lose connected state when we fall to 0 router
-        // connections.  These log when we flip from disconnected to connected (info) or vice versa
-        // (warning).
-        void set_connected();
-        void set_disconnected();
+        // Returns the client connectivity status: we enter "connected" state once the target number
+        // of edge router connections is reached, and we lose connected state when we lose all edge
+        // connections.  Application code can monitor this state by setting callbacks via
+        // `on_connected`/`on_disconnected`.
         bool is_connected() const;
+
+        // Adds an application callback to invoke when the connectivity state changes to
+        // "connected".  If the state is already connected when this is called, the callback will be
+        // invoked immediately.  If `persistent` is true then the callback will be stored and called
+        // again if the state leaves and re-enters the connected state.
+        void on_connected(std::function<void()> callback, bool persistent);
+
+        // Like `is_connected`, but fires on disconnections.
+        void on_disconnected(std::function<void()> callback, bool persistent);
+
+        // Internal method: called from link::Endpoint to re-check and possibly change connected
+        // state when a client edge connection is established or lost.
+        void on_edge_conn_change();
 
         bool is_running() const { return _is_running; }
 


### PR DESCRIPTION
This adds hooks for embedded clients (primarily) to get notified when we are mostly connected to edges, which is the point at which the client can reasonable start making sessions.