### PR TITLE
Datagram congestion

### DIFF
--- a/llarp/consensus/reachability_testing.cpp
+++ b/llarp/consensus/reachability_testing.cpp
@@ -80,8 +80,10 @@ namespace llarp::consensus
             }
 
             auto [conn, btstr] = router.link_endpoint().testing_client_connect(*rc);
-            btstr->command("ping", "", TEST_REQUEST_TIMEOUT, [this, conn, rid, prev_fails](quic::message m) mutable {
-                conn->close_connection();
+            btstr->command("ping", "", TEST_REQUEST_TIMEOUT, [this, weak_conn = std::weak_ptr{conn}, rid, prev_fails](quic::message m) mutable {
+                auto conn = weak_conn.lock();
+                if (conn)
+                    conn->close_connection();
                 router.loop.call_soon([this, rid, prev_fails, m = std::move(m)] {
                     if (m)
                     {

--- a/llarp/link/endpoint.cpp
+++ b/llarp/link/endpoint.cpp
@@ -95,7 +95,7 @@ namespace llarp::link
             },
             inbound_alpn,
             quic::opt::outbound_alpns{{router.is_service_node ? RELAY_ALPN : CLIENT_ALPN}},
-            quic::opt::enable_datagrams{quic::Splitting::ACTIVE});
+            quic::opt::enable_datagrams{quic::Splitting::ACTIVE}.queue_limit(2'000'000));
 
         tls_creds->enable_outbound_0rtt(
             [this](


### PR DESCRIPTION
Makes quic connections use libquic's datagram queue tail-drop.  Testing with many values on connections varying from ~200ms to ~500ms latency, 2MB seems to make Goldilocks pretty happy.