### PR TITLE
Randomize path expiry, allow experimental extended inbound path counts

### DIFF
--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -1472,6 +1472,20 @@ namespace llarp
 
         conf.define_option<int>(
             "paths",
+            "inbound-pivot-reuse",
+            ClientOnly,
+            Default{1},
+            Comment{
+                "This configures the maximum number of times a single relay may be used as a path pivot.",
+                "The default is one, meaning each inbound path is built to a distinct pivot, but special",
+                "cases (such as a one-hop reachable endpoint using a small number of pivots) may want to",
+                "increase this to allow multiple pivots to be used at once.  Leaving this at the default",
+                "of 1 is recommended for most cases.",
+            },
+            lower_bounded_assignment_acceptor(inbound_pivot_reuse, 1, "[paths]:inbound-pivot-reuse"));
+
+        conf.define_option<int>(
+            "paths",
             "unique-range-size",
             Default{24},
             ClientOnly,

--- a/llarp/config/config.cpp
+++ b/llarp/config/config.cpp
@@ -1445,6 +1445,18 @@ namespace llarp
 
         conf.define_option<int>(
             "paths",
+            "inbound-paths-extra",
+            FullClientOnly,
+            Hidden,
+            Default{0},
+            Comment{
+                "Extra inbound paths to use for Lokinet connectivity.  This option is hidden as it is not",
+                "meant for normal Lokinet use, and may be removed or replaced without warning in the future",
+            },
+            lower_bounded_assignment_acceptor(inbound_paths_extra, 0, "[paths]:inbound-paths-extra"));
+
+        conf.define_option<int>(
+            "paths",
             "inbound-hops",
             ClientOnly,
             Comment{

--- a/llarp/config/config.hpp
+++ b/llarp/config/config.hpp
@@ -91,6 +91,7 @@ namespace llarp
         /// Number of paths to maintain for inbound reachability and network queries (such as
         /// looking up client contacts).
         int inbound_paths = 4;
+        int inbound_paths_extra = 0;
 
         /// Length of the "inbound" paths we use for inbound connections and network queries.
         /// If unset, use client_hops.

--- a/llarp/config/config.hpp
+++ b/llarp/config/config.hpp
@@ -93,6 +93,10 @@ namespace llarp
         int inbound_paths = 4;
         int inbound_paths_extra = 0;
 
+        /// Number of times the same relay can be used as an inbound path pivot.  The default is 1,
+        /// which means every inbound path uses a distinct relay.
+        int inbound_pivot_reuse = 1;
+
         /// Length of the "inbound" paths we use for inbound connections and network queries.
         /// If unset, use client_hops.
         std::optional<int> inbound_hops_;

--- a/llarp/constants/path.hpp
+++ b/llarp/constants/path.hpp
@@ -20,7 +20,19 @@ namespace llarp::path
     /// Length of each frame of a path build.
     inline constexpr size_t BUILD_FRAME_SIZE = 169;
 
+    /// Max base lifetime of paths.  This is the lifetime of outbound paths, and is the maximum
+    /// target lifetime of inbound paths.  Inbound paths also have up some random fuzz added to
+    /// this, and so the actual maximum allowed by a relay is be slightly higher than this; see
+    /// next two variables.
     inline constexpr std::chrono::seconds MAX_LIFETIME = 20min;
+
+    /// Maximum path expiry randomness: when building paths we add a random value up to this amount
+    /// to the path lifetime, and so relays will accept paths of up to MAX_LIFETIME plus this value.
+    inline constexpr std::chrono::seconds MAX_LIFETIME_FUZZ = 3min;
+
+    /// The maximum path life accepted by a relay: this is the maximum life plus the maximum amount
+    /// of random fuzz.
+    inline constexpr std::chrono::seconds MAX_LIFETIME_ACCEPTED = MAX_LIFETIME + MAX_LIFETIME_FUZZ;
 
     /// The minimum expiry time slots for inbound paths.  See detailed comments in
     /// SessionEndpoint::update_paths().

--- a/llarp/contact/client_contact.cpp
+++ b/llarp/contact/client_contact.cpp
@@ -215,6 +215,6 @@ namespace llarp
 
     bool EncryptedClientContact::is_expired(std::chrono::milliseconds now) const
     {
-        return now >= signed_at + path::MAX_LIFETIME;
+        return now >= signed_at + path::MAX_LIFETIME_ACCEPTED;
     }
 }  //  namespace llarp

--- a/llarp/handlers/session.cpp
+++ b/llarp/handlers/session.cpp
@@ -185,8 +185,18 @@ namespace llarp::handlers
         path::PathHandler::stop();
     }
 
-    std::chrono::seconds SessionEndpoint::inbound_path_fuzz()
+    void SessionEndpoint::cleanup_old_fuzz(int oldest_slot)
     {
+        if (auto it = _slot_fuzz.lower_bound(oldest_slot); it != _slot_fuzz.end() && it != _slot_fuzz.begin())
+            _slot_fuzz.erase(_slot_fuzz.begin(), it);
+    }
+
+    std::chrono::seconds SessionEndpoint::inbound_path_fuzz(int slot)
+    {
+        auto it = _slot_fuzz.lower_bound(slot);
+        if (it != _slot_fuzz.end() && it->first == slot)
+            return it->second;
+
         // Note that this fuzz must not be negative!  If we allowed negative fuzz then a path could
         // expire *before* its slot expired, and as a result we would try to build a new very short
         // path to make up for the expired slot.
@@ -198,6 +208,9 @@ namespace llarp::handlers
             if (fuzz < 0s)
                 fuzz = -fuzz;
         } while (fuzz > path::MAX_LIFETIME_FUZZ);
+
+        _slot_fuzz.emplace_hint(it, slot, fuzz);
+
         return fuzz;
     }
 
@@ -388,6 +401,12 @@ namespace llarp::handlers
             log::trace(
                 logcat, "Current {} path expiry slots (oldest-newest): {}", path_count, fmt::join(slot_count, "-"));
 
+            // We want all paths built in a given slot to expire at the same time so that we publish
+            // CCs on average once every 5 minutes, even if we are using many paths, and so we reuse
+            // the same fuzz value for any paths built in the same slot (whether in this build or a
+            // previous one that we are rebuilding for here).
+            cleanup_old_fuzz(slot0);
+
             // Now we select new ones by looking for the slot with the fewest paths in it, preferring
             // later slots (i.e. longer expiries) in case of a tie, and keep repeating this for
             // however many paths we need:
@@ -397,7 +416,8 @@ namespace llarp::handlers
                 for (int j = 1; j < slots; j++)
                     if (slot_count[j] <= slot_count[best])
                         best = j;
-                expiries.emplace_back(path_expiry_basis + (slot0 + best) * slot_size + inbound_path_fuzz());
+                const auto slot = slot0 + best;
+                expiries.emplace_back(path_expiry_basis + slot * slot_size + inbound_path_fuzz(slot));
                 slot_count[best]++;
             }
 

--- a/llarp/handlers/session.cpp
+++ b/llarp/handlers/session.cpp
@@ -343,11 +343,20 @@ namespace llarp::handlers
 
             std::array<int, path::MAX_LIFETIME_SLOTS> slot_count = {0};
 
-            // The base slot, as a multiple of the slot_size since our fixed basis: we consider
-            // other path expiries relative to this.  There is an argument to be made to not
-            // build a path that would only have a duration of 0-5 min, but for now it's much
-            // simpler and cleaner to just build those paths anyway (if no path in that slot).
-            auto slot0 = (std::chrono::floor<std::chrono::seconds>(now) - path_expiry_basis) / slot_size;
+            // The base slot, measured in multiples of `slot_size` relative to our fixed basis: we
+            // consider other path expiries relative to this base slot.
+            //
+            // The +1 here is because (now-basis)/slot_size (i.e. without the +1) is going to give
+            // us a slot index that translates to a slot start time in the past (i.e. 0-5min ago),
+            // but we don't build for that slot: instead we build for slots at +5m, +10m, +15m, +20m
+            // from that now-or-earlier point.  Thus +1 brings us up to the first slot position
+            // within the next [0-5min], and that is our "slot0" value, i.e. the index 0 slot of all
+            // slots we consider building for.
+            //
+            // There is an argument to be made to not build new paths that would only have a
+            // duration of 0-5 min, but for now it's much simpler and cleaner to just build those
+            // paths anyway (if no path in that slot).
+            auto slot0 = (std::chrono::floor<std::chrono::seconds>(now) - path_expiry_basis) / slot_size + 1;
 
             // First count up all the slots we are already using with existing paths:
             int path_count = 0;
@@ -362,7 +371,7 @@ namespace llarp::handlers
                     "The slot calculation below requires path max fuzz be strictly smaller than the smallest allowed "
                     "path slot size!");
                 auto slot = (path.expiry() - path_expiry_basis) / slot_size;
-                if (slot <= slot0)
+                if (slot < slot0)
                 {
                     log::debug(logcat, "Ignoring expired/expiring path slot {}", slot);
                     continue;  // Path is expired/expiring, so ignore it.
@@ -386,13 +395,9 @@ namespace llarp::handlers
             {
                 int best = 0;
                 for (int j = 1; j < slots; j++)
-                {
                     if (slot_count[j] <= slot_count[best])
                         best = j;
-                }
-                // +1 here because slot0 is <= now, and so we want to start at slot0+1 so that our
-                // first expiry slot is somewhere in the [0-5min] range.
-                expiries.emplace_back(path_expiry_basis + (slot0 + best + 1) * slot_size + inbound_path_fuzz());
+                expiries.emplace_back(path_expiry_basis + (slot0 + best) * slot_size + inbound_path_fuzz());
                 slot_count[best]++;
             }
 

--- a/llarp/handlers/session.cpp
+++ b/llarp/handlers/session.cpp
@@ -325,6 +325,11 @@ namespace llarp::handlers
         // This is somewhat lopsided for non-multiples of 4, but there's still lots of spread in
         // there so that even with multiple paths expiring at the same time, there are still lots of
         // alternatives for remotes to switch to.
+        //
+        // Note that all of the above ignores "fuzz", i.e. each path has a small random amount of
+        // lifetime (well less than 5min) added to it to reduce the fingerprintability of path build
+        // expiries.  All of the above still holds with respect to slots, it's just that where we
+        // write "+Nm" it's actually "+Nm+fuzz[0,3m]".
 
         std::vector<std::chrono::seconds> expiries;
         expiries.reserve(needed);

--- a/llarp/handlers/session.cpp
+++ b/llarp/handlers/session.cpp
@@ -28,7 +28,8 @@ namespace llarp::handlers
     static auto logcat = log::Cat("session_ep");
 
     SessionEndpoint::SessionEndpoint(Router& r)
-        : path::PathHandler{r, r.config().paths.inbound_paths, r.config().paths.inbound_hops()},
+        : path::
+              PathHandler{r, r.config().paths.inbound_paths + r.config().paths.inbound_paths_extra, r.config().paths.inbound_hops()},
           cc_blind_keys{r.secret_key(), crypto::blinding::CLIENT_CONTACT}
     {
         const auto& netconf = router.config().network;

--- a/llarp/handlers/session.cpp
+++ b/llarp/handlers/session.cpp
@@ -1,5 +1,6 @@
 #include "session.hpp"
 
+#include <llarp/constants/path.hpp>
 #include <llarp/contact/contactdb.hpp>
 #include <llarp/contact/relay_contact.hpp>
 #include <llarp/crypto/crypto.hpp>
@@ -20,6 +21,7 @@
 #include <oxenc/base32z.h>
 
 #include <memory>
+#include <random>
 
 namespace llarp::handlers
 {
@@ -182,6 +184,22 @@ namespace llarp::handlers
         path::PathHandler::stop();
     }
 
+    std::chrono::seconds SessionEndpoint::inbound_path_fuzz()
+    {
+        // Note that this fuzz must not be negative!  If we allowed negative fuzz then a path could
+        // expire *before* its slot expired, and as a result we would try to build a new very short
+        // path to make up for the expired slot.
+        std::normal_distribution<float> dist{0, path::MAX_LIFETIME_FUZZ.count() / 2.575829f};
+        std::chrono::seconds fuzz;
+        do
+        {
+            fuzz = std::chrono::seconds{static_cast<int>(dist(csrng))};
+            if (fuzz < 0s)
+                fuzz = -fuzz;
+        } while (fuzz > path::MAX_LIFETIME_FUZZ);
+        return fuzz;
+    }
+
     void SessionEndpoint::update_paths(std::chrono::milliseconds now)
     {
         int have = num_paths(now);
@@ -330,6 +348,13 @@ namespace llarp::handlers
             for (auto& path : paths())
             {
                 path_count++;
+                // Path expiries will be up to +MAX_LIFETIME_FUZZ of their slot target expiry time, so we need
+                // to be sure that the maximum fuzz is less then the smallest possible slot size so
+                // that it is guaranteed to be counted in the same slot:
+                static_assert(
+                    path::MAX_LIFETIME_FUZZ < path::MAX_LIFETIME / path::MAX_LIFETIME_SLOTS,
+                    "The slot calculation below requires path max fuzz be strictly smaller than the smallest allowed "
+                    "path slot size!");
                 auto slot = (path.expiry() - path_expiry_basis) / slot_size;
                 if (slot <= slot0)
                 {
@@ -359,7 +384,9 @@ namespace llarp::handlers
                     if (slot_count[j] <= slot_count[best])
                         best = j;
                 }
-                expiries.emplace_back(path_expiry_basis + (slot0 + best + 1) * slot_size);
+                // +1 here because slot0 is <= now, and so we want to start at slot0+1 so that our
+                // first expiry slot is somewhere in the [0-5min] range.
+                expiries.emplace_back(path_expiry_basis + (slot0 + best + 1) * slot_size + inbound_path_fuzz());
                 slot_count[best]++;
             }
 
@@ -776,7 +803,19 @@ namespace llarp::handlers
 
         client_contact.update_intros(std::move(intros));
 
-        log::trace(logcat, "New ClientContact: {}", client_contact);
+        log::debug(logcat, "New ClientContact: {}", client_contact);
+#ifndef NDEBUG
+        log::trace(logcat, "ClientContact details:");
+        log::trace(logcat, "Pubkey: {}", client_contact.pubkey());
+        log::trace(logcat, "Intros ({}):", client_contact.intros().size());
+        for (const auto& ci : client_contact.intros())
+            log::trace(
+                logcat,
+                "    • {}, hopid: {}, expiry: {}",
+                ci.relay.to_network_address(),
+                ci.hop,
+                std::chrono::floor<std::chrono::seconds>(ci.expires_in(now)));
+#endif
 
         try
         {

--- a/llarp/handlers/session.cpp
+++ b/llarp/handlers/session.cpp
@@ -217,7 +217,12 @@ namespace llarp::handlers
     void SessionEndpoint::update_paths(std::chrono::milliseconds now)
     {
         int have = num_paths(now);
-        int needed = _target_paths - have;
+        // If you ask for more than 10 inbound paths (which is only possible via an undocumented
+        // option) and more than the number of RCs we know about then silently cut off at the number
+        // of RCs we know about (or a multiple of those, if pivot reuse is allowed) to avoid seeing
+        // a warning about not being able to select new pivots every 250ms.
+        int max_paths = router.node_db().num_rcs() * router.config().paths.inbound_pivot_reuse;
+        int needed = (_target_paths > 10 && _target_paths > max_paths ? max_paths : _target_paths) - have;
         if (needed <= 0)
         {
             log::trace(
@@ -267,11 +272,14 @@ namespace llarp::handlers
             if (unique_edge_range and unique_edge_range->contains(rc.addr().to_ipv4()))
                 return false;
 
-            // Exclude any inbound pivots we are already using so that we diversify:
+            // Exclude any inbound pivots we are already using (or using more than
+            // inbound_pivot_reuse times, if that option is higher than 1) so that we diversify:
+            int count = 0;
             const auto& rid = rc.router_id();
             for (const auto& p : paths())
                 if (p.terminal_rid() == rid)
-                    return false;
+                    if (++count >= router.config().paths.inbound_pivot_reuse)
+                        return false;
 
             return not router.router_profiling().is_bad_for_path(rid, 1);
         };
@@ -369,7 +377,8 @@ namespace llarp::handlers
             // There is an argument to be made to not build new paths that would only have a
             // duration of 0-5 min, but for now it's much simpler and cleaner to just build those
             // paths anyway (if no path in that slot).
-            auto slot0 = (std::chrono::floor<std::chrono::seconds>(now) - path_expiry_basis) / slot_size + 1;
+            int slot0 =
+                static_cast<int>((std::chrono::floor<std::chrono::seconds>(now) - path_expiry_basis) / slot_size + 1);
 
             // First count up all the slots we are already using with existing paths:
             int path_count = 0;
@@ -445,22 +454,34 @@ namespace llarp::handlers
         }
         else
         {
-            auto new_pivots = router.node_db().get_n_random_rcs(needed, true, filter);
-            if (needed > static_cast<int>(new_pivots.size()))
+            // We can potentially multi-pass through this because it can only return at most # of
+            // RCs, but pivot reuse might mean that we need to build paths using some RCs more than
+            // once.  (This is probably mostly a testnet concern).
+            int built = 0;
+            do
+            {
+                auto new_pivots = router.node_db().get_n_random_rcs(needed, true, filter);
+                if (new_pivots.empty())
+                    break;
+                needed -= static_cast<int>(new_pivots.size());
+                for (const llarp::RelayContact* rc : new_pivots)
+                {
+                    log::debug(logcat, "Selected new inbound path terminus {}", rc->router_id().short_string());
+                    auto hops = select_hops_to_remote(rc->router_id());
+                    if (!hops)
+                        continue;  // No need to warn: the call above should already if it fails
+
+                    build(*hops, *next_expiry++);
+                    built++;
+                }
+            } while (needed > 0);
+
+            if (needed > 0)
                 log::warning(
                     logcat,
-                    "Unable to build {} new inbound paths: {} unused/acceptable pivots currently available",
+                    "Failed to build {} of {} new inbound paths: ran out of available unused/acceptable pivots",
                     needed,
-                    new_pivots.size());
-            for (const llarp::RelayContact* rc : new_pivots)
-            {
-                log::debug(logcat, "Selected new inbound path terminus {}", rc->router_id().short_string());
-                auto hops = select_hops_to_remote(rc->router_id());
-                if (!hops)
-                    continue;  // No need to warn: the call above should already if it fails
-
-                build(*hops, *next_expiry++);
-            }
+                    needed + built);
         }
     }
 

--- a/llarp/handlers/session.hpp
+++ b/llarp/handlers/session.hpp
@@ -68,6 +68,22 @@ namespace llarp
 
             void session_post_init(std::shared_ptr<session::InboundSession> new_session);
 
+            // Returns a random amount of path "fuzz" to add to the path build time to make it
+            // harder to correlate repeated path builds over time from the same client.
+            //
+            // The value is cached so that repeated calls with the same slot return the same value.
+            //
+            // This currently returns a truncated normal distribution with truncation points at 0
+            // and MAX_LIFETIME_FUZZ such that the truncation point eliminates values above the
+            // 0.5th percentile of the distribution.
+            std::chrono::seconds inbound_path_fuzz(int slot);
+
+            // The cache of slot fuzz values returned by inbound_path_fuzz.
+            std::map<int, std::chrono::seconds> _slot_fuzz;
+
+            // Called to clean up expired slot values out of _slot_fuzz
+            void cleanup_old_fuzz(int oldest_slot);
+
           public:
             SessionEndpoint(Router& r);
 
@@ -75,14 +91,6 @@ namespace llarp
 
             // Checks if we need more inbound paths and, if so, starts building them.
             void update_paths(std::chrono::milliseconds now) override;
-
-            // Returns a random amount of path "fuzz" to add to the path build time to make it
-            // harder to correlate repeated path builds over time from the same client.
-            //
-            // This currently returns a truncated normal distribution with truncation points at 0
-            // and MAX_LIFETIME_FUZZ such that the truncation point eliminates values above the
-            // 0.5th percentile of the distribution.
-            static std::chrono::seconds inbound_path_fuzz();
 
             // bool build_path_to_random(bool exclude_current_termini)
 

--- a/llarp/handlers/session.hpp
+++ b/llarp/handlers/session.hpp
@@ -76,6 +76,14 @@ namespace llarp
             // Checks if we need more inbound paths and, if so, starts building them.
             void update_paths(std::chrono::milliseconds now) override;
 
+            // Returns a random amount of path "fuzz" to add to the path build time to make it
+            // harder to correlate repeated path builds over time from the same client.
+            //
+            // This currently returns a truncated normal distribution with truncation points at 0
+            // and MAX_LIFETIME_FUZZ such that the truncation point eliminates values above the
+            // 0.5th percentile of the distribution.
+            static std::chrono::seconds inbound_path_fuzz();
+
             // bool build_path_to_random(bool exclude_current_termini)
 
             /// Returns array of:

--- a/llarp/link/link_manager.cpp
+++ b/llarp/link/link_manager.cpp
@@ -690,7 +690,7 @@ namespace llarp::link
             auto [hop, dh_nonce] =
                 path::PathHandler::decrypt_build_frame(frames_in.first<path::BUILD_FRAME_SIZE>(), router, from, now);
 
-            if (hop->expiry > now + path::MAX_LIFETIME || hop->expiry <= now)
+            if (hop->expiry > now + path::MAX_LIFETIME_ACCEPTED || hop->expiry <= now)
                 throw path::TransitHopError::INVALID_LIFETIME();
 
             if (router.path_context.has_transit_hop(hop->rxid) || router.path_context.has_transit_hop(hop->txid))

--- a/llarp/link/link_manager.hpp
+++ b/llarp/link/link_manager.hpp
@@ -72,7 +72,7 @@ namespace llarp::link
         friend class Endpoint;
         friend class llarp::NodeDB;
 
-        util::DecayingHashSet<RouterID> clients{path::MAX_LIFETIME};
+        util::DecayingHashSet<RouterID> clients{path::MAX_LIFETIME_ACCEPTED};
 
         quic::Address addr;
 

--- a/llarp/path/path_handler.cpp
+++ b/llarp/path/path_handler.cpp
@@ -639,9 +639,9 @@ namespace llarp::path
 
             std::chrono::seconds lifetime{
                 oxenc::load_little_to_host<uint32_t>(inner.require_span<std::byte, sizeof(uint32_t)>("l").data())};
-            if (lifetime > path::MAX_LIFETIME)
+            if (lifetime > path::MAX_LIFETIME_ACCEPTED)
                 throw std::runtime_error{
-                    "Path lifetime {} exceeds maximum allowed path lifetime {}"_format(lifetime, path::MAX_LIFETIME)};
+                    "Path lifetime {} exceeds maximum allowed path lifetime {}"_format(lifetime, path::MAX_LIFETIME_ACCEPTED)};
             hop.expiry = now + lifetime;
             hop.rxid.assign(inner.require_span<std::byte, HopID::SIZE>("r"));
             hop.txid.assign(inner.require_span<std::byte, HopID::SIZE>("t"));


### PR DESCRIPTION
Adds random fuzz to inbound path expiries.

This extends inbound path lifetimes by up to 3min, drawn from a truncated normal N(0s, 180s/2.575) distribution with truncation at 0 and 3min.  (This means about a third of random values are <= 30s, ~61% <= 60s, ~92% <= 120s)

The basic idea here is that adding some fuzz makes the paths of long-running clients harder to identify: without this they would always build with expiry timestamps using the same % 300 value, and so you could (in theory) correlate the paths of long-running clients without knowing their keys.  By randomizing it, we make such fingerprinting harder to identify.

So as not to cause CC publish churn, this constrains the randomness to one random value per inbound path 5-minute "slot", so that even if you are building many paths, we target them all to expire at the same time, thus maintaining 1 expire-and-rebuild cycle per 5 minute interval under typical operation.  (This makes paths constructed at the same slot somewhat identifiable, but only for paths in that slot, and not across different time slots, which is the main point here).

This also adds two new options:
- one option allows building inbound paths to the same relay; without this (and still the default) inbound paths only build to pivots with whom we do not already have a building or built path.  This option allows you to control how often a pivot may be selected for simultaneous use in paths.
-  the second option is mainly a dev option to allow building more inbound paths than the default allowed config limit; this option is deliberately not added to the config file as a future release is likely to break or replace the option with alternative means of maintaining more paths, but this is useful for testing for now.