### PR TITLE
Fix pinned edges; zstd compress bootstrap fetch; fix snode blacklist

### DIFF
--- a/cmake/StaticBuild.cmake
+++ b/cmake/StaticBuild.cmake
@@ -53,6 +53,13 @@ set(ZLIB_SOURCE zlib-${ZLIB_VERSION}.tar.xz)
 set(ZLIB_HASH SHA256=38ef96b8dfe510d42707d9c781877914792541133e1870841463bfa73f883e32
   CACHE STRING "zlib source hash")
 
+set(ZSTD_VERSION 1.5.7 CACHE STRING "zstd version")
+set(ZSTD_MIRROR ${LOCAL_MIRROR} https://github.com/facebook/zstd/releases/download/v${ZSTD_VERSION}
+    CACHE STRING "zstd mirror(s)")
+set(ZSTD_SOURCE zstd-${ZSTD_VERSION}.tar.gz
+set(ZSTD_HASH SHA256=eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3
+    CACHE STRING "zstd source hash")
+
 include(ExternalProject)
 
 set(DEPS_DESTDIR ${CMAKE_BINARY_DIR}/static-deps)
@@ -192,6 +199,12 @@ function(build_external target)
   endforeach()
   string(REPLACE ___TARGET___ ${target} arg_BUILD_BYPRODUCTS "${arg_BUILD_BYPRODUCTS}")
 
+  if(arg_CONFIGURE_COMMAND STREQUAL DEFAULT_CMAKE)
+    set(configure)
+  else()
+    set(configure CONFIGURE_COMMAND ${arg_CONFIGURE_COMMAND})
+  endif()
+
   string(TOUPPER "${target}" prefix)
   expand_urls(urls ${${prefix}_SOURCE} ${${prefix}_MIRROR})
   ExternalProject_Add("${target}_external"
@@ -202,7 +215,7 @@ function(build_external target)
     URL_HASH ${${prefix}_HASH}
     DOWNLOAD_NO_PROGRESS ON
     PATCH_COMMAND ${arg_PATCH_COMMAND}
-    CONFIGURE_COMMAND ${arg_CONFIGURE_COMMAND}
+    ${configure}
     BUILD_COMMAND ${arg_BUILD_COMMAND}
     INSTALL_COMMAND ${arg_INSTALL_COMMAND}
     BUILD_BYPRODUCTS ${arg_BUILD_BYPRODUCTS}
@@ -219,6 +232,21 @@ endif()
 if(LOKINET_PEERSTATS)
   build_external(sqlite3)
   add_static_target(sqlite3 sqlite3_external libsqlite3.a)
+endif()
+
+
+if(NOT TARGET libzstd::static)
+  build_external(zstd
+      CONFIGURE_COMMAND DEFAULT_CMAKE
+      SOURCE_SUBDIR build/cmake
+      BUILD_BYPRODUCTS
+        ${DEPS_DESTDIR}/lib/libzstd.a
+        ${DEPS_DESTDIR}/include/zstd.h
+  )
+  add_static_target(zstd zstd_external libzstd.a)
+  # Use the same target name as libsession-util so that we can use libsession's static zstd if we
+  # are being built as part of libsession:
+  add_library(libzstd::static ALIAS zstd_external)
 endif()
 
 

--- a/contrib/liblokinet_jank_test.cpp
+++ b/contrib/liblokinet_jank_test.cpp
@@ -1,28 +1,55 @@
 #include <lokinet.hpp>
 
-#include <thread>
-#include <iostream>
-#include <cstdint>
+#include <exception>
 #include <filesystem>
+#include <future>
+#include <iostream>
+#include <thread>
 
 using namespace std::literals;
 
-int main(int argc, char** argv) {
-  lokinet::Lokinet loki{std::filesystem::path{"lokinet.ini"}};
-  //lokinet::Lokinet loki{lokinet::Network::TESTNET};
-  std::this_thread::sleep_for(5s);
-  std::string ignored;
-  if (argc > 1) {
-    std::string target{argv[1]};
-    std::cout << "\nPRESS ENTER TO START SESSION TO " << target << "\n";
-    std::getline(std::cin, ignored);
-    try {
-      auto udp_info = loki.establish_udp_blocking(target, 12345);
-      std::cout << "\nudp bound to port " << udp_info.local_port << "\n";
+int main(int argc, char** argv)
+{
+    if (argc <= 1)
+    {
+        std::cerr << "USAGE: " << argv[0] << " {WHATEVER.loki | WHATEVER.snode}\n";
+        return 1;
     }
-    catch (const std::exception& e) {
-      std::cerr << "\nError establishing session to " << target << ": " << e.what() << "\n";
-      return 1;
+
+    std::string target{argv[1]};
+
+    lokinet::Lokinet loki{std::filesystem::path{"lokinet.ini"}};
+
+    std::promise<void> prom;
+    loki.on_connected([&] {
+        std::cout << "\n\x1b[32;1mLokinet connected!\x1b[0m\n\n\x1b[33;1mINITIATING SESSION TO " << target
+                  << "\x1b[0m\n\n"
+                  << std::flush;
+        loki.establish_udp(
+            target,
+            12345,
+            [](auto udp_info) {
+                std::cout << "\n\x1b[32;1mUDP bound to port " << udp_info.local_port << "\x1b[0m\n\n" << std::flush;
+            },
+            [&prom](std::string_view fail_msg) {
+                try
+                {
+                    throw std::runtime_error{std::string{fail_msg}};
+                }
+                catch (...)
+                {
+                    prom.set_exception(std::current_exception());
+                }
+            });
+    });
+    try
+    {
+        prom.get_future().get();
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "\n\n\x1b[31;1mError establishing session to " << target << ": " << e.what() << "\x1b[0m\n\n";
+        return 1;
     }
 
     /*
@@ -34,8 +61,8 @@ int main(int argc, char** argv) {
           std::cerr << "\nTCP Tunnel map error: " << error_str << "\n";
         });
     */
-  }
-  std::cout << "\nPRESS ENTER TO EXIT\n";
-  std::getline(std::cin, ignored);
-  std::cout << "\nEXITING\n";
+    std::cout << "\nPRESS ENTER TO EXIT\n";
+    std::string ignored;
+    std::getline(std::cin, ignored);
+    std::cout << "\nEXITING\n";
 }

--- a/include/lokinet.hpp
+++ b/include/lokinet.hpp
@@ -80,7 +80,7 @@ namespace lokinet
         // Destructor stops the lokinet instance.  The destructor blocks until shutdown is complete.
         ~Lokinet();
 
-        // Schedules the given callback to be fired when Lokinet edge connections are fully
+        // Schedules the given callback to be fired when Lokinet edge connections are mostly
         // established (and thus Lokinet is ready to start building paths).  If lokinet is already
         // established, this will schedule an immediate invocation of the callback.
         //

--- a/include/lokinet.hpp
+++ b/include/lokinet.hpp
@@ -80,6 +80,21 @@ namespace lokinet
         // Destructor stops the lokinet instance.  The destructor blocks until shutdown is complete.
         ~Lokinet();
 
+        // Schedules the given callback to be fired when Lokinet edge connections are fully
+        // established (and thus Lokinet is ready to start building paths).  If lokinet is already
+        // established, this will schedule an immediate invocation of the callback.
+        //
+        // If persist is true then the callback will be stored and called *each* time Lokinet enters
+        // the connected state (i.e. it will be called again if Lokinet loses all connectivity and
+        // then regains connections).
+        void on_connected(std::function<void()> callback, bool persist = false);
+
+        // Schedules the given callback to be fired when Lokinet becomes fully disconnected, i.e.
+        // loses all established edge connections.  If persist is true then the callback will be
+        // fired *each* time Lokinet transitions from connected to disconnected state.  If Lokinet
+        // is not currently connected then the callback will be scheduled immediately.
+        void on_disconnected(std::function<void()> callback, bool persist = false);
+
         // Establishes a UDP session to the given remote (.loki or .snode) and port.  When the
         // lokinet session to the remote is established, the callback is invoked with the info
         // corresponding to the session and tunnel.  This call can happen instantly (before this

--- a/llarp/CMakeLists.txt
+++ b/llarp/CMakeLists.txt
@@ -81,6 +81,7 @@ lokinet_add_library(lokinet-utils
   util/thread/queue_manager.cpp  
   util/thread/threading.cpp
   util/time.cpp
+  util/zstd.cpp
 )
 
 add_dependencies(lokinet-utils genversion)
@@ -305,6 +306,15 @@ if(NOT TARGET libevent::core)
   add_library(libevent::core ALIAS libevent_core)
 endif()
 target_link_libraries(lokinet-addressing PRIVATE libevent::core)
+
+
+# libzstd
+if(TARGET libzstd::static)  # static dep or libsession-util's embedded static target
+    target_link_libraries(lokinet-utils PRIVATE libzstd::static)
+else()
+    pkg_check_modules(LIBZSTD libzstd>=1.3 IMPORTED_TARGET REQUIRED)
+    target_link_libraries(lokinet-utils PRIVATE PkgConfig::LIBZSTD)
+endif()
 
 
 add_library(liblokinet lokinet.cpp)

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -113,22 +113,7 @@ namespace llarp
             Comment{"Network ID; this is '{}' for mainnet, '{}' for testnet."_format(NetID::MAINNET, NetID::TESTNET)},
             [this](std::string arg) { net_id = netid_from_string(arg); });
 
-        conf.define_option<int>(
-            "router",
-            "relay-connections",
-            Default{CLIENT_ROUTER_CONNECTIONS},
-            ClientOnly,
-            Comment{
-                "Minimum number of routers lokinet client will attempt to maintain connections to.",
-                "If [network]:strict-connect is defined, the number of maintained client <-> router",
-                "connections set by [router]:relay-connections will be at MOST the number of pinned edges"},
-            [this](int arg) {
-                if (arg < CLIENT_ROUTER_CONNECTIONS)
-                    throw std::invalid_argument{
-                        "Client relay connections must be >= {}"_format(CLIENT_ROUTER_CONNECTIONS)};
-
-                client_router_connections = arg;
-            });
+        conf.define_option<int>("router", "relay-connections", Deprecated);
 
         conf.define_option<int>("router", "min-connections", Deprecated);
 
@@ -421,24 +406,6 @@ namespace llarp
         conf.define_option<bool>("network", "profiling", Default{true}, Hidden, assignment_acceptor(enable_profiling));
 
         conf.define_option<std::string>("network", "profiles", Deprecated);
-
-        conf.define_option<std::string>(
-            "network",
-            "strict-connect",
-            ClientOnly,
-            MultiValue,
-            [this](std::string value) {
-                RouterID router;
-                if (not router.from_relay_address(value))
-                    throw std::invalid_argument{"bad .snode pubkey: {}"_format(value)};
-                if (not pinned_edges.insert(router).second)
-                    throw std::invalid_argument{"duplicate strict connect .snode: {}"_format(value)};
-            },
-            Comment{
-                "Public keys of routers which will act as pinned first-hops. This may be used to",
-                "provide a trusted router (consider that you are not fully anonymous with your",
-                "first hop).  This REQUIRES two or more nodes to be specified.",
-            });
 
         conf.define_option<std::string>(
             "network",
@@ -741,25 +708,6 @@ namespace llarp
                 {
                     throw std::invalid_argument{"[endpoint]:mapaddr invalid entry '{}': {}"_format(arg, e.what())};
                 }
-            });
-
-        conf.define_option<std::string>(
-            "network",
-            "blacklist-snode",
-            ClientOnly,
-            MultiValue,
-            Comment{
-                "Adds a lokinet relay `.snode` address to the list of relays to avoid when",
-                "building paths. Can be specified multiple times.",
-            },
-            [this](std::string arg) {
-                RouterID id;
-                if (not id.from_relay_address(arg))
-                    throw std::invalid_argument{"Invalid RouterID: {}"_format(arg)};
-
-                auto itr = snode_blacklist.emplace(std::move(id));
-                if (not itr.second)
-                    throw std::invalid_argument{"Duplicate blacklist-snode: {}"_format(arg)};
             });
 
         // TODO: support SRV records for routers, but for now client only
@@ -1412,6 +1360,19 @@ namespace llarp
 
         conf.define_option<int>(
             "paths",
+            "edge-connections",
+            Default{CLIENT_ROUTER_CONNECTIONS},
+            ClientOnly,
+            Comment{
+                "Minimum number of routers lokinet client will attempt to maintain direct (i.e. \"edge\")",
+                "connections to.  All paths will start through one of these edges.",
+                "",
+                "Lokinet may use more than this number of edges in single-hop connection mode",
+                "(see [paths]:client-hops) and may use fewer connections if limited by [paths]:strict-edge."},
+            lower_bounded_assignment_acceptor(edge_connections, 1, "[paths]:edge-connections"));
+
+        conf.define_option<int>(
+            "paths",
             "outbound-paths",
             ClientOnly,
             Default{2},
@@ -1424,8 +1385,8 @@ namespace llarp
                 "connections to 5 clients and 3 snodes, lokinet will maintain 16 outbound paths (at the",
                 "default setting of 2).",
                 "",
-                "Setting this value to 1 is allowed, but may result in occassional packet loss during",
-                "as paths expire and rotate.",
+                "Setting this value to 1 is allowed, but will result in brief periods of packet loss",
+                "whenever paths expire due to the lack of allowed backup path.",
             },
             bounded_assignment_acceptor(outbound_paths, 1, 4, "[paths]:outbound-paths"));
 
@@ -1440,7 +1401,11 @@ namespace llarp
                 "",
                 "The overall number of hops to the remote client is this value PLUS the number of inbound",
                 "hops the other client has configured for their inbound hops (via [paths]:inbound-hops).",
-            },
+                "",
+                "Setting this value to 1 puts lokinet into single-hop mode for the connection from this",
+                "client to the aligned pivot router, which potentially weakens connection privacy as",
+                "your public IP will be observable to any service node listed as a pivot for any remote",
+                "client that you connect to."},
             bounded_assignment_acceptor(client_hops, 1, path::BUILD_LENGTH, "[paths]:client-hops"));
 
         conf.define_option<int>(
@@ -1450,14 +1415,18 @@ namespace llarp
             Comment{
                 "Number of hops to use when establishing a connection to talk to a service node.",
                 "",
-                "A value of 1 results in establishing direct connection to the snode (i.e. only encryption",
-                "but no onion routing), 2 would select one intermediate snode to onion route through, 4",
-                "uses three intermediates, and so on.",
+                "A value of 1 results in establishing direct connection to the snode (i.e. only",
+                "encryption but no onion routing); 2 would select one intermediate snode to onion",
+                "route through; 4 uses three intermediates, and so on, up to the maximum of 8.",
                 "",
-                "Additional hops increases privacy but reduces network performance through the path.",
+                "Additional hops increases privacy but also increase latency and reduces network",
+                "performance through the path.",
                 "",
                 "If not set, this default to one greater than the value of [paths]:client-hops.",
-            },
+                "",
+                "Setting this value to 1 puts lokinet into single-hop mode for the connection from this",
+                "client to service node (i.e. `.snode` addresses) which potentially weakens connection",
+                "privacy as any service nodes you connect to will be able to observe your public IP."},
             bounded_assignment_acceptor(relay_hops_, 1, path::BUILD_LENGTH, "[paths]:relay-hops"));
 
         conf.define_option<int>(
@@ -1573,6 +1542,72 @@ namespace llarp
         conf.define_option<uint64_t>(
             "paths", "debug-path-seed", ClientOnly, Hidden, assignment_acceptor(debug_path_seed));
 #endif
+
+        conf.define_option<std::string>(
+            "paths",
+            "strict-edge",
+            ClientOnly,
+            MultiValue,
+            [this](std::string value) {
+                RouterID router;
+                if (value.size() == 64 && oxenc::is_hex(value))
+                    oxenc::from_hex(value.begin(), value.end(), router.begin());
+                else if (not router.from_relay_address(value))
+                    throw std::invalid_argument{"[paths]:strict-edge: Invalid .snode pubkey: {}"_format(value)};
+
+                if (not strict_edges.insert(router).second)
+                    throw std::invalid_argument{
+                        "[paths]:strict-edge: Duplicate strict connect .snode value: {}"_format(value)};
+            },
+            Comment{
+                R"(List of service node public keys of "edge" nodes (also known as "first hops") that)",
+                "Lokinet will exclusively use when establishing paths through the network.  You can use",
+                "this to always use closer (i.e. lower latency) first hops, or to limit which network",
+                "nodes see connections from your IP address.",
+                "",
+                "Public keys can be provided either in native lokinet address format (ADDR.snode), or using",
+                "the 64-character hexademical pubkey notation common used for Session service nodes.",
+                "Specify this option multiple times to specify multiple allowed edge nodes.",
+                "",
+                "Note that only registered service node pubkeys will be used, and so connectivity will be",
+                "lost entirely if all of the listed pubkeys are or become deregistered.",
+                "",
+                "This option is incompatible with single-hop outbound path mode (see `[paths]:client-hops`",
+                "and `[paths]:relay-hops`).",
+                "",
+                "Note that if bootstrapping is needed a connection will be made to the configured bootstrap",
+                "nodes to obtain an initial router list.  See [bootstrap]:add-node if you want to also",
+                "override the nodes used for bootstrapping."});
+
+        conf.add_options_validator([this] {
+            if (strict_edges.empty())
+                return;
+            if (client_hops == 1)
+                throw std::invalid_argument{
+                    "[paths]:strict-edge cannot be used with [paths]:client-hops=1 single hop mode"};
+            if (relay_hops_ and *relay_hops_ == 1)
+                throw std::invalid_argument{
+                    "[paths]:strict-edge cannot be used with [paths]:relay-hops=1 single hop mode"};
+        });
+
+        conf.define_option<std::string>(
+            "paths",
+            "blacklist-snode",
+            ClientOnly,
+            MultiValue,
+            Comment{
+                "Adds a lokinet relay `.snode` address to the list of relays to avoid when",
+                "connecting to edges or building paths. Can be specified multiple times.",
+            },
+            [this](std::string arg) {
+                RouterID id;
+                if (not id.from_relay_address(arg))
+                    throw std::invalid_argument{"Invalid RouterID: {}"_format(arg)};
+
+                auto itr = snode_blacklist.emplace(std::move(id));
+                if (not itr.second)
+                    throw std::invalid_argument{"Duplicate blacklist-snode: {}"_format(arg)};
+            });
 
 #ifdef WITH_GEOIP
         conf.defineOption<std::string>(

--- a/llarp/config/config.hpp
+++ b/llarp/config/config.hpp
@@ -56,8 +56,6 @@ namespace llarp
 
     struct RouterConfig
     {
-        int client_router_connections{CLIENT_ROUTER_CONNECTIONS};
-
         NetID net_id = NetID::MAINNET;
 
         std::filesystem::path data_dir;
@@ -81,6 +79,15 @@ namespace llarp
     /// config for path hop selection
     struct PathConfig
     {
+        int edge_connections{CLIENT_ROUTER_CONNECTIONS};
+
+        // If non-empty then *only* use these nodes for first hops.  (Except for single-hop outbound
+        // paths, which ignore this).
+        std::unordered_set<RouterID> strict_edges;
+
+        // Blacklist of relays to avoid using for edges or path hops
+        std::unordered_set<RouterID> snode_blacklist;
+
         /// Number of paths to maintain for inbound reachability and network queries (such as
         /// looking up client contacts).
         int inbound_paths = 4;
@@ -158,14 +165,11 @@ namespace llarp
     {
         bool enable_profiling{false};
         bool save_profiles{false};
-        std::unordered_set<RouterID> pinned_edges;
 
         std::optional<std::filesystem::path> keyfile;
 
         bool enable_ipv6{false};
         bool is_reachable{false};
-
-        std::set<RouterID> snode_blacklist;
 
         /*   Auth specific config   */
         auth::AuthType auth_type = auth::AuthType::NONE;

--- a/llarp/link/endpoint.cpp
+++ b/llarp/link/endpoint.cpp
@@ -310,7 +310,7 @@ namespace llarp::link
                 // We are a client, and so *all* connections are outbound to a relay that we
                 // initiated: Unlike the above, we would never initiate to an already pending or
                 // already connected node, so don't have to worry about duplicates.
-                c = static_cast<int>(client_conns.size() + pending_outbound.size());
+                c = static_cast<int>(client_conns.size() + (include_pending ? pending_outbound.size() : 0));
             }
             return c;
         });
@@ -570,6 +570,9 @@ namespace llarp::link
         }
 
         pending_outbound.erase(pit);
+
+        if (not router.is_service_node)
+            router.on_edge_conn_change();
     }
 
     void Endpoint::on_conn_established(quic::Connection& conn)
@@ -579,8 +582,9 @@ namespace llarp::link
         std::shared_ptr<quic::BTRequestStream> inbound_cstream;
         if (conn.is_inbound())
             // We have to set up the control stream here, before the router loop transfer below,
-            // because the stream must be queued before stream data gets processed which could
-            // happen immediately after this callback.
+            // because the stream must be queued before stream data gets processed (which could
+            // happen immediately after this method call returns) so that we don't accidentally end
+            // up with a plain Stream for the stream id rather than a BTRequestStream.
             inbound_cstream = make_control(conn, RouterID{conn.remote_key().first<32>()}, conn.selected_alpn());
 
         router.loop.call([this, weak = conn.weak_from_this(), inbound_cstream = std::move(inbound_cstream)]() {
@@ -595,18 +599,6 @@ namespace llarp::link
                 on_inbound_conn(std::move(conn), std::move(inbound_cstream));
             else
                 on_outbound_conn(std::move(conn));
-
-            if (not router.is_service_node and not _client_connected)
-                if (int n = num_relay_conns(/*include_pending=*/false); n >= router.client_target_outbounds())
-                {
-                    _client_connected = true;
-                    log::info(
-                        log_global,
-                        "Lokinet is now connected to the network ({}) with {} relay connections",
-                        router.config().network.is_reachable ? router.local_rid().to_network_address(false).to_string()
-                                                             : "outgoing-only",
-                        n);
-                }
         });
     }
 
@@ -687,17 +679,9 @@ namespace llarp::link
                     ref_id,
                     ec);
             }
-            if (not router.is_service_node and _client_connected and num_relay_conns(/*include_pending=*/false) == 0)
-            {
-                _client_connected = false;
-                log::warning(log_global, "Lokinet is no longer connected to the network!");
-            }
+            if (not router.is_service_node)
+                router.on_edge_conn_change();
         });
-    }
-
-    bool Endpoint::is_client_connected() const
-    {
-        return router.loop.call_get([this] { return _client_connected; });
     }
 
     std::pair<std::shared_ptr<quic::Connection>, std::shared_ptr<quic::BTRequestStream>> Endpoint::bootstrap_connect(

--- a/llarp/link/endpoint.hpp
+++ b/llarp/link/endpoint.hpp
@@ -102,11 +102,6 @@ namespace llarp::link
         std::shared_ptr<quic::Ticker> redundancy_ticker;
         std::shared_ptr<quic::GNUTLSCreds> tls_creds;
 
-        // Tracks client connectivity: a client becomes "connected" when it reaches the configured
-        // number of router connections, and becomes disconnected when it loses all connections.
-        // (And so in between could be in either state).
-        bool _client_connected{false};
-
       public:
         void start_tickers();
 
@@ -210,11 +205,6 @@ namespace llarp::link
 
         // Closes all connections and stops the network event loop
         void shutdown();
-
-        // Returns true if the endpoint is "connected", that is, has reached the target number of
-        // connections.  Once true, this value becomes false if all router connections are lost.  No
-        // meaningful value for service nodes.
-        bool is_client_connected() const;
 
         // Makes a new connection to the given relay as a Lokinet bootstrap client (i.e. using the
         // special bootstrapping ALPN, even if this node is a relay) *without* using an existing

--- a/llarp/link/link_manager.cpp
+++ b/llarp/link/link_manager.cpp
@@ -234,7 +234,7 @@ namespace llarp::link
         log::critical(logcat, "Handling bootstrap fetch request...");
 
         std::optional<RemoteRC> remote;
-        size_t quantity;
+        int quantity;
 
         try
         {
@@ -242,7 +242,7 @@ namespace llarp::link
             if (btdc.skip_until("l"))
                 remote.emplace(btdc.consume_dict_data(), router.netid());
 
-            quantity = btdc.require<size_t>("q");
+            quantity = btdc.require<int>("q");
         }
         catch (const std::exception& e)
         {
@@ -253,53 +253,53 @@ namespace llarp::link
 
         if (remote)
         {
-            auto& remote_rc = *remote;
-            if (router.node_db().is_registered(remote_rc.router_id()))
+            if (router.node_db().is_registered(remote->router_id()))
             {
-                router.node_db().put_rc(remote_rc);
+                router.node_db().put_rc(*remote);
                 log::debug(
                     logcat,
-                    "Bootstrap node confirmed RID:{} is registered; approving fetch request and saving RC!",
-                    remote_rc.router_id());
+                    "Bootstrap node confirmed {} is registered; approving fetch request and saving RC!",
+                    remote->router_id().to_network_address(true));
             }
             else
-                log::warning(
-                    logcat,
-                    "Bootstrap node failed to confirm RID:{} is not registered; something is wrong",
-                    remote_rc.router_id());
+                log::debug(logcat, "Ignoring bootstrap fetch with unregistered RC from RID:{}", remote->router_id());
         }
-
-        auto& src = router.node_db().get_known_rcs();
-        auto count = src.size();
-
-        // if quantity is 0, then the service node requesting this wants all the RC's; otherwise,
-        // send the amount requested in the message
-        quantity = quantity == 0 || quantity > count ? count : quantity;
-
-        auto now = llarp::time_now_ms();
 
         std::vector<std::string_view> rcs;
-        rcs.reserve(quantity);
-        for (const auto& [rid, rc] : src)
+        if (quantity == 0)
         {
-            if (not rc.is_expired(now))
-            {
-                rcs.push_back(rc.view());
-                if (rcs.size() > quantity)
-                    break;
-            }
+            // 0 means "all"
+            auto& src = router.node_db().get_known_rcs();
+
+            rcs.reserve(src.size());
+            auto now = llarp::time_now_ms();
+            for (const auto& rc : std::views::values(src))
+                if (not rc.is_expired(now))
+                    rcs.push_back(rc.view());
+
+            std::ranges::shuffle(rcs, llarp::csrng);
         }
+        else
+        {
+            rcs.reserve(quantity);
+            for (auto* rc : router.node_db().get_n_random_rcs(quantity))
+                rcs.push_back(rc->view());
+        }
+
         if (rcs.empty())
         {
             m.respond("No RCs", true);
             return;
         }
 
-        std::ranges::shuffle(rcs, llarp::csrng);
+        size_t reserve = 7;  // d1:rl...ee  (not counting the "...")
+        for (auto& rc : rcs)
+            reserve += rc.size();  // Pre-encoded bt data, so no additional overhead
+
         oxenc::bt_dict_producer btdp;
+        btdp.reserve(reserve);
         {
             auto rc_list = btdp.append_list("r");
-            rc_list.reserve(rcs[0].size() * (rcs.size() + 1));  // might be a waste of time
             for (const auto& rc : rcs)
                 rc_list.append_encoded(rc);
         }

--- a/llarp/link/link_manager.cpp
+++ b/llarp/link/link_manager.cpp
@@ -16,6 +16,7 @@
 #include <llarp/util/bspan.hpp>
 #include <llarp/util/random.hpp>
 #include <llarp/util/time.hpp>
+#include <llarp/util/zstd.hpp>
 
 #include <nlohmann/json.hpp>
 #include <oxen/quic/btstream.hpp>
@@ -220,90 +221,76 @@ namespace llarp::link
                 rc.router_id().short_string());
     }
 
-    void Manager::fetch_bootstrap_rcs(
-        const RemoteRC& source, std::vector<std::byte> payload, std::function<void(quic::message)> func)
-    {
-        assert(router.loop.inside());
-        endpoint.send_command(source, "bfetch_rcs", std::move(payload), std::move(func));
-    }
-
     void Manager::handle_fetch_bootstrap_rcs(quic::message m)
     {
         // this handler should not be registered for clients
         assert(router.is_service_node);
-        log::critical(logcat, "Handling bootstrap fetch request...");
-
-        std::optional<RemoteRC> remote;
-        int quantity;
-
-        try
-        {
-            oxenc::bt_dict_consumer btdc{m.body()};
-            if (btdc.skip_until("l"))
-                remote.emplace(btdc.consume_dict_data(), router.netid());
-
-            quantity = btdc.require<int>("q");
-        }
-        catch (const std::exception& e)
-        {
-            log::critical(logcat, "Exception handling bootstrap RC Fetch request (body:{}): {}", m.body(), e.what());
-            m.respond(messages::ERROR_RESPONSE, true);
-            return;
-        }
-
-        if (remote)
-        {
-            if (router.node_db().is_registered(remote->router_id()))
-            {
-                router.node_db().put_rc(*remote);
-                log::debug(
-                    logcat,
-                    "Bootstrap node confirmed {} is registered; approving fetch request and saving RC!",
-                    remote->router_id().to_network_address(true));
-            }
-            else
-                log::debug(logcat, "Ignoring bootstrap fetch with unregistered RC from RID:{}", remote->router_id());
-        }
+        log::info(logcat, "Handling bootstrap fetch request");
 
         std::vector<std::string_view> rcs;
-        if (quantity == 0)
-        {
-            // 0 means "all"
-            auto& src = router.node_db().get_known_rcs();
+        rcs.push_back("l"sv);
+        auto& src = router.node_db().get_known_rcs();
 
-            rcs.reserve(src.size());
-            auto now = llarp::time_now_ms();
-            for (const auto& rc : std::views::values(src))
-                if (not rc.is_expired(now))
-                    rcs.push_back(rc.view());
+        rcs.reserve(src.size());
+        auto now = llarp::time_now_ms();
+        for (const auto& rc : std::views::values(src))
+            if (not rc.is_expired(now))
+                rcs.push_back(rc.view());
+        rcs.push_back("e"sv);
 
-            std::ranges::shuffle(rcs, llarp::csrng);
-        }
-        else
-        {
-            rcs.reserve(quantity);
-            for (auto* rc : router.node_db().get_n_random_rcs(quantity))
-                rcs.push_back(rc->view());
-        }
-
-        if (rcs.empty())
+        if (rcs.size() == 2)
         {
             m.respond("No RCs", true);
             return;
         }
 
-        size_t reserve = 7;  // d1:rl...ee  (not counting the "...")
-        for (auto& rc : rcs)
-            reserve += rc.size();  // Pre-encoded bt data, so no additional overhead
+        if (!compressor)
+            compressor.emplace();
 
-        oxenc::bt_dict_producer btdp;
-        btdp.reserve(reserve);
+        // Our output is a dict containing a single key `z` which contains the zstd-compressed bytes
+        // of a bt-encoded list of all RCs.
+
+        std::vector<std::byte> response_raw;
+        // We don't know the size in advance, so write a dummy value, compress, then fill it in:
+        constexpr auto compress_template = "d1:z999999999:"sv;
+        try
         {
-            auto rc_list = btdp.append_list("r");
-            for (const auto& rc : rcs)
-                rc_list.append_encoded(rc);
+            response_raw = compressor->compress(rcs, zstd::compressor::DEFAULT_LEVEL, compress_template);
         }
-        m.respond(std::move(btdp).str());
+        catch (const std::exception& e)
+        {
+            log::warning(logcat, "Bootstrap request RCs compression failed: {}", e.what());
+            m.respond("Compress failed", true);
+            return;
+        }
+
+        size_t comp_size = response_raw.size() - compress_template.size();
+
+#ifndef NDEBUG
+        size_t rcs_size = 0;
+        for (auto& rc : rcs)
+            rcs_size += rc.size();
+        log::debug(
+            logcat,
+            "compressed RC list to {}B ({:.1f}% of raw {}B)",
+            comp_size,
+            comp_size * 100.0 / rcs_size,
+            rcs_size);
+#endif
+
+        // Now we need to rewrite the actual `d1:ZNNN:` prefix with the correct NNN for the
+        // compressed data:
+        std::string actual = "d1:Z{}:"_format(comp_size);
+        assert(actual.size() <= compress_template.size());
+        // Our actual size is almost certainly shorter than the 999999999 value we used, so we skip
+        // however many leading bytes as needed to represent the proper final value without needing
+        // to shift the compressed data around in the buffer:
+        size_t skip = compress_template.size() - actual.size();
+        std::memcpy(response_raw.data() + skip, actual.data(), actual.size());
+        // Response dict terminator:
+        response_raw.push_back(std::byte{'e'});
+
+        m.respond(std::span{response_raw.data() + skip, response_raw.size() - skip});
     }
 
     void Manager::handle_fetch_rcs(quic::message m, std::optional<std::string> inner_body)

--- a/llarp/link/link_manager.cpp
+++ b/llarp/link/link_manager.cpp
@@ -155,26 +155,16 @@ namespace llarp::link
 
     void Manager::connect_to_keep_alive(int num_conns)
     {
-        if (router.node_db().strict_connect_enabled())
-        {
-            assert(not router.is_service_node);
+        auto rcs = router.node_db().get_n_random_edge_rcs(
+            num_conns, false /* shuffling not needed */, [this](const RemoteRC& rc) {
+                return not router.link_endpoint().connected_to_relay(rc.router_id(), /*include_pending=*/true);
+            });
 
-            // TESTNET: TODO: if given strict-connects, fetch their RCs SPECIFICALLY in bootstrapping
-            // TODO FIXME: why?  That sounds rather metadata-leaky.
-            log::warning(logcat, "FINISH STRICT CONNECT (SEE COMMENT)");
-        }
+        for (const auto* rc : rcs)
+            endpoint.ensure_connection(*rc);
 
-        if (auto rcs = router.node_db().get_n_random_rcs(
-                num_conns,
-                true,
-                [this](const RemoteRC& rc) {
-                    return not router.link_endpoint().connected_to_relay(rc.router_id(), /*include_pending=*/true);
-                });
-            !rcs.empty())
-            for (const auto* rc : rcs)
-                endpoint.ensure_connection(*rc);
-        else
-            log::warning(logcat, "NodeDB query for {} random RCs for connection returned none", num_conns);
+        if (rcs.empty())
+            log::debug(logcat, "NodeDB query for {} edge RCs returned none", num_conns);
     }
 
     int Manager::gossip_rc(const RemoteRC& rc, const quic::ConnectionID* sender)

--- a/llarp/link/link_manager.hpp
+++ b/llarp/link/link_manager.hpp
@@ -11,6 +11,7 @@
 #include <llarp/router/router.hpp>
 #include <llarp/util/compare_ptr.hpp>
 #include <llarp/util/decaying_hashset.hpp>
+#include <llarp/util/zstd.hpp>
 
 #include <oxen/quic/btstream.hpp>
 #include <oxen/quic/connection.hpp>
@@ -75,6 +76,8 @@ namespace llarp::link
 
         std::atomic<bool> is_stopping{false};
 
+        std::optional<zstd::compressor> compressor;
+
         // Registers commands on the client or relay end of a client-relay or relay-relay connection
         // NB: this could be called from either the network or router loop thread!
         void register_commands(quic::BTRequestStream& s, const RouterID& rid, bool client_only = false);
@@ -120,8 +123,6 @@ namespace llarp::link
       private:
         void handle_gossip_rc(quic::message);
 
-        void fetch_bootstrap_rcs(
-            const RemoteRC& source, std::vector<std::byte> payload, std::function<void(quic::message)> func);
         void handle_fetch_bootstrap_rcs(quic::message m);
 
         // Inner handlers for relayed requests

--- a/llarp/lokinet.cpp
+++ b/llarp/lokinet.cpp
@@ -60,6 +60,14 @@ namespace lokinet
         context->wait();
     }
 
+    void Lokinet::on_connected(std::function<void()> callback, bool persist) {
+        context->router->on_connected(std::move(callback), persist);
+    }
+
+    void Lokinet::on_disconnected(std::function<void()> callback, bool persist) {
+        context->router->on_disconnected(std::move(callback), persist);
+    }
+
     void Lokinet::establish_udp(
         std::string_view remote,
         uint16_t port,

--- a/llarp/nodedb.cpp
+++ b/llarp/nodedb.cpp
@@ -30,6 +30,7 @@ namespace llarp
 #ifdef LOKINET_DEBUG_PATH_SEED
     static std::vector<const std::pair<const RouterID, RemoteRC>*> debug_sort_admissable(
         const std::unordered_map<RouterID, RemoteRC>& known_rcs,
+        const std::unordered_set<RouterID>& blacklist,
         const std::function<bool(const RemoteRC&)>& predicate,
         std::chrono::milliseconds now = llarp::time_now_ms())
     {
@@ -37,7 +38,8 @@ namespace llarp
         if (!predicate)
             admitted.reserve(known_rcs.size());
         for (const auto& x : known_rcs)
-            if (not x.second.is_expired(now) and (not predicate or predicate(x.second)))
+            if (not x.second.is_expired(now) and not blacklist.contains(x.first)
+                and (not predicate or predicate(x.second)))
                 admitted.push_back(&x);
         // We need a sorted list of known rcs because of the potentially non-reproducible order
         // of elements in an unordered map:
@@ -53,7 +55,7 @@ namespace llarp
 #ifdef LOKINET_DEBUG_PATH_SEED
         if (auto& s = _router.config().paths.debug_path_seed)
         {
-            auto admitted = debug_sort_admissable(known_rcs, predicate, now);
+            auto admitted = debug_sort_admissable(known_rcs, _router.config().paths.snode_blacklist, predicate, now);
             if (admitted.empty())
                 return nullptr;
             std::mt19937_64 rng{*s};
@@ -64,7 +66,8 @@ namespace llarp
         int admitted = 0;
         for (const auto& rc : std::views::values(known_rcs))
         {
-            if (not rc.is_expired(now) and (not predicate or predicate(rc)))
+            if (not rc.is_expired(now) and not _router.config().paths.snode_blacklist.contains(rc.router_id())
+                and (not predicate or predicate(rc)))
             {
                 if (admitted == 0 || std::uniform_int_distribution<int>{0, admitted}(llarp::csrng) == 0)
                     result = &rc;
@@ -85,7 +88,7 @@ namespace llarp
 #ifdef LOKINET_DEBUG_PATH_SEED
         if (auto& s = _router.config().paths.debug_path_seed)
         {
-            auto admitted = debug_sort_admissable(known_rcs, predicate, now);
+            auto admitted = debug_sort_admissable(known_rcs, _router.config().paths.snode_blacklist, predicate, now);
             std::mt19937_64 rng{*s};
             auto end = std::ranges::sample(
                 admitted | std::views::transform([](const auto* x) { return &x->second; }), rand.begin(), n, rng);
@@ -97,8 +100,9 @@ namespace llarp
         }
 #endif
 
-        auto pred = [&predicate, &now](const RemoteRC& rc) {
-            return not rc.is_expired(now) and (not predicate or predicate(rc));
+        auto pred = [&predicate, &now, &blacklist = _router.config().paths.snode_blacklist](const RemoteRC& rc) {
+            return not rc.is_expired(now) and not blacklist.contains(rc.router_id())
+                and (not predicate or predicate(rc));
         };
         auto end = std::ranges::sample(
             known_rcs | std::views::values | std::views::filter(pred)
@@ -110,6 +114,74 @@ namespace llarp
             rand.resize(len);
         if (shuffle && rand.size() > 1)
             std::ranges::shuffle(rand, csrng);
+        return rand;
+    }
+
+    std::vector<const RemoteRC*> NodeDB::get_n_random_edge_rcs(
+        int n, bool shuffle, const std::function<bool(const RemoteRC&)>& predicate) const
+    {
+        assert(_router.loop.inside());
+        auto& strict = _router.config().paths.strict_edges;
+        if (_router.is_service_node || strict.empty())
+            return get_n_random_rcs(n, shuffle, predicate);
+
+        n = std::min(n, static_cast<int>(strict.size()));
+
+        auto now = llarp::time_now_ms();
+
+        std::vector<const RemoteRC*> rand;
+        rand.resize(n);
+        int admitted = 0;
+
+#ifdef LOKINET_DEBUG_PATH_SEED
+        if (auto& s = _router.config().paths.debug_path_seed)
+        {
+            std::vector<RouterID> sorted_strict;
+            sorted_strict.reserve(strict.size());
+            sorted_strict.assign(strict.begin(), strict.end());
+            std::sort(sorted_strict.begin(), sorted_strict.end());
+            std::mt19937_64 rng{*s};
+            for (const auto& rid : sorted_strict)
+            {
+                auto* rc = get_rc(rid);
+                if (not rc or rc->is_expired(now) or _router.config().paths.snode_blacklist.contains(rid)
+                    or (predicate and not predicate(*rc)))
+                    continue;
+
+                int pos = admitted < n ? admitted : std::uniform_int_distribution{0, admitted}(llarp::csrng);
+                admitted++;
+                if (pos < n)
+                    rand[pos] = rc;
+            }
+            if (admitted < n)
+                rand.resize(admitted);
+
+            if (shuffle && rand.size() > 1)
+                std::ranges::shuffle(rand, rng);
+
+            return rand;
+        }
+#endif
+
+        for (const auto& rid : strict)
+        {
+            auto* rc = get_rc(rid);
+            if (not rc or rc->is_expired(now) or _router.config().paths.snode_blacklist.contains(rid)
+                or (predicate and not predicate(*rc)))
+                continue;
+
+            int pos = admitted < n ? admitted : std::uniform_int_distribution{0, admitted}(llarp::csrng);
+            admitted++;
+            if (pos < n)
+                rand[pos] = rc;
+        }
+
+        if (admitted < n)
+            rand.resize(admitted);
+
+        if (shuffle && rand.size() > 1)
+            std::ranges::shuffle(rand, llarp::csrng);
+
         return rand;
     }
 
@@ -226,7 +298,7 @@ namespace llarp
                     return false;
                 }
 
-                if (not is_connection_allowed(rc.router_id()))
+                if (not is_registered(rc.router_id()))
                 {
                     log::trace(logcat, "Removing {}: not a valid router", rc.router_id());
                     return true;
@@ -442,9 +514,11 @@ namespace llarp
 
         if (not _router.is_service_node)
         {
-            _rc_fetch_ticker = _router.loop.call_every(FETCH_INTERVAL, [this] { fetch_rcs(); }, not need_bootstrap);
+            _rc_fetch_ticker = _router.loop.call_every(
+                FETCH_INTERVAL, [this] { fetch_rcs(); }, not need_bootstrap);
 
-            _rid_fetch_ticker = _router.loop.call_every(FETCH_INTERVAL, [this] { fetch_rids(); }, not need_bootstrap);
+            _rid_fetch_ticker = _router.loop.call_every(
+                FETCH_INTERVAL, [this] { fetch_rids(); }, not need_bootstrap);
         }
 
         if (need_bootstrap)
@@ -721,35 +795,6 @@ namespace llarp
                 _registered_relays.begin(),
                 std::uniform_int_distribution<int>{0, static_cast<int>(_registered_relays.size())}(llarp::csrng));
         return result;
-    }
-
-    bool NodeDB::is_connection_allowed(const RouterID& remote) const
-    {
-        assert(_router.loop.inside());
-        if (not _router.is_service_node)
-        {
-            if (_pinned_edges.size() and not _pinned_edges.contains(remote))
-                return false;
-
-            return known_rids.contains(remote);
-        }
-
-        return known_rids.contains(remote) and is_registered(remote);
-    }
-
-    bool NodeDB::is_first_hop_allowed(const RouterID& remote) const
-    {
-        assert(_router.loop.inside());
-        if (_pinned_edges.size() && _pinned_edges.count(remote) == 0)
-            return false;
-
-        return true;
-    }
-
-    void NodeDB::set_pinned_edges(std::unordered_set<RouterID> edges)
-    {
-        _strict_connect = true;
-        _pinned_edges = std::move(edges);
     }
 
     void NodeDB::load_from_disk()

--- a/llarp/nodedb.cpp
+++ b/llarp/nodedb.cpp
@@ -28,13 +28,15 @@ namespace llarp
 
 #ifdef LOKINET_DEBUG_PATH_SEED
     static std::vector<const std::pair<const RouterID, RemoteRC>*> debug_sort_admissable(
-        const std::unordered_map<RouterID, RemoteRC>& known_rcs, const std::function<bool(const RemoteRC&)>& predicate)
+        const std::unordered_map<RouterID, RemoteRC>& known_rcs,
+        const std::function<bool(const RemoteRC&)>& predicate,
+        std::chrono::milliseconds now = llarp::time_now_ms())
     {
         std::vector<const std::pair<const RouterID, RemoteRC>*> admitted;
         if (!predicate)
             admitted.reserve(known_rcs.size());
         for (const auto& x : known_rcs)
-            if (!predicate || predicate(x.second))
+            if (not x.second.is_expired(now) and (not predicate or predicate(x.second)))
                 admitted.push_back(&x);
         // We need a sorted list of known rcs because of the potentially non-reproducible order
         // of elements in an unordered map:
@@ -45,10 +47,12 @@ namespace llarp
 
     const RemoteRC* NodeDB::get_random_rc(const std::function<bool(const RemoteRC&)>& predicate) const
     {
+        auto now = llarp::time_now_ms();
+
 #ifdef LOKINET_DEBUG_PATH_SEED
         if (auto& s = _router.config().paths.debug_path_seed)
         {
-            auto admitted = debug_sort_admissable(known_rcs, predicate);
+            auto admitted = debug_sort_admissable(known_rcs, predicate, now);
             if (admitted.empty())
                 return nullptr;
             std::mt19937_64 rng{*s};
@@ -59,7 +63,7 @@ namespace llarp
         int admitted = 0;
         for (const auto& rc : std::views::values(known_rcs))
         {
-            if (!predicate || predicate(rc))
+            if (not rc.is_expired(now) and (not predicate or predicate(rc)))
             {
                 if (admitted == 0 || std::uniform_int_distribution<int>{0, admitted}(llarp::csrng) == 0)
                     result = &rc;
@@ -72,6 +76,7 @@ namespace llarp
     std::vector<const RemoteRC*> NodeDB::get_n_random_rcs(
         int n, bool shuffle, const std::function<bool(const RemoteRC&)>& predicate) const
     {
+        auto now = llarp::time_now_ms();
         assert(_router.loop.inside());
         std::vector<const RemoteRC*> rand;
         rand.resize(n);
@@ -79,7 +84,7 @@ namespace llarp
 #ifdef LOKINET_DEBUG_PATH_SEED
         if (auto& s = _router.config().paths.debug_path_seed)
         {
-            auto admitted = debug_sort_admissable(known_rcs, predicate);
+            auto admitted = debug_sort_admissable(known_rcs, predicate, now);
             std::mt19937_64 rng{*s};
             auto end = std::ranges::sample(
                 admitted | std::views::transform([](const auto* x) { return &x->second; }), rand.begin(), n, rng);
@@ -91,11 +96,15 @@ namespace llarp
         }
 #endif
 
-        auto all_rcs = known_rcs | std::views::values;
-        auto to_ptr = std::views::transform([](const auto& rc) { return &rc; });
-        auto end = predicate
-            ? std::ranges::sample(all_rcs | std::views::filter(predicate) | to_ptr, rand.begin(), n, csrng)
-            : std::ranges::sample(all_rcs | to_ptr, rand.begin(), n, csrng);
+        auto pred = [&predicate, &now](const RemoteRC& rc) {
+            return not rc.is_expired(now) and (not predicate or predicate(rc));
+        };
+        auto end = std::ranges::sample(
+            known_rcs | std::views::values | std::views::filter(pred)
+                | std::views::transform([](const auto& rc) { return &rc; }),
+            rand.begin(),
+            n,
+            csrng);
         if (auto len = std::distance(rand.begin(), end); len < n)
             rand.resize(len);
         if (shuffle && rand.size() > 1)

--- a/llarp/nodedb.cpp
+++ b/llarp/nodedb.cpp
@@ -5,6 +5,7 @@
 #include <llarp/messages/fetch.hpp>
 #include <llarp/util/random.hpp>
 #include <llarp/util/time.hpp>
+#include <llarp/util/zstd.hpp>
 
 #include <oxen/quic/btstream.hpp>
 #include <sodium/crypto_generichash.h>
@@ -127,7 +128,7 @@ namespace llarp
         {
             NodeDB& nodedb;
             size_t rc_i = 0;
-            std::vector<std::byte> body;
+            std::string body;
             RouterID source;
 
             // Shared pointer to ourself to keep us alive.  This is released once we run out of rcs,
@@ -180,9 +181,8 @@ namespace llarp
         };
         auto bs = std::make_shared<bs_data>(*this);
         bs->keep_alive = bs;
-        bs->body = BootstrapFetch::serialize(
-            _router.is_service_node ? std::make_optional(_router.rc()) : std::nullopt,
-            _router.is_service_node ? SERVICE_NODE_BOOTSTRAP_SOURCE_COUNT : CLIENT_BOOTSTRAP_SOURCE_COUNT);
+
+        bs->body = "de";
 
         bs->try_next();
     }
@@ -632,28 +632,34 @@ namespace llarp
         assert(_router.loop.inside());
         log::debug(logcat, "Received response to BootstrapRC fetch request...");
 
-        int num = 0, accepted = 0;
+        int num = 0, n_new = 0;
 
         try
         {
             oxenc::bt_dict_consumer btdc{body};
 
-            btdc.required("r");
+            auto compressed_rcs = btdc.require_span<std::byte>("Z");
 
-            {
-                auto sublist = btdc.consume_list_consumer();
-
-                while (not sublist.is_finished())
-                {
-                    // if we're trusting the bootstrap for RCs regardless of RouterID, we
-                    // should trust the RouterID as well.
-                    RemoteRC new_rc{sublist.consume_dict_data(), _router.netid()};
-                    known_rids.insert(new_rc.router_id());
-                    accepted += put_rc(std::move(new_rc));
-                    ++num;
-                }
-            }
             btdc.finish();
+
+            zstd::decompressor decompressor;
+            // 20M here is just a safety margin so that a malicious bootstrap can't feed us some
+            // tiny data that decompresses into something that exhausts memory:
+            auto rcs_data = zstd::decompressor{}.decompress(compressed_rcs, 20'000'000);
+            if (!rcs_data)
+                throw std::runtime_error{"Failed to decompress RC list"};
+
+            oxenc::bt_list_consumer rclist{*rcs_data};
+
+            while (not rclist.is_finished())
+            {
+                RemoteRC new_rc{rclist.consume_dict_data(), _router.netid()};
+                // if we're trusting the bootstrap for RCs regardless of RouterID, we
+                // should trust the RouterID as well.
+                known_rids.insert(new_rc.router_id());
+                n_new += put_rc(std::move(new_rc));
+                ++num;
+            }
         }
         catch (const std::exception& e)
         {
@@ -662,7 +668,7 @@ namespace llarp
             return false;
         }
 
-        log::info(logcat, "Bootstrap fetch successfully retrieved {} RCs ({} new)", num, accepted);
+        log::info(logcat, "Bootstrap fetch successfully retrieved {} RCs ({} new)", num, n_new);
         return true;
     }
 

--- a/llarp/nodedb.cpp
+++ b/llarp/nodedb.cpp
@@ -80,9 +80,6 @@ namespace llarp
         if (auto& s = _router.config().paths.debug_path_seed)
         {
             auto admitted = debug_sort_admissable(known_rcs, predicate);
-            log::warning(logcat, "DPS mode with {}", admitted.size());
-            for (auto& a : admitted)
-                log::warning(logcat, "   - {}", a->first);
             std::mt19937_64 rng{*s};
             auto end = std::ranges::sample(
                 admitted | std::views::transform([](const auto* x) { return &x->second; }), rand.begin(), n, rng);

--- a/llarp/nodedb.hpp
+++ b/llarp/nodedb.hpp
@@ -102,12 +102,6 @@ namespace llarp
         std::unordered_set<RouterID> _registered_relays;
         mutable std::shared_mutex _registered_relays_mutex;
 
-        // if populated from a config file, lists specific exclusively used as path first-hops
-        std::unordered_set<RouterID> _pinned_edges;
-
-        // if true, ONLY use pinned edges for first hop
-        bool _strict_connect{false};
-
         // set of 8 randomly selected RID's from the client's set of routers
         std::unordered_set<RouterID> rid_sources{};
         // logs the RID's that resulted in an error during RID fetching
@@ -136,8 +130,6 @@ namespace llarp
       public:
         explicit NodeDB(Router& r);
 
-        bool strict_connect_enabled() const { return _strict_connect; }
-
         // Starts the nodedb tickers for purge and fetch (clients), and initiates a bootstrap if the
         // nodedb has too few RCs.
         void start();
@@ -157,38 +149,14 @@ namespace llarp
 
         std::optional<RouterID> get_random_registered_relay() const;
 
-        // client:
-        //   if pinned edges were specified, connections are allowed only to those and
-        //   to the configured bootstrap nodes.  otherwise, always allow.
-        //
-        // relay:
-        //   outgoing connections are allowed only to other registered relays
-        bool is_connection_allowed(const RouterID& remote) const;
-
-        // client:
-        //   same as is_connection_allowed
-        //
-        // server:
-        //   we only build new paths through registered, non-decommissioned relays
-        //   TODO FIXME: What does this mean? Servers don't build paths?
-        bool is_path_allowed(const RouterID& remote) const { return known_rids.count(remote); }
-
-        // if pinned edges were specified, the remote must be in that set, else any remote
-        // is allowed as first hop.
-        bool is_first_hop_allowed(const RouterID& remote) const;
-
-        const std::unordered_set<RouterID>& pinned_edges() const { return _pinned_edges; }
-
-        // Sets the bootstrap list in strict-connect, pinned-edge mode, where we will only make
-        // paths starting with the given router IDs.
-        void set_pinned_edges(std::unordered_set<RouterID> edges);
+        const std::unordered_set<RouterID>& strict_edges() const;
 
         int num_bootstraps() const { return static_cast<int>(_bootstraps.size()); }
 
         bool has_bootstraps() const { return !_bootstraps.empty(); }
 
         // Returns true if `relay` is a registered relay.  This uses a mutex (rather that event
-        // loop) protection so that it can be safely called from either event loop without disk a
+        // loop) protection so that it can be safely called from either event loop without risking a
         // deadlock between the loops.
         bool is_registered(const RouterID& relay) const;
 
@@ -214,17 +182,24 @@ namespace llarp
         /// maybe get an rc by its ident pubkey.  Returns nullptr if not found.
         const RemoteRC* get_rc(const RouterID& pk) const;
 
-        /// Selects a random RC from all known RCs that return true from the given predicate (from
-        /// all known RCs if no predicate is given).  Returns nullptr if there are no acceptable
-        /// RCs.
+        /// Selects a random RC from all unexpired, non-blacklisted RCs (optionally filtering by
+        /// those that return true from the given predicate).  Returns nullptr if there are no
+        /// acceptable RCs.
         const RemoteRC* get_random_rc(const std::function<bool(const RemoteRC&)>& predicate = nullptr) const;
 
-        /// Selects n random RCs from all known RCs (if a predicate is given, all that return true
-        /// from the given predicate).  If there are fewer than `n` admissable RCs then all
-        /// admissable RCs are returned.  The resulting RCs will also be shuffled before being
-        /// returned, unless the shuffle argument is set to false.  The returned pointers are
-        /// guaranteed to be non-nullptr.
+        /// Selects n random RCs from all known, unexpired, non-blocklisted RCs (if a predicate is
+        /// given, they must also pass the given predicate).  If there are fewer than `n` admissable
+        /// RCs then all admissable RCs are returned.  The resulting RCs will also be shuffled
+        /// before being returned, unless the shuffle argument is set to false.  The returned
+        /// pointers are guaranteed to be non-nullptr.
         std::vector<const RemoteRC*> get_n_random_rcs(
+            int n, bool shuffle = true, const std::function<bool(const RemoteRC&)>& predicate = nullptr) const;
+
+        /// Same as `get_n_random_rcs`, except that this only returns RCs that are eligible for
+        /// direct connections.  For a relay, or a client not using strict edges, this is exactly
+        /// the same as `get_n_random_rcs`, but when strict edges are active, only listed strict
+        /// router IDs are considered.
+        std::vector<const RemoteRC*> get_n_random_edge_rcs(
             int n, bool shuffle = true, const std::function<bool(const RemoteRC&)>& predicate = nullptr) const;
 
         /// Stores an RC broadcast to the network.  The return value indicates whether this RC

--- a/llarp/path/path_handler.cpp
+++ b/llarp/path/path_handler.cpp
@@ -143,8 +143,7 @@ namespace llarp::path
 #else
         auto current_remotes =
 #endif
-            router.node_db().strict_connect_enabled() ? router.node_db().pinned_edges()
-                                                      : router.link_manager().endpoint.get_current_relays();
+            router.link_manager().endpoint.get_current_relays();
 
 #ifdef LOKINET_DEBUG_PATH_SEED
         std::vector<RouterID> current_remotes;

--- a/llarp/path/path_handler.cpp
+++ b/llarp/path/path_handler.cpp
@@ -112,7 +112,7 @@ namespace llarp::path
 
         expire_paths(now);
 
-        if (not router.is_service_node and not router.link_endpoint().is_client_connected())
+        if (not router.is_service_node and not router.is_connected())
             // If we are not yet fully connected then we can't initiate path builds.  (In theory we
             // could whe not yet fully connected, but don't want to because that would bias edge
             // router selection towards faster ones).

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -1006,6 +1006,99 @@ namespace llarp
         return 0s;
     }
 
+    bool Router::is_connected() const
+    {
+        return loop.call_get([this] { return _is_connected; });
+    }
+
+    void Router::on_connected(std::function<void()> callback, bool persistent)
+    {
+        if (!callback)
+            return;
+        loop.call([this, callback = std::move(callback), persistent] {
+            if (_is_connected)
+                try
+                {
+                    callback();
+                }
+                catch (const std::exception& e)
+                {
+                    log::error(logcat, "Uncaught exception calling on_connected callback: {}", e.what());
+                }
+
+            if (persistent or not _is_connected)
+                _on_connected.emplace_back(std::move(callback), persistent);
+        });
+    }
+
+    void Router::on_disconnected(std::function<void()> callback, bool persistent)
+    {
+        if (!callback)
+            return;
+        loop.call([this, callback = std::move(callback), persistent] {
+            if (not _is_connected)
+                try
+                {
+                    callback();
+                }
+                catch (const std::exception& e)
+                {
+                    log::error(logcat, "Uncaught exception calling on_disconnected callback: {}", e.what());
+                }
+
+            if (persistent or _is_connected)
+                _on_disconnected.emplace_back(std::move(callback), persistent);
+        });
+    }
+
+    static void process_on_conn_callbacks(
+        std::list<std::pair<std::function<void()>, bool>> callbacks, std::string_view type)
+    {
+        for (auto it = callbacks.begin(); it != callbacks.end();)
+        {
+            auto& [f, persist] = *it;
+            try
+            {
+                f();
+            }
+            catch (const std::exception& e)
+            {
+                log::error(logcat, "Uncaught exception calling {} callback: {}", type, e.what());
+            }
+            if (persist)
+                ++it;
+            else
+                it = callbacks.erase(it);
+        }
+    }
+
+    void Router::on_edge_conn_change()
+    {
+        assert(loop.inside());
+
+        int conns = link_endpoint().num_relay_conns();
+        if (conns == 0 and _is_connected)
+        {
+            _is_connected = false;
+
+            log::warning(log_global, "Lokinet is no longer connected to the network!");
+
+            process_on_conn_callbacks(_on_disconnected, "on_disconnected");
+        }
+        else if (not _is_connected and conns >= _client_target_outbounds)
+        {
+            _is_connected = true;
+
+            log::info(
+                log_global,
+                "Lokinet is now connected to the network ({}) with {} relay connections",
+                config().network.is_reachable ? local_rid().to_network_address(false).to_string() : "outgoing-only",
+                conns);
+
+            process_on_conn_callbacks(_on_connected, "on_connected");
+        }
+    }
+
     void Router::stop()
     {
         if (!_is_running)

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -350,10 +350,8 @@ namespace llarp
             llarp::logRingBuffer.reset();
     }
 
-    void Router::process_routerconfig()
+    void Router::process_config()
     {
-        _client_target_outbounds = config().router.client_router_connections;
-
         if (is_service_node && embedded())
             throw std::runtime_error{"Invalid config: service node and embedded modes are incompatible!"};
 
@@ -452,97 +450,95 @@ namespace llarp
                 throw std::runtime_error{
                     "public-ip/port ({}) and listen address ({}) are both public addresses but do not match!"_format(
                         _public_address, _listen_address)};
+
+            log::info(
+                log_global,
+                "Lokinet relay listening on {}{}",
+                _listen_address,
+                _public_address ? " with public address {}"_format(*_public_address) : "");
         }
         else  // Not a service node:
         {
             _listen_address = _config.links.listen_addr.value_or(DEFAULT_CLIENT_ADDR);
 
-            log::info(logcat, "Using {} for Lokinet communications", _listen_address);
+            log::info(log_global, "Lokinet client connection using {}", _listen_address);
         }
 
         RelayContact::BLOCK_BOGONS = _config.router.block_bogons;
-    }
 
-    void Router::process_netconfig()
-    {
-        auto& conf = _config.network;
+        auto& netconf = _config.network;
 
         if (!embedded())
         {
             assert(net());
 
-            if (!conf._if_name)
-                conf._if_name = net()->find_free_tun();
+            if (!netconf._if_name)
+                netconf._if_name = net()->find_free_tun();
 
-            if (!(conf._local_ip_net && conf._local_ip_net->ip.addr))
+            if (!(netconf._local_ip_net && netconf._local_ip_net->ip.addr))
             {
-                if (auto maybe = net()->find_free_ipv4_net(conf._local_ip_net ? conf._local_ip_net->mask : 16))
-                    conf._local_ip_net = std::move(*maybe);
+                if (auto maybe = net()->find_free_ipv4_net(netconf._local_ip_net ? netconf._local_ip_net->mask : 16))
+                    netconf._local_ip_net = std::move(*maybe);
                 else
                     throw std::runtime_error("cannot find free IPv4 address range!");
             }
-            log::info(logcat, "Lokinet IPv4 local network is {}", *conf._local_ip_net);
+            log::info(logcat, "Lokinet IPv4 local network is {}", *netconf._local_ip_net);
 
-            if (conf.enable_ipv6)
+            if (netconf.enable_ipv6)
             {
-                if (!conf._local_ipv6_net || (!conf._local_ipv6_net->ip.hi && !conf._local_ipv6_net->ip.lo))
+                if (!netconf._local_ipv6_net || (!netconf._local_ipv6_net->ip.hi && !netconf._local_ipv6_net->ip.lo))
                 {
-                    if (auto maybe = net()->find_free_ipv6_net(conf._local_ipv6_net ? conf._local_ipv6_net->mask : 64))
-                        conf._local_ipv6_net = std::move(*maybe);
+                    if (auto maybe =
+                            net()->find_free_ipv6_net(netconf._local_ipv6_net ? netconf._local_ipv6_net->mask : 64))
+                        netconf._local_ipv6_net = std::move(*maybe);
                     else
                         throw std::runtime_error("cannot find free IPv6 address range!");
                 }
-                log::info(logcat, "Lokinet IPv6 local network is {}", *conf._local_ipv6_net);
+                log::info(logcat, "Lokinet IPv6 local network is {}", *netconf._local_ipv6_net);
                 log::warning(
                     logcat,
                     "Lokinet IPv6 support is a work-in-progress and unsupported; enabling it is not recommended");
             }
 
             // Make sure any reserved addresses are within our local network range:
-            std::erase_if(conf._reserved_local_ipv4, [&conf](const auto& addr_ip) {
-                return !conf._local_ip_net->contains(addr_ip.second);
+            std::erase_if(netconf._reserved_local_ipv4, [&netconf](const auto& addr_ip) {
+                return !netconf._local_ip_net->contains(addr_ip.second);
             });
-            if (conf._local_ipv6_net)
-                std::erase_if(conf._reserved_local_ipv6, [&conf](const auto& addr_ip) {
-                    return !conf._local_ipv6_net->contains(addr_ip.second);
+            if (netconf._local_ipv6_net)
+                std::erase_if(netconf._reserved_local_ipv6, [&netconf](const auto& addr_ip) {
+                    return !netconf._local_ipv6_net->contains(addr_ip.second);
                 });
         }
 
-        // parse strict-connet pubkeys
-        if (auto& conf_edges = conf.pinned_edges; not conf_edges.empty())
+        if (not is_service_node)
         {
-            if (is_service_node)
-                throw std::runtime_error("cannot use strict-connect option as service node");
+            auto& pathconf = _config.paths;
 
-            auto n_edges = static_cast<int>(conf_edges.size());
-
-            // bad inputs throw in config parsing, so we should never have 0 pinned_edges
-            assert(n_edges > 0);
-
-            if (not n_edges)
-                throw std::runtime_error(
-                    "Must specify at least ONE valid strict-connect relay if using [network]:strict-connect");
-
-            node_db().set_pinned_edges(std::move(conf_edges));
-
-            // TODO: load strict-connects as bootstraps as well
-
-            log::debug(logcat, "Local client configured to strictly use {} edge relays", n_edges);
-
-            if (_client_target_outbounds > n_edges)
+            if (int conf_edges = static_cast<int>(_config.paths.strict_edges.size()); conf_edges > 0)
             {
-                _client_target_outbounds = n_edges;
-                log::warning(logcat, "Minimum router connections reduced to {} to match strict-connect edges", n_edges);
+                if (pathconf.edge_connections > conf_edges)
+                {
+                    log::warning(
+                        logcat,
+                        "[paths]:edge-connections is set to {0}, but only {1} strict edges are defined; lowering "
+                        "edge-connections to {1}",
+                        pathconf.edge_connections,
+                        conf_edges);
+                    pathconf.edge_connections = conf_edges;
+                }
+                else
+                    log::debug(
+                        logcat,
+                        "Local client configured to maintain {} of {} possible strict edge relays",
+                        pathconf.edge_connections,
+                        conf_edges);
             }
+            else
+                log::debug(
+                    logcat,
+                    "Local client configured to maintain {} random router edge connections",
+                    config().paths.edge_connections);
         }
-        else
-            log::debug(
-                logcat,
-                "Local client configured to maintain {} router connections at minimum",
-                _client_target_outbounds);
-
-        if (not _client_target_outbounds)
-            throw std::runtime_error{"Client must be configured to have at least 1 outbound router connection!"};
     }
 
     void Router::configure()
@@ -602,21 +598,7 @@ namespace llarp
 
         log::trace(logcat, "Initializing from configuration");
 
-        process_routerconfig();
-
-        if (is_service_node)
-            log::info(
-                log_global,
-                "Lokinet relay listening on {}{}",
-                _listen_address,
-                _public_address ? " with public address {}"_format(*_public_address) : "");
-        else
-            log::info(log_global, "Lokinet client connection using {}", _listen_address);
-
-        // We process the relevant netconfig values (ip_range, address, and ip) here; in case the range or interface
-        // is bad, we search for a free one and set it BACK into the config. Every subsequent object configuring
-        // using the NetworkConfig (ex: tun/null, exit::Handler, etc) will have processed values
-        process_netconfig();
+        process_config();
 
         _node_db = std::make_unique<NodeDB>(*this);
 
@@ -783,6 +765,8 @@ namespace llarp
             }
         }
 
+        // FIXME: we don't connect to ourself, so this needs a -1 once the nodedb has our own pubkey
+        // in it.
         if (registered and link_endpoint().num_relay_conns(/*include_pending=*/true) < node_db().num_rcs())
         {
             log::debug(
@@ -803,18 +787,18 @@ namespace llarp
         if (should_report_stats(now))
             report_stats();
 
-        // TODO: make "use_pinned_edges" boolean to only connect to pinned edges
         // if we need more sessions to routers we shall connect out to others
-        if (int n_conns = link_endpoint().num_relay_conns(/*include_pending=*/true); n_conns < _client_target_outbounds)
+        if (int n_conns = link_endpoint().num_relay_conns(/*include_pending=*/true);
+            n_conns < config().paths.edge_connections)
         {
-            auto num_needed = _client_target_outbounds - n_conns;
+            auto num_needed = config().paths.edge_connections - n_conns;
 
             log::debug(
                 logcat,
-                "Client connecting to {} random routers to keep alive (current:{}, needed:{})",
+                "Client connecting to {} random routers to keep alive (current:{}, target:{})",
                 num_needed,
                 n_conns,
-                _client_target_outbounds);
+                config().paths.edge_connections);
             _link_manager->connect_to_keep_alive(num_needed);
         }
 
@@ -1087,7 +1071,8 @@ namespace llarp
         }
         else if (
             not _is_connected
-            and conns * CLIENT_CONNECTED_THRESHOLD::den >= _client_target_outbounds * CLIENT_CONNECTED_THRESHOLD::num)
+            and conns * CLIENT_CONNECTED_THRESHOLD::den
+                >= config().paths.edge_connections * CLIENT_CONNECTED_THRESHOLD::num)
         {
             _is_connected = true;
 
@@ -1096,7 +1081,7 @@ namespace llarp
                 "Lokinet is now connected to the network ({}) with {}/{} relay connections",
                 config().network.is_reachable ? local_rid().to_network_address(false).to_string() : "outgoing-only",
                 conns,
-                _client_target_outbounds);
+                config().paths.edge_connections);
 
             process_on_conn_callbacks(_on_connected, "on_connected");
         }

--- a/llarp/router/router.cpp
+++ b/llarp/router/router.cpp
@@ -1085,15 +1085,18 @@ namespace llarp
 
             process_on_conn_callbacks(_on_disconnected, "on_disconnected");
         }
-        else if (not _is_connected and conns >= _client_target_outbounds)
+        else if (
+            not _is_connected
+            and conns * CLIENT_CONNECTED_THRESHOLD::den >= _client_target_outbounds * CLIENT_CONNECTED_THRESHOLD::num)
         {
             _is_connected = true;
 
             log::info(
                 log_global,
-                "Lokinet is now connected to the network ({}) with {} relay connections",
+                "Lokinet is now connected to the network ({}) with {}/{} relay connections",
                 config().network.is_reachable ? local_rid().to_network_address(false).to_string() : "outgoing-only",
-                conns);
+                conns,
+                _client_target_outbounds);
 
             process_on_conn_callbacks(_on_connected, "on_connected");
         }

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -160,8 +160,6 @@ namespace llarp
 
         Profiling _router_profiling;
 
-        int _client_target_outbounds = 0;
-
         bool should_report_stats(std::chrono::milliseconds now) const;
 
         std::string _stats_line(std::chrono::milliseconds now) const;
@@ -174,9 +172,7 @@ namespace llarp
 
         void init_logging();
 
-        void process_routerconfig();
-
-        void process_netconfig();
+        void process_config();
 
         void _relay_tick(std::chrono::milliseconds now);
 
@@ -194,8 +190,6 @@ namespace llarp
         const bool is_service_node{_config.router.is_relay};
 
         bool is_fully_meshed() const;
-
-        int client_target_outbounds() const { return _client_target_outbounds; }
 
         const std::shared_ptr<handlers::TunEPBase>& tun_endpoint() { return _tun; }
 

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -62,6 +62,13 @@ namespace llarp
 
     inline constexpr auto SERVICE_MANAGER_REPORT_INTERVAL{5s};
 
+    // The proportion of its target number of edge connections a client needs to have established
+    // connections with before we consider it "connected" to the network.  We allow less than full
+    // connectivity so that a single relay connection timeout doesn't stall connectivity for the
+    // full timeout duration, but generally want more than 1 so that we don't end up clustering all
+    // initial path builds through a single edge.
+    using CLIENT_CONNECTED_THRESHOLD = std::ratio<2, 3>;
+
     class ContactDB;
     class NodeDB;
 

--- a/llarp/router/router.hpp
+++ b/llarp/router/router.hpp
@@ -73,7 +73,7 @@ namespace llarp
             Config conf,
             std::shared_ptr<quic::Loop> loop,
             std::shared_ptr<vpn::Platform> vpnPlatform,
-            std::promise<void> p);
+            std::promise<void> close_promise);
 
         ~Router();
 
@@ -136,6 +136,15 @@ namespace llarp
         std::chrono::milliseconds _next_dereg_warning{time_now_ms() + 15s};
 
         std::chrono::milliseconds _last_path_ping{0s};
+
+        // Application callback(s) to fire as soon as we reach "connected" or "disconnected" status,
+        // which means when we have established our target number of edge connections or lost all
+        // edge connections, respectively.  Typically used as a "ready-to-go" callback during
+        // initialization.  The bool value indicates whether the callback is persistent (true) or
+        // one-time (false).  Note that callbacks are only called when the connected state changes:
+        // that is when we were disconnected and became connected, or were connected and became
+        // disconnected.
+        std::list<std::pair<std::function<void()>, bool>> _on_connected, _on_disconnected;
 
         // These aren't actually shared, but we unique_ptr requires destructor visibility, which
         // embedded-only clients won't have as they don't compile any RPC code.
@@ -277,13 +286,24 @@ namespace llarp
 
         std::string status_line();
 
-        // Client connectivity status: we enter "client connected" state when we have reached our
-        // target number of router connections, and we lose connected state when we fall to 0 router
-        // connections.  These log when we flip from disconnected to connected (info) or vice versa
-        // (warning).
-        void set_connected();
-        void set_disconnected();
+        // Returns the client connectivity status: we enter "connected" state once the target number
+        // of edge router connections is reached, and we lose connected state when we lose all edge
+        // connections.  Application code can monitor this state by setting callbacks via
+        // `on_connected`/`on_disconnected`.
         bool is_connected() const;
+
+        // Adds an application callback to invoke when the connectivity state changes to
+        // "connected".  If the state is already connected when this is called, the callback will be
+        // invoked immediately.  If `persistent` is true then the callback will be stored and called
+        // again if the state leaves and re-enters the connected state.
+        void on_connected(std::function<void()> callback, bool persistent);
+
+        // Like `is_connected`, but fires on disconnections.
+        void on_disconnected(std::function<void()> callback, bool persistent);
+
+        // Internal method: called from link::Endpoint to re-check and possibly change connected
+        // state when a client edge connection is established or lost.
+        void on_edge_conn_change();
 
         bool is_running() const { return _is_running; }
 

--- a/llarp/util/zstd.cpp
+++ b/llarp/util/zstd.cpp
@@ -1,0 +1,117 @@
+#include "zstd.hpp"
+
+#include "formattable.hpp"
+
+#include <zstd.h>
+
+#include <cassert>
+#include <stdexcept>
+
+namespace llarp::zstd
+{
+
+    static ZSTD_CCtx* cctx(void* c) { return static_cast<ZSTD_CCtx*>(c); }
+    static ZSTD_DCtx* dctx(void* d) { return static_cast<ZSTD_DCtx*>(d); }
+
+    compressor::compressor() : _context{ZSTD_createCCtx()} {}
+    compressor::~compressor() { ZSTD_freeCCtx(cctx(_context)); }
+
+    decompressor::decompressor() : _context{ZSTD_createDCtx()} {}
+    decompressor::~decompressor() { ZSTD_freeDCtx(dctx(_context)); }
+
+    std::vector<std::byte> compressor::compress(
+        std::span<const std::byte> data, int level, std::span<const std::byte> prefix)
+    {
+        auto* ctx = cctx(_context);
+        std::vector<std::byte> compressed;
+        compressed.resize(prefix.size() + ZSTD_compressBound(data.size()));
+        if (!prefix.empty())
+            std::memcpy(compressed.data(), prefix.data(), prefix.size());
+        auto size = ZSTD_compressCCtx(
+            ctx, compressed.data() + prefix.size(), compressed.size() - prefix.size(), data.data(), data.size(), level);
+        if (ZSTD_isError(size))
+            throw std::runtime_error{"Compression failed: {}"_format(ZSTD_getErrorName(size))};
+        compressed.resize(prefix.size() + size);
+        return compressed;
+    }
+    std::vector<std::byte> compressor::compress(std::string_view data, int level, std::string_view prefix)
+    {
+        return compress(
+            {reinterpret_cast<const std::byte*>(data.data()), data.size()},
+            level,
+            {reinterpret_cast<const std::byte*>(prefix.data()), prefix.size()});
+    }
+
+    template <typename B>
+    static std::vector<std::byte> compress_piecewise(ZSTD_CCtx* ctx, std::span<const B> buffers, int level, const B prefix)
+    {
+        ZSTD_CCtx_reset(ctx, ZSTD_reset_session_and_parameters);
+        size_t in_size = 0;
+        for (auto& b : buffers)
+            in_size += b.size();
+        ZSTD_CCtx_setParameter(ctx, ZSTD_c_compressionLevel, level);
+        ZSTD_CCtx_setPledgedSrcSize(ctx, in_size);
+        std::vector<std::byte> compressed;
+        compressed.resize(prefix.size() + ZSTD_compressBound(in_size));
+        if (!prefix.empty())
+            std::memcpy(compressed.data(), prefix.data(), prefix.size());
+        ZSTD_outBuffer output{.dst = compressed.data() + prefix.size(), .size = compressed.size() - prefix.size(), .pos = 0};
+        for (const auto& buf : buffers)
+        {
+            const auto last = &buf == &buffers.back();
+            const auto mode = last ? ZSTD_e_end : ZSTD_e_continue;
+            ZSTD_inBuffer input{.src = buf.data(), .size = buf.size(), .pos = 0};
+            bool finished;
+            do
+            {
+                const auto remaining = ZSTD_compressStream2(ctx, &output, &input, mode);
+                if (ZSTD_isError(remaining))
+                    throw std::runtime_error{"Compression failed: {}"_format(ZSTD_getErrorName(remaining))};
+                finished = last ? remaining == 0 : input.pos == input.size;
+            } while (not finished);
+            assert(input.pos == input.size);
+        }
+        assert(prefix.size() + output.pos <= compressed.size());
+        compressed.resize(prefix.size() + output.pos);
+        return compressed;
+    }
+
+    std::vector<std::byte> compressor::compress(std::span<const std::string_view> buffers, int level, std::string_view prefix)
+    {
+        return compress_piecewise(cctx(_context), buffers, level, prefix);
+    }
+    std::vector<std::byte> compressor::compress(std::span<const std::span<const std::byte>> buffers, int level, const std::span<const std::byte> prefix)
+    {
+        return compress_piecewise(cctx(_context), buffers, level, prefix);
+    }
+
+    /// Attempts to decompress `data`.  Returns nullopt if decompression fails.  If max_size is
+    /// non-zero then this returns nullopt if the decompressed data would expand to more than
+    /// max_size bytes.
+    std::optional<std::vector<std::byte>> decompressor::decompress(
+        std::span<const std::byte> compressed, size_t max_size)
+    {
+        auto* ctx = dctx(_context);
+        ZSTD_initDStream(ctx);
+        ZSTD_inBuffer input{.src = compressed.data(), .size = compressed.size(), .pos = 0};
+
+        std::array<std::byte, 16384> out_buf;
+        ZSTD_outBuffer output{.dst = out_buf.data(), .size = out_buf.size(), .pos = 0};
+
+        std::vector<std::byte> decompressed;
+
+        size_t ret;
+        do
+        {
+            output.pos = 0;
+            ret = ZSTD_decompressStream(ctx, &output, &input);
+            if (ZSTD_isError(ret) or (max_size > 0 && decompressed.size() + output.pos > max_size))
+                return std::nullopt;
+
+            decompressed.insert(decompressed.end(), out_buf.begin(), out_buf.begin() + output.pos);
+        } while (ret > 0 or input.pos < input.size);
+
+        return decompressed;
+    }
+
+}  // namespace llarp::zstd

--- a/llarp/util/zstd.hpp
+++ b/llarp/util/zstd.hpp
@@ -1,0 +1,68 @@
+#pragma once
+#include <memory>
+#include <optional>
+#include <span>
+#include <vector>
+
+namespace llarp::zstd
+{
+    // Compression class that can be held to be used repeatedly, saving some system resources for
+    // repeated compressions.  NOT thread-safe (i.e. the same instance must not be used from
+    // different threads at the same time).
+    class compressor
+    {
+      private:
+        void* _context;
+
+      public:
+        static constexpr int DEFAULT_LEVEL = 3;
+
+        compressor();
+
+        compressor(compressor&&) = delete;
+        compressor(const compressor&) = delete;
+        compressor& operator=(const compressor&) = delete;
+        compressor& operator=(compressor&&) = delete;
+
+        // Compress a single buffer.  Throws on serious error.  If non-empty, `prefix` will be
+        // prepended to the returned vector.
+        std::vector<std::byte> compress(
+            std::span<const std::byte> data, int level = DEFAULT_LEVEL, std::span<const std::byte> prefix = {});
+        std::vector<std::byte> compress(std::string_view data, int level = DEFAULT_LEVEL, std::string_view prefix = {});
+
+        // Compress the concatenation of multiple buffers without requiring pre-concatenation.
+        // Throws on serious error.
+        std::vector<std::byte> compress(
+            std::span<const std::span<const std::byte>> buffers,
+            int level = DEFAULT_LEVEL,
+            std::span<const std::byte> prefix = {});
+        std::vector<std::byte> compress(
+            std::span<const std::string_view> buffers, int level = DEFAULT_LEVEL, std::string_view prefix = {});
+
+        ~compressor();
+    };
+
+    // Decompression class that can be stored to save initialization if used repeatedly.  NOT
+    // thread-safe.
+    class decompressor
+    {
+      private:
+        void* _context;
+
+      public:
+        decompressor();
+
+        decompressor(decompressor&&) = delete;
+        decompressor(const decompressor&) = delete;
+        decompressor& operator=(const decompressor&) = delete;
+        decompressor& operator=(decompressor&&) = delete;
+
+        // Attempts to decompress a single buffer with maximum allowed decompressed size of
+        // `max_size` (if non-zero).  Returns nullptr if compression failed (or if the `max_size`
+        // limit is hit).
+        std::optional<std::vector<std::byte>> decompress(std::span<const std::byte> compressed, size_t max_size = 0);
+
+        ~decompressor();
+    };
+
+}  // namespace llarp::zstd


### PR DESCRIPTION
(Built on top of #2267)

- Fixes non-randomness in bfetch_rcs: it was returning the first N results, shuffled, rather than a random set of N results.
- Fix get_n_random_rcs not checking for expired RC before returning results
- Make bootstrap fetch return *all* RCs.  Returning a small subset isn't very useful because the client is just going to have to go out and slowly build them up anyway, using more requests and bandwidth to do so, so they might as well start out with the full list (when bootstrapping).
- Use zstd compression for bootstrap fetch response.  This reduces the response size by about 1/3.
- Make strict-edges (formerly pinned edges) work.  In stable it never really worked properly, and in dev it was an unimplemented FIXME.
- Fix the snode-blacklist setting.  `dev` was ignoring it.
- Various other smaller changes/cleanups.
