### PR TITLE
bundle session init with path switch so restarted clients/relays can "path switch"

### DIFF
--- a/llarp/contact/contactdb.cpp
+++ b/llarp/contact/contactdb.cpp
@@ -9,16 +9,6 @@ namespace llarp
 
     ContactDB::ContactDB(Router& r) : _router{r} {}
 
-    std::optional<ClientContact> ContactDB::get_decrypted_cc(RouterID remote) const
-    {
-        PubKey blinded;
-        if (!crypto::blind(blinded, remote, crypto::blinding::CLIENT_CONTACT))
-            return std::nullopt;
-        if (auto* enc = get_encrypted_cc(blinded))
-            return enc->decrypt(remote);
-        return std::nullopt;
-    }
-
     const EncryptedClientContact* ContactDB::get_encrypted_cc(const PubKey& blinded_key) const
     {
         if (auto it = _storage.find(blinded_key); it != _storage.end() && not it->second.is_expired())
@@ -30,9 +20,7 @@ namespace llarp
 
     void ContactDB::start_tickers()
     {
-        // FIXME: this class is dumb...
-        //
-        // Need to periodically call purge_ccs?
+        _purge_ticker = _router.loop.call_every(30s, [this](){ purge_ccs(); }, true);
     }
 
     void ContactDB::purge_ccs(std::chrono::milliseconds now)

--- a/llarp/contact/contactdb.hpp
+++ b/llarp/contact/contactdb.hpp
@@ -29,8 +29,6 @@ namespace llarp
       public:
         explicit ContactDB(Router& r);
 
-        std::optional<ClientContact> get_decrypted_cc(RouterID remote) const;
-
         const EncryptedClientContact* get_encrypted_cc(const PubKey& blinded_pk) const;
 
         void put_cc(EncryptedClientContact enc);

--- a/llarp/handlers/session.cpp
+++ b/llarp/handlers/session.cpp
@@ -1000,16 +1000,6 @@ namespace llarp::handlers
         return ret;
     }
 
-    std::shared_ptr<session::Session> SessionEndpoint::remote_session(const NetworkAddress& remote)
-    {
-        assert(router.loop.inside());
-
-        if (auto it = _sessions.find(remote); it != _sessions.end())
-            return it->second;
-
-        return nullptr;
-    }
-
     std::shared_ptr<session::Session> SessionEndpoint::initiate_remote_session(
         const NetworkAddress& remote,
         std::function<void(session::Session& session)> on_attempted,

--- a/llarp/handlers/session.cpp
+++ b/llarp/handlers/session.cpp
@@ -654,12 +654,6 @@ namespace llarp::handlers
 
     void SessionEndpoint::lookup_client_intro(RouterID remote, std::function<void(std::optional<ClientContact>)> func)
     {
-        if (auto maybe_intro = router.contact_db().get_decrypted_cc(remote))
-        {
-            log::debug(logcat, "Decrypted ClientContact for remote (rid: {}) found locally!", remote);
-            return func(std::move(maybe_intro));
-        }
-
         PubKey remote_key;
         if (!crypto::blind(remote_key, remote, crypto::blinding::CLIENT_CONTACT))
         {
@@ -679,7 +673,7 @@ namespace llarp::handlers
 
         auto remaining = std::make_shared<int>(0);
 
-        auto response_handler = [this, remote, func = std::move(func), remaining](auto resp) {
+        auto response_handler = [remote, func = std::move(func), remaining](auto resp) {
             int rem = --*remaining;
             if (rem < 0)
             {
@@ -699,7 +693,6 @@ namespace llarp::handlers
                     if (auto intro = enc.decrypt(remote))
                     {
                         log::debug(logcat, "Storing ClientContact for remote rid:{}", remote);
-                        router.contact_db().put_cc(std::move(enc));
                         cc = std::move(intro);
                     }
                     else

--- a/llarp/handlers/session.hpp
+++ b/llarp/handlers/session.hpp
@@ -191,11 +191,6 @@ namespace llarp
                 std::function<void(session::Session& session)> on_established,
                 std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
-            // More internal version of initiate_remote_session: this may only be called from inside
-            // the router loop, takes no callback, and returns the Session (which may be brand new
-            // if one did not already exist to the remote).
-            std::shared_ptr<session::Session> remote_session(const NetworkAddress& remote);
-
             void tick(std::chrono::milliseconds now) override;
 
             void queue_session_packet(const NetworkAddress& remote, IPPacket pkt);

--- a/llarp/link/link_manager.cpp
+++ b/llarp/link/link_manager.cpp
@@ -1036,36 +1036,38 @@ namespace llarp::link
             if (msgtype == path::Path::PATH_SWITCH_MESSAGE_TYPE)
             {
                 log::debug(logcat, "client handling path switch/session init message");
-                oxenc::bt_list_consumer btlp{message};
-                auto path_switch = btlp.consume_string_view();
-                auto session_init = btlp.consume_string_view();
-                btlp.finish();
 
+                if (message.size() < sizeof(session::session_tag))
+                {
+                    log::info(logcat, "invalid path switch / session reinit message received");
+                    return;
+                }
                 session_tag tag;
-                auto tag_span = std::span{path_switch}.last<sizeof(session_tag)>();
+                auto tag_span = std::span{message}.last<sizeof(session_tag)>();
                 tag = oxenc::load_big_to_host<session_tag>(tag_span.data());
+                message.resize(message.size() - sizeof(session::session_tag));
+
+                oxenc::bt_list_consumer btlc{message};
+                auto path_switch = btlc.consume_string_view();
+                auto session_init = btlc.consume_string_view();
+                btlc.finish();
+
                 if (router.session_endpoint().get_session(tag))
                 {
+                    log::debug(logcat, "Handling incoming session path switch message at the client end of a path");
                     // to avoid nonce re-use, mutate by xor factor
                     nonce ^= session::switch_xor_factor;
                     std::vector<std::byte> bytes;
-                    bytes.resize(path_switch.size() - sizeof(session_tag));
+                    bytes.resize(path_switch.size());
                     std::memcpy(bytes.data(), path_switch.data(), bytes.size());
-                    log::debug(logcat, "Handling incoming session path switch message at the client end of a path");
                     handle_session_control(std::move(bytes), tag, nonce, path->shared_from_this());
                 }
                 else
                 {
-#ifndef NDEBUG
-                    session_tag zero_tag;
-                    auto zero_tag_span = std::span{session_init}.last<sizeof(session_tag)>();
-                    zero_tag = oxenc::load_big_to_host<session_tag>(zero_tag_span.data());
-                    assert(zero_tag == 0);
-#endif
-                    std::vector<std::byte> bytes;
-                    bytes.resize(session_init.size() - sizeof(session_tag));
-                    std::memcpy(bytes.data(), session_init.data(), bytes.size());
                     log::debug(logcat, "Handling incoming session init message at the client end of a path");
+                    std::vector<std::byte> bytes;
+                    bytes.resize(session_init.size());
+                    std::memcpy(bytes.data(), session_init.data(), bytes.size());
                     router.session_endpoint().handle_session_init(std::move(bytes), path->shared_from_this());
                 }
                 return;
@@ -1137,37 +1139,31 @@ namespace llarp::link
                 if (msgtype == path::Path::PATH_SWITCH_MESSAGE_TYPE)
                 {
                     log::debug(logcat, "client handling path switch/session init message");
-                    oxenc::bt_list_consumer btlp{message};
-                    auto path_switch = btlp.consume_string_view();
-                    auto session_init = btlp.consume_string_view();
-                    btlp.finish();
+
+                    oxenc::bt_list_consumer btlc{payload};
+                    auto path_switch = btlc.consume_string_view();
+                    auto session_init = btlc.consume_string_view();
+                    btlc.finish();
 
                     session_tag tag;
-                    auto tag_span = std::span{path_switch}.last<sizeof(session_tag)>();
-                    tag = oxenc::load_big_to_host<session_tag>(tag_span.data());
+                    tag = oxenc::load_big_to_host<session_tag>(bsession_tag.data());
                     if (router.session_endpoint().get_session(tag))
                     {
+                        log::debug(logcat, "Handling incoming session path switch message at the relay end of a path");
                         // to avoid nonce re-use, mutate by xor factor
                         nonce ^= session::switch_xor_factor;
                         std::vector<std::byte> bytes;
-                        bytes.resize(path_switch.size() - sizeof(session_tag));
+                        bytes.resize(path_switch.size());
                         std::memcpy(bytes.data(), path_switch.data(), bytes.size());
-                        log::debug(logcat, "Handling incoming session path switch message at the client end of a path");
                         handle_session_control(
                             std::move(bytes), tag, nonce, router.path_context.get_transit_hop_ptr(hop_id));
                     }
                     else
                     {
-#ifndef NDEBUG
-                        session_tag zero_tag;
-                        auto zero_tag_span = std::span{session_init}.last<sizeof(session_tag)>();
-                        zero_tag = oxenc::load_big_to_host<session_tag>(zero_tag_span.data());
-                        assert(zero_tag == 0);
-#endif
+                        log::debug(logcat, "Handling incoming session init message at the relay end of a path");
                         std::vector<std::byte> bytes;
-                        bytes.resize(session_init.size() - sizeof(session_tag));
+                        bytes.resize(session_init.size());
                         std::memcpy(bytes.data(), session_init.data(), bytes.size());
-                        log::debug(logcat, "Handling incoming session init message at the client end of a path");
                         router.session_endpoint().handle_session_init(
                             std::move(bytes), router.path_context.get_transit_hop_ptr(hop_id));
                     }

--- a/llarp/link/link_manager.cpp
+++ b/llarp/link/link_manager.cpp
@@ -1,7 +1,5 @@
 #include "link_manager.hpp"
 
-#include <llarp/session/session.hpp>
-
 #include <llarp/constants/path.hpp>
 #include <llarp/contact/contactdb.hpp>
 #include <llarp/contact/router_id.hpp>
@@ -15,6 +13,7 @@
 #include <llarp/path/path.hpp>
 #include <llarp/path/transit_hop.hpp>
 #include <llarp/router/router.hpp>
+#include <llarp/session/session.hpp>
 #include <llarp/util/bspan.hpp>
 #include <llarp/util/random.hpp>
 #include <llarp/util/time.hpp>

--- a/llarp/link/link_manager.cpp
+++ b/llarp/link/link_manager.cpp
@@ -1,5 +1,7 @@
 #include "link_manager.hpp"
 
+#include <llarp/session/session.hpp>
+
 #include <llarp/constants/path.hpp>
 #include <llarp/contact/contactdb.hpp>
 #include <llarp/contact/router_id.hpp>
@@ -1045,6 +1047,8 @@ namespace llarp::link
                 tag = oxenc::load_big_to_host<session_tag>(tag_span.data());
                 if (router.session_endpoint().get_session(tag))
                 {
+                    // to avoid nonce re-use, mutate by xor factor
+                    nonce ^= session::switch_xor_factor;
                     std::vector<std::byte> bytes;
                     bytes.resize(path_switch.size() - sizeof(session_tag));
                     std::memcpy(bytes.data(), path_switch.data(), bytes.size());
@@ -1144,6 +1148,8 @@ namespace llarp::link
                     tag = oxenc::load_big_to_host<session_tag>(tag_span.data());
                     if (router.session_endpoint().get_session(tag))
                     {
+                        // to avoid nonce re-use, mutate by xor factor
+                        nonce ^= session::switch_xor_factor;
                         std::vector<std::byte> bytes;
                         bytes.resize(path_switch.size() - sizeof(session_tag));
                         std::memcpy(bytes.data(), path_switch.data(), bytes.size());

--- a/llarp/link/link_manager.cpp
+++ b/llarp/link/link_manager.cpp
@@ -951,7 +951,8 @@ namespace llarp::link
     //
     // Warns and returns nullopt if the input vector is too short or the message type byte is
     // invalid (and thus the message should be dropped).
-    static std::optional<std::pair<HopID, SymmNonce>> extract_path_message_metadata(std::vector<std::byte>& message)
+    static std::optional<std::tuple<HopID, SymmNonce, std::byte>> extract_path_message_metadata(
+        std::vector<std::byte>& message)
     {
         if (message.size() < MIN_PATH_DATA_MESSAGE_SIZE)
         {
@@ -963,17 +964,18 @@ namespace llarp::link
         // updated here as well:
         static_assert(path::Path::ENCRYPT_PATH_MESSAGE_OVERHEAD == SymmNonce::SIZE + HopID::SIZE + 1);
 
+        std::optional<std::tuple<HopID, SymmNonce, std::byte>> result;
+        auto& [hop_id, nonce, msgtype] = result.emplace();
+
         // For the detailed structure of this encoding, see description in session/session.cpp
-        std::byte msgtype = message.back();
-        if (msgtype != std::byte{0x01})
+        msgtype = message.back();
+        if (msgtype != std::byte{0x01} && msgtype != std::byte{0x02})
         {
-            log::warning(logcat, "Dropping data message with invalid msgtype {}", std::to_integer<int>(msgtype));
+            log::warning(logcat, "Received path message of unknown type: {}", std::to_integer<int>(msgtype));
             return std::nullopt;
         }
         message.pop_back();
 
-        std::optional<std::pair<HopID, SymmNonce>> result;
-        auto& [hop_id, nonce] = result.emplace();
         hop_id.assign(std::span{message}.last<HopID::SIZE>());
         message.resize(message.size() - HopID::SIZE);
 
@@ -988,7 +990,7 @@ namespace llarp::link
         auto maybe_hop_nonce = extract_path_message_metadata(message);
         if (!maybe_hop_nonce)
             return;
-        auto& [hop_id, nonce] = *maybe_hop_nonce;
+        auto& [hop_id, nonce, msgtype] = *maybe_hop_nonce;
 
         // The remainder of `message` is onion-encrypted.
 
@@ -1025,6 +1027,45 @@ namespace llarp::link
             {
                 crypto::xchacha20(message, hop.shared_secret, nonce);
                 nonce ^= hop.xor_nonce;
+            }
+
+            // NB: path switch is a special case, as it comes bundled as 2 messages:
+            //     a path switch session control message, and
+            //     a session init message
+            if (msgtype == path::Path::PATH_SWITCH_MESSAGE_TYPE)
+            {
+                log::debug(logcat, "client handling path switch/session init message");
+                oxenc::bt_list_consumer btlp{message};
+                auto path_switch = btlp.consume_string_view();
+                auto session_init = btlp.consume_string_view();
+                btlp.finish();
+
+                session_tag tag;
+                auto tag_span = std::span{path_switch}.last<sizeof(session_tag)>();
+                tag = oxenc::load_big_to_host<session_tag>(tag_span.data());
+                if (router.session_endpoint().get_session(tag))
+                {
+                    std::vector<std::byte> bytes;
+                    bytes.resize(path_switch.size() - sizeof(session_tag));
+                    std::memcpy(bytes.data(), path_switch.data(), bytes.size());
+                    log::debug(logcat, "Handling incoming session path switch message at the client end of a path");
+                    handle_session_control(std::move(bytes), tag, nonce, path->shared_from_this());
+                }
+                else
+                {
+#ifndef NDEBUG
+                    session_tag zero_tag;
+                    auto zero_tag_span = std::span{session_init}.last<sizeof(session_tag)>();
+                    zero_tag = oxenc::load_big_to_host<session_tag>(zero_tag_span.data());
+                    assert(zero_tag == 0);
+#endif
+                    std::vector<std::byte> bytes;
+                    bytes.resize(session_init.size() - sizeof(session_tag));
+                    std::memcpy(bytes.data(), session_init.data(), bytes.size());
+                    log::debug(logcat, "Handling incoming session init message at the client end of a path");
+                    router.session_endpoint().handle_session_init(std::move(bytes), path->shared_from_this());
+                }
+                return;
             }
 
             // Client-bound session data has no pivot, just [encrypted][sessiontag], so we extract
@@ -1086,6 +1127,48 @@ namespace llarp::link
                 // Case 2: this is a session data message to this relay; extract the session tag and
                 // then drop everything down to the session payload for handle_session_data to deal
                 // with.
+
+                // NB: path switch is a special case, as it comes bundled as 2 messages:
+                //     a path switch session control message, and
+                //     a session init message
+                if (msgtype == path::Path::PATH_SWITCH_MESSAGE_TYPE)
+                {
+                    log::debug(logcat, "client handling path switch/session init message");
+                    oxenc::bt_list_consumer btlp{message};
+                    auto path_switch = btlp.consume_string_view();
+                    auto session_init = btlp.consume_string_view();
+                    btlp.finish();
+
+                    session_tag tag;
+                    auto tag_span = std::span{path_switch}.last<sizeof(session_tag)>();
+                    tag = oxenc::load_big_to_host<session_tag>(tag_span.data());
+                    if (router.session_endpoint().get_session(tag))
+                    {
+                        std::vector<std::byte> bytes;
+                        bytes.resize(path_switch.size() - sizeof(session_tag));
+                        std::memcpy(bytes.data(), path_switch.data(), bytes.size());
+                        log::debug(logcat, "Handling incoming session path switch message at the client end of a path");
+                        handle_session_control(
+                            std::move(bytes), tag, nonce, router.path_context.get_transit_hop_ptr(hop_id));
+                    }
+                    else
+                    {
+#ifndef NDEBUG
+                        session_tag zero_tag;
+                        auto zero_tag_span = std::span{session_init}.last<sizeof(session_tag)>();
+                        zero_tag = oxenc::load_big_to_host<session_tag>(zero_tag_span.data());
+                        assert(zero_tag == 0);
+#endif
+                        std::vector<std::byte> bytes;
+                        bytes.resize(session_init.size() - sizeof(session_tag));
+                        std::memcpy(bytes.data(), session_init.data(), bytes.size());
+                        log::debug(logcat, "Handling incoming session init message at the client end of a path");
+                        router.session_endpoint().handle_session_init(
+                            std::move(bytes), router.path_context.get_transit_hop_ptr(hop_id));
+                    }
+                    return;
+                }
+
                 session_tag tag;
                 auto tag_span = bsession_tag.first<sizeof(session_tag)>();
                 tag = oxenc::load_big_to_host<session_tag>(tag_span.data());
@@ -1131,14 +1214,14 @@ namespace llarp::link
             // xor happens *before* the xchacha.
 
             static_assert(path::Path::ENCRYPT_PATH_MESSAGE_OVERHEAD == SymmNonce::SIZE + HopID::SIZE + 1);
-            auto [session_payload, bnonce, bhop, msgtype] = split_span_tail<SymmNonce::SIZE, HopID::SIZE, 1>(message);
+            auto [session_payload, bnonce, bhop, bmsgtype] = split_span_tail<SymmNonce::SIZE, HopID::SIZE, 1>(message);
 
             nonce ^= trans_hop->xor_nonce;
             crypto::xchacha20(session_payload, trans_hop->shared_secret, nonce);
 
             nonce.copy_to(bnonce);
             pivot_id.copy_to(bhop);
-            msgtype[0] = std::byte{0x01};
+            bmsgtype[0] = msgtype;
 
             log::trace(logcat, "Pivoting message down another path");
             if (control)
@@ -1160,7 +1243,7 @@ namespace llarp::link
         auto [enc_data, bnonce, bhop, bmsgtype] = split_span_tail<SymmNonce::SIZE, HopID::SIZE, 1>(message);
         nonce.copy_to(bnonce);
         next_hopid.copy_to(bhop);
-        bmsgtype[0] = std::byte{0x01};
+        bmsgtype[0] = msgtype;
 
         if (control)
             endpoint.send_command(next_target, "session_control"s, std::move(message), nullptr);

--- a/llarp/path/path.cpp
+++ b/llarp/path/path.cpp
@@ -290,9 +290,9 @@ namespace llarp::path
             edge().router_id, "path_control", std::move(payload), std::move(decryptor));
     }
 
-    void Path::send_session_control_message(std::vector<std::byte>&& body, SymmNonce&& nonce)
+    void Path::send_session_control_message(std::vector<std::byte>&& body, SymmNonce&& nonce, std::byte type)
     {
-        encrypt_path_message(body, std::move(nonce), CONTROL_MESSAGE_TYPE, false /* mac on session payload */);
+        encrypt_path_message(body, std::move(nonce), type, false /* mac on session payload */);
         _router.link_endpoint().send_command(edge().router_id, "session_control", std::move(body), nullptr);
     }
 

--- a/llarp/path/path.hpp
+++ b/llarp/path/path.hpp
@@ -107,17 +107,18 @@ namespace llarp::path
             const EncryptedClientContact& ecc, int location, std::function<void(path_control_response)> func);
 
         // The constant "type" values that we put on the end of control (stream) and data
-        // (datagram) messages, which currently must always be this value; any other value is
-        // reserved for future use.
-        static constexpr std::byte CONTROL_MESSAGE_TYPE{0x01};
+        // (datagram) messages.  Data message can overlap since it comes on a different channel
         static constexpr std::byte DATA_MESSAGE_TYPE{0x01};
+        static constexpr std::byte CONTROL_MESSAGE_TYPE{0x01};
+        static constexpr std::byte PATH_SWITCH_MESSAGE_TYPE{0x02};
 
         void send_path_data_message(std::vector<std::byte>&& body, SymmNonce&& nonce = SymmNonce::make_random());
 
         void send_path_control_message(
             std::string_view method, std::span<const std::byte> body, std::function<void(path_control_response)> func);
 
-        void send_session_control_message(std::vector<std::byte>&& body, SymmNonce&& nonce);
+        void send_session_control_message(
+            std::vector<std::byte>&& body, SymmNonce&& nonce, std::byte type = CONTROL_MESSAGE_TYPE);
 
         // The overhead added to encrypted path messages (either data messages or path control
         // messages) by the `encrypt_path_message` function.  This is the amount that the

--- a/llarp/path/path_handler.cpp
+++ b/llarp/path/path_handler.cpp
@@ -87,6 +87,17 @@ namespace llarp::path
             log::debug(logcat, "{} expired paths dropped", n);
     }
 
+    void PathHandler::invalidate_paths()
+    {
+        log::trace(logcat, "{} dropping all paths", __PRETTY_FUNCTION__);
+        Lock_t lock{paths_mutex};
+        for (auto itr = _paths.begin(); itr != _paths.end();)
+        {
+            router.path_context.drop(*itr->second);
+            itr = _paths.erase(itr);
+        }
+    }
+
     Path* PathHandler::get_path_by_edge(const HopID& edge_hop_id)
     {
         if (auto it = _paths.find(edge_hop_id); it != _paths.end())

--- a/llarp/path/path_handler.hpp
+++ b/llarp/path/path_handler.hpp
@@ -104,6 +104,10 @@ namespace llarp
 
             void expire_paths(std::chrono::milliseconds now);
 
+            // In case we know none of our paths are still valid, e.g. we received a close on a
+            // relay session so we assume it's restarting.
+            void invalidate_paths();
+
             void add_path(Path& path);
 
             // Returns a random path, or nullptr if there are no paths.

--- a/llarp/session/session.cpp
+++ b/llarp/session/session.cpp
@@ -917,7 +917,7 @@ namespace llarp::session
 
     void OutboundClientSession::tick(std::chrono::milliseconds now)
     {
-        if ((now - last_cc_update > 5min) || (now - last_inbound_activity > 10s))
+        if ((now - last_cc_update > 10min) || (now - last_inbound_activity > 30s))
         {
             log::critical(
                 logcat,

--- a/llarp/session/session.cpp
+++ b/llarp/session/session.cpp
@@ -111,57 +111,57 @@ namespace llarp::session
                                               quic::Stream& stream, std::span<const std::byte> data) mutable {
                     uint16_t dest_port{0};
 
-                    if (data.empty())
-                    {
-                        log::error(logcat, "QUIC stream data callback with no data!");
-                        return;
-                    }
-                    if (prev_byte)
-                    {
-                        std::array<std::byte, 2> buf;
-                        buf[0] = *prev_byte;
-                        buf[1] = data[0];
-                        dest_port = oxenc::load_big_to_host<uint16_t>(buf.data());
-                        data = data.subspan(1);
-                    }
-                    else if (data.size() >= 2)
-                    {
-                        dest_port = oxenc::load_big_to_host<uint16_t>(data.data());
-                        data = data.subspan(2);
-                    }
-                    else
-                    {  // only got 1 byte total so far, need 2 for dest port
-                        prev_byte = data[0];
-                        return;
-                    }
+                                        if (data.empty())
+                                        {
+                                            log::error(logcat, "QUIC stream data callback with no data!");
+                                            return;
+                                        }
+                                        if (prev_byte)
+                                        {
+                                            std::array<std::byte, 2> buf;
+                                            buf[0] = *prev_byte;
+                                            buf[1] = data[0];
+                                            dest_port = oxenc::load_big_to_host<uint16_t>(buf.data());
+                                            data = data.subspan(1);
+                                        }
+                                        else if (data.size() >= 2)
+                                        {
+                                            dest_port = oxenc::load_big_to_host<uint16_t>(data.data());
+                                            data = data.subspan(2);
+                                        }
+                                        else
+                                        {  // only got 1 byte total so far, need 2 for dest port
+                                            prev_byte = data[0];
+                                            return;
+                                        }
 
-                    stream.pause();
+                                        stream.pause();
 
-                    // FIXME: TCPHandle::connect replaces the stream's data callback.  Perhaps
-                    // that should happen here instead.
-                    // FIXME: the connection should probably come from tun bind address, if
-                    // available, rather than always 127.0.0.1
-                    auto tcp_conn = TCPHandle::connect(
-                        session._r.loop.get_event_base(), FAKE_QUIC_ADDR, stream.shared_from_this(), dest_port);
-                    if (!tcp_conn)
-                    {
-                        stream.close(11223322);  // TODO: meaningful error code
-                        return;
-                    }
+                                        // FIXME: TCPHandle::connect replaces the stream's data callback.  Perhaps
+                                        // that should happen here instead.
+                                        // FIXME: the connection should probably come from tun bind address, if
+                                        // available, rather than always 127.0.0.1
+                                        auto tcp_conn = TCPHandle::connect(
+                                            session._r.loop.get_event_base(), FAKE_QUIC_ADDR, stream.shared_from_this(),
+                       dest_port); if (!tcp_conn)
+                                        {
+                                            stream.close(11223322);  // TODO: meaningful error code
+                                            return;
+                                        }
 
-                    _tcp_conns.push_back(tcp_conn);
+                                        _tcp_conns.push_back(tcp_conn);
 
-                    if (data.size())
-                    {
-                        // put any remaining stream data on the tcp socket
-                        stream.data_callback(stream, data);
-                    }
+                                        if (data.size())
+                                        {
+                                            // put any remaining stream data on the tcp socket
+                                            stream.data_callback(stream, data);
+                                        }
 
-                    stream.enable_watermarks(
-                        500'000,
-                        [this, tcp_conn](auto&) { tcp_conn->stop_reading(); },
-                        50'000,
-                        [this, tcp_conn](auto&) { tcp_conn->resume_reading(); });
+                                        stream.enable_watermarks(
+                                            500'000,
+                                            [this, tcp_conn](auto&) { tcp_conn->stop_reading(); },
+                                            50'000,
+                                            [this, tcp_conn](auto&) { tcp_conn->resume_reading(); });
                 });
 */
                 return 0;
@@ -359,6 +359,7 @@ namespace llarp::session
         const SymmNonce& nonce,
         [[maybe_unused]] std::variant<std::shared_ptr<path::TransitHop>, std::shared_ptr<path::Path>> source)
     {
+        last_inbound_activity = llarp::time_now_ms();
         update_active();
         auto decrypted = crypto::xchacha20_poly1305_decrypt(message, _shared_secret, nonce);
         if (decrypted.size() == 0)
@@ -628,6 +629,7 @@ namespace llarp::session
 
     void Session::recv_session_data_message(std::vector<std::byte> data, const SymmNonce& nonce)
     {
+        last_inbound_activity = llarp::time_now_ms();
         update_active();
         if (data.empty())
         {
@@ -695,6 +697,7 @@ namespace llarp::session
         if (auto cc = ecc.decrypt(_remote.router_id()); cc)
         {
             log::debug(logcat, "Session with {} received valid new client contact, updating.", _remote.router_id());
+            _intro_update_processed = false;
             update_intros(*cc);
         }
         else
@@ -893,6 +896,19 @@ namespace llarp::session
         close_old_paths(now);
         path::PathHandler::tick(now);
         fire_waiting(now);
+    }
+
+    void OutboundClientSession::tick(std::chrono::milliseconds now)
+    {
+        if ((now - last_cc_update > 5min) || (now - last_inbound_activity > 10s))
+        {
+            log::critical(
+                logcat,
+                "It has been > 5min since last cc update, or > 10s since last inbound activity; attempting to fetch a "
+                "new intro set for session to {}",
+                _remote);
+            refresh_intros();
+        }
     }
 
     template <typename T>
@@ -1144,14 +1160,19 @@ namespace llarp::session
 
     void OutboundClientSession::refresh_intros()
     {
+        if (updating_intros)
+            return;
+        updating_intros = true;
         log::debug(logcat, "Initiating intro lookup for {}", _remote);
         _parent.lookup_client_intro(
             _remote.router_id(), [this, alive = canary()](std::optional<ClientContact> cc) mutable {
                 if (!alive.lock())
                     return;
+                updating_intros = false;
                 if (cc)
                 {
                     log::debug(logcat, "Session initiation returned client contact: {}", *cc);
+                    _intro_update_processed = false;
                     update_intros(*cc);
                 }
                 else
@@ -1162,6 +1183,7 @@ namespace llarp::session
     void OutboundClientSession::update_intros(const ClientContact& cc)
     {
         log::debug(logcat, "Update session {} intros from client contact: {}", *this, cc);
+        last_cc_update = llarp::time_now_ms();
         auto intros = cc.intros();
         _intros.assign(intros.begin(), intros.end());
         log::trace(logcat, "New client intros: {}", fmt::join(_intros, ", "));
@@ -1184,12 +1206,35 @@ namespace llarp::session
         if (!_intro_update_processed)
         {
             // Intros updated since we last updated, so we may have paths to pivots that are no
-            // longer valid and need to be dropped
-
+            // longer valid and need to be dropped.  Checking that the pivot relay is still
+            // present is not sufficient, as the remote client may have built a new path to that
+            // relay with a different terminal HopID.
+            std::unordered_map<RouterID, std::vector<HopID>> pivots;
+            for (const auto& i : _intros)
+            {
+                auto& p = pivots[i.relay];
+                p.push_back(i.hop);
+            }
             std::list<path::Path*> drop;  // Use a list because it isn't valid to drop while iterating
             for (auto& p : paths())
-                if (!_pivots.count(p.terminal_rid()))
+            {
+                const auto itr = pivots.find(p.terminal_rid());
+                bool keep = false;
+                if (itr != pivots.end())
+                {
+                    for (const auto& hopid : itr->second)
+                    {
+                        if (hopid == p.aligned_hopid)
+                        {
+                            keep = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!keep)
                     drop.push_back(&p);
+            }
 
             for (auto* drop : drop)
                 drop_path(*drop);

--- a/llarp/session/session.cpp
+++ b/llarp/session/session.cpp
@@ -1493,7 +1493,10 @@ namespace llarp::session
     {
         if (_is_established)
         {
-            log::warning(logcat, "Received session accept message, but session already established.");
+            log::debug(
+                logcat,
+                "Received session accept message for established session, likely a path switch failed because the "
+                "remote restarted, so it accepted our backup session init.");
             return;
         }
         oxenc::bt_dict_consumer btdc{params};

--- a/llarp/session/session.cpp
+++ b/llarp/session/session.cpp
@@ -1192,15 +1192,9 @@ namespace llarp::session
                 if (cc)
                 {
                     log::debug(logcat, "Session initiation returned client contact: {}", *cc);
-                    if (current_cc && (*cc == *current_cc))
-                    {
-                        log::debug(logcat, "Client contact received, but is old.");
-                        return;
-                    }
-                    current_cc = std::move(cc);
                     cc_ok = true;
                     _intro_update_processed = false;
-                    update_intros(*current_cc);
+                    update_intros(*cc);
                 }
                 else
                     log::warning(logcat, "Failed to lookup intros for {}", _remote);

--- a/llarp/session/session.cpp
+++ b/llarp/session/session.cpp
@@ -376,7 +376,7 @@ namespace llarp::session
         if (method == "session_accept"sv)
             handle_session_accept(params);
         else if (method == "session_close")
-            _parent.close_session(_inbound_tag, false);
+            recv_close();
         else if (method == "publish_cc"sv)
             handle_client_contact(params);
         else if (method == "path_switch"sv)
@@ -817,6 +817,23 @@ namespace llarp::session
         }
     }
 
+    void Session::recv_close()
+    {
+        _parent.close_session(_inbound_tag, false);
+    }
+
+    void OutboundRelaySession::recv_close()
+    {
+        log::debug(logcat, "OutboundRelaySession received close, manually dropping all paths.");
+        invalidate_paths();
+    }
+
+    void OutboundClientSession::recv_close()
+    {
+        invalidate_paths();
+        cc_ok = false;
+    }
+
     bool Session::is_expired(std::chrono::milliseconds now) const { return now - last_activity > SESSION_TIMEOUT; }
 
     std::string OutboundSession::to_string() const
@@ -1167,13 +1184,23 @@ namespace llarp::session
         _parent.lookup_client_intro(
             _remote.router_id(), [this, alive = canary()](std::optional<ClientContact> cc) mutable {
                 if (!alive.lock())
+                {
+                    log::debug(logcat, "OutboundClientSession::refresh_intros lookup_client_intro callback returning early; session-alive canary is dead");
                     return;
+                }
                 updating_intros = false;
                 if (cc)
                 {
                     log::debug(logcat, "Session initiation returned client contact: {}", *cc);
+                    if (current_cc && (*cc == *current_cc))
+                    {
+                        log::debug(logcat, "Client contact received, but is old.");
+                        return;
+                    }
+                    current_cc = std::move(cc);
+                    cc_ok = true;
                     _intro_update_processed = false;
-                    update_intros(*cc);
+                    update_intros(*current_cc);
                 }
                 else
                     log::warning(logcat, "Failed to lookup intros for {}", _remote);
@@ -1184,6 +1211,7 @@ namespace llarp::session
     {
         log::debug(logcat, "Update session {} intros from client contact: {}", *this, cc);
         last_cc_update = llarp::time_now_ms();
+        last_inbound_activity = last_cc_update; // so we don't just fetch again right away
         auto intros = cc.intros();
         _intros.assign(intros.begin(), intros.end());
         log::trace(logcat, "New client intros: {}", fmt::join(_intros, ", "));
@@ -1191,7 +1219,7 @@ namespace llarp::session
         for (auto& i : _intros)
             _pivots.insert(i.relay);
 
-        update_paths(llarp::time_now_ms());
+        update_paths(last_cc_update);
     }
 
     void OutboundClientSession::update_paths(std::chrono::milliseconds now)
@@ -1200,6 +1228,12 @@ namespace llarp::session
         //   it.
         // - If we killed our currently active path then switch to another.
         // - If we end up with too few paths then start some builds.
+
+        if (!cc_ok)
+        {
+            log::debug(logcat, "{} returning early, client contact empty or no longer usable", __PRETTY_FUNCTION__);
+            return;
+        }
 
         Lock_t l(paths_mutex);
 

--- a/llarp/session/session.cpp
+++ b/llarp/session/session.cpp
@@ -1389,16 +1389,9 @@ namespace llarp::session
                 _remote_pivot_txid,
                 path);
 
-            auto maybe_session_init_msg =
-                make_session_data_message(as_bspan(make_session_init(path)), 0, true, true, dh_nonce);
-            if (!maybe_session_init_msg)
-            {
-                log::warning(logcat, "Failed to create session init message");
-                return;
-            }
+            auto session_init_msg = make_session_init(path);
 
             auto switch_nonce = dh_nonce ^ switch_xor_factor;
-
             oxenc::bt_dict_producer btdp;
             btdp.append("p"sv, path.terminal_hopid().span());
             auto maybe_path_switch_msg = make_session_data_message(
@@ -1408,12 +1401,19 @@ namespace llarp::session
                 log::warning(logcat, "Failed to create path switch message");
                 return;
             }
+            auto& m = maybe_path_switch_msg->first;
+            m.resize(m.size() - (sizeof(session_tag) + HopID::SIZE)); // these go on outer message here
 
             oxenc::bt_list_producer btlp;
             btlp.append(std::move((*maybe_path_switch_msg).first));
-            btlp.append(std::move((*maybe_session_init_msg).first));
+            btlp.append(std::move(session_init_msg));
             auto list_span = btlp.span<std::byte>();
             std::vector<std::byte> payload{list_span.begin(), list_span.end()};
+            auto old_size = payload.size();
+            payload.resize(payload.size() + sizeof(_outbound_tag) + HopID::SIZE); // see make_session_data_message
+            auto [payload_span, tag_span, pivot_span] = split_span(payload, old_size, sizeof(_outbound_tag));
+            oxenc::write_host_as_big(_outbound_tag, tag_span.data());
+            std::memcpy(pivot_span.data(), _remote_pivot_txid.data(), _remote_pivot_txid.size());
             send_path_control_message(std::move(payload), SymmNonce{dh_nonce}, /*path_switch=*/true);
         }
     }
@@ -1570,20 +1570,21 @@ namespace llarp::session
 
     void OutboundSession::handle_session_accept(std::span<const std::byte> params)
     {
-        if (_is_established)
+        bool was_established = _is_established;
+        if (was_established)
         {
             log::debug(
                 logcat,
                 "Received session accept message for established session, likely a path switch failed because the "
                 "remote restarted, so it accepted our backup session init.");
-            return;
         }
+        _is_established = false; // become unestablished if this parsing fails to trigger a new session init
         oxenc::bt_dict_consumer btdc{params};
         _outbound_tag = btdc.require<session_tag>("t"sv);
 
         log::debug(logcat, "Remote provided session tag: {}", _outbound_tag);
 
-        log::trace(logcat, "Outbound session to {} successfully created.", remote());
+        log::trace(logcat, "Outbound session to {} successfully {}established.", remote(), was_established ? "re-"sv : ""sv);
         _is_established = true;
 
         if (pre_establish_data_queue)

--- a/llarp/session/session.cpp
+++ b/llarp/session/session.cpp
@@ -450,7 +450,8 @@ namespace llarp::session
     // TODO FIXME: we could make this take a vector&& as input, and then provide a
     // SESSION_DATA_MESSAGE constant that callers can use to reserve the needed extra storage before
     // moving the vector into here.
-    void Session::send_session_data_message(std::span<const std::byte> data, uint8_t type, bool control, bool init)
+    std::optional<std::pair<std::vector<std::byte>, SymmNonce>> Session::make_session_data_message(
+        std::span<const std::byte> data, uint8_t type, bool control, bool init, SymmNonce nonce)
     {
         log::trace(logcat, "{} called", __PRETTY_FUNCTION__);
 
@@ -458,13 +459,13 @@ namespace llarp::session
         {
             log::debug(logcat, "Session not yet established: queuing packet for delayed delivery");
             queue_data_message(data, type);
-            return;
+            return std::nullopt;
         }
 
         if (_dead_path)
         {
             log::warning(logcat, "Dropping session data message: session has no current path");
-            return;
+            return std::nullopt;
         }
 
         // We use a single nonce for session + path encryption, but noting that path mutations
@@ -488,7 +489,6 @@ namespace llarp::session
         // down the aligned path, each one mutating it with the xor nonce; the final client
         // then undoes all of the far-side nonce mutations to arrive back at N, which it then
         // uses to also decrypt the *session* level encryption.
-        auto nonce = SymmNonce::make_random();
 
         // As this packet is what carries IP data, we want to make it as small as possible, and thus
         // don't use bt-encoding here.  We also build this "backwards" by putting the parts
@@ -594,9 +594,19 @@ namespace llarp::session
 
         if (!init)
             crypto::xchacha20_poly1305_encrypt(ciphertext, _shared_secret, nonce);
+        return std::make_pair(std::move(everything), std::move(nonce));
+    }
 
+    void Session::send_session_data_message(std::span<const std::byte> data, uint8_t type, bool control, bool init)
+    {
+        auto maybe_message = make_session_data_message(data, type, control, init);
+        if (!maybe_message)
+            return;
+
+        auto& everything = (*maybe_message).first;
+        auto& nonce = (*maybe_message).second;
         if (control)
-            send_path_control_message(std::move(everything), std::move(nonce));
+            send_path_control_message(std::move(everything), std::move(nonce), false);
         else
             send_path_data_message(std::move(everything), std::move(nonce));
     }
@@ -846,6 +856,7 @@ namespace llarp::session
     {
         if (on_est)
             on_established(std::move(on_est), est_timeout);
+        std::tie(_shared_secret, dh_pk, dh_nonce) = crypto::dh_client_gen(_remote.router_id());
         // TODO: kick off path builds immediately
     }
 
@@ -916,7 +927,11 @@ namespace llarp::session
     }
 
     static void send_path_control_impl(
-        std::shared_ptr<path::Path>& path, Session& s, std::vector<std::byte>&& data, SymmNonce&& nonce)
+        std::shared_ptr<path::Path>& path,
+        Session& s,
+        std::vector<std::byte>&& data,
+        SymmNonce&& nonce,
+        bool path_switch)
     {
         if (check_dead(path, s))
         {
@@ -929,7 +944,10 @@ namespace llarp::session
             return;
         }
 
-        path->send_session_control_message(std::move(data), std::move(nonce));
+        path->send_session_control_message(
+            std::move(data),
+            std::move(nonce),
+            path_switch ? path::Path::PATH_SWITCH_MESSAGE_TYPE : path::Path::CONTROL_MESSAGE_TYPE);
     }
 
     void OutboundSession::send_path_data_message(std::vector<std::byte>&& data, SymmNonce&& nonce)
@@ -943,15 +961,16 @@ namespace llarp::session
         send_path_data_impl(_current_path, *this, std::move(data), std::move(nonce));
     }
 
-    void OutboundSession::send_path_control_message(std::vector<std::byte>&& data, SymmNonce&& nonce)
+    void OutboundSession::send_path_control_message(std::vector<std::byte>&& data, SymmNonce&& nonce, bool path_switch)
     {
         update_active();
-        send_path_control_impl(_current_path, *this, std::move(data), std::move(nonce));
+        send_path_control_impl(_current_path, *this, std::move(data), std::move(nonce), path_switch);
     }
-    void InboundClientSession::send_path_control_message(std::vector<std::byte>&& data, SymmNonce&& nonce)
+    void InboundClientSession::send_path_control_message(
+        std::vector<std::byte>&& data, SymmNonce&& nonce, bool path_switch)
     {
         update_active();
-        send_path_control_impl(_current_path, *this, std::move(data), std::move(nonce));
+        send_path_control_impl(_current_path, *this, std::move(data), std::move(nonce), path_switch);
     }
 
     void OutboundSession::close_old_paths(std::chrono::milliseconds now)
@@ -1236,7 +1255,7 @@ namespace llarp::session
         log::debug(logcat, "Initiated {} path builds for {}", count, _remote);
     }
 
-    void OutboundSession::session_init(path::Path& path)
+    std::string OutboundSession::make_session_init(path::Path& path)
     {
         oxenc::bt_dict_producer inner_btdp;
 
@@ -1252,17 +1271,15 @@ namespace llarp::session
 
         auto inner_payload = std::move(inner_btdp).str();
         inner_payload.resize(inner_payload.size() + crypto::MAC_SIZE);
-        auto [secret, eph_pk, dh_nonce] = crypto::dh_client_gen(_remote.router_id());
-        _shared_secret = secret;
-        crypto::xchacha20_poly1305_encrypt(inner_payload, secret, dh_nonce);
+        crypto::xchacha20_poly1305_encrypt(inner_payload, _shared_secret, dh_nonce);
 
         oxenc::bt_dict_producer btdp;
 
-        btdp.append("k", eph_pk.span());
+        btdp.append("k", dh_pk.span());
         btdp.append("n", dh_nonce.span());
         btdp.append("x", inner_payload);
 
-        send_session_data_message(btdp.span<std::byte>(), 0, true, true);
+        return std::move(btdp).str();
     }
 
     void OutboundSession::switch_path(path::Path& path, const HopID& pivot_hopid)
@@ -1281,7 +1298,8 @@ namespace llarp::session
                 _remote.client() ? "Aligned path for" : "Path to",
                 _remote);
 
-            session_init(path);
+            auto msg = make_session_init(path);
+            send_session_data_message(as_bspan(msg), 0, true, true);
         }
         else
         {
@@ -1292,9 +1310,32 @@ namespace llarp::session
                 _remote_pivot_txid,
                 path);
 
+            auto maybe_session_init_msg =
+                make_session_data_message(as_bspan(make_session_init(path)), 0, true, true, dh_nonce);
+            if (!maybe_session_init_msg)
+            {
+                log::warning(logcat, "Failed to create session init message");
+                return;
+            }
+
+            auto switch_nonce = dh_nonce ^ switch_xor_factor;
+
             oxenc::bt_dict_producer btdp;
             btdp.append("p"sv, path.terminal_hopid().span());
-            send_session_control_message("path_switch"sv, btdp.span<std::byte>());
+            auto maybe_path_switch_msg = make_session_data_message(
+                PATH::CONTROL::serialize("path_switch"sv, btdp.span<std::byte>()), 0, true, false, switch_nonce);
+            if (!maybe_path_switch_msg)
+            {
+                log::warning(logcat, "Failed to create path switch message");
+                return;
+            }
+
+            oxenc::bt_list_producer btlp;
+            btlp.append(std::move((*maybe_path_switch_msg).first));
+            btlp.append(std::move((*maybe_session_init_msg).first));
+            auto list_span = btlp.span<std::byte>();
+            std::vector<std::byte> payload{list_span.begin(), list_span.end()};
+            send_path_control_message(std::move(payload), SymmNonce{dh_nonce}, /*path_switch=*/true);
         }
     }
 
@@ -1523,7 +1564,8 @@ namespace llarp::session
         _parent.router.link_endpoint().send_datagram(_current_thop->downstream, std::move(data));
     }
 
-    void InboundRelaySession::send_path_control_message(std::vector<std::byte>&& data, SymmNonce&& nonce)
+    void InboundRelaySession::send_path_control_message(
+        std::vector<std::byte>&& data, SymmNonce&& nonce, bool path_switch)
     {
         update_active();
         if (check_dead(_current_thop, *this))

--- a/llarp/session/session.hpp
+++ b/llarp/session/session.hpp
@@ -115,6 +115,10 @@ namespace llarp
             uint16_t next_udp_client_port{1024};
             std::chrono::milliseconds last_activity = llarp::time_now_ms();
 
+            // only currently useful for outbound client sessions, but more convenient here
+            // than an overload on all inbound traffic functions for that one case
+            std::chrono::milliseconds last_inbound_activity = llarp::time_now_ms();
+
             void update_active();
 
             // We capture a weak_ptr to this shared_ptr to avoid needing to use shared_from_this
@@ -344,6 +348,9 @@ namespace llarp
             std::vector<ClientIntro> _intros;
             std::unordered_set<RouterID> _pivots;
             bool _intro_update_processed = false;
+            bool updating_intros = true;
+
+            std::chrono::milliseconds last_cc_update = 0s;
 
             // Chooses the next router id to pivot to, based on introset and current paths.  Returns
             // nullopt if no pivot is available right now, otherwise the router id and the lifetime
@@ -360,6 +367,8 @@ namespace llarp
             // Initiates a client intro lookup via the session endpoint.  This can be called even if
             // there already is intros, to refresh/replace them.
             void refresh_intros();
+
+            void tick(std::chrono::milliseconds now) override;
 
             // Called with a client contact to replace the current set of client intros used by this
             // session with the ones in the given client contact.  This is called by

--- a/llarp/session/session.hpp
+++ b/llarp/session/session.hpp
@@ -355,7 +355,6 @@ namespace llarp
             bool updating_intros = false;
 
             std::chrono::milliseconds last_cc_update = 0s;
-            std::optional<ClientContact> current_cc{std::nullopt};
             bool cc_ok = false;
 
             // Chooses the next router id to pivot to, based on introset and current paths.  Returns

--- a/llarp/session/session.hpp
+++ b/llarp/session/session.hpp
@@ -221,6 +221,8 @@ namespace llarp
             // send a session_close control message down the active path.
             void close(bool send_close);
 
+            virtual void recv_close();
+
             bool is_expired(std::chrono::milliseconds now) const;
 
             virtual std::string to_string() const = 0;
@@ -327,6 +329,8 @@ namespace llarp
 
             void update_paths(std::chrono::milliseconds now) override;
 
+            void recv_close() override;
+
             // void stop(bool send_close = false) override;
 
           private:
@@ -348,9 +352,11 @@ namespace llarp
             std::vector<ClientIntro> _intros;
             std::unordered_set<RouterID> _pivots;
             bool _intro_update_processed = false;
-            bool updating_intros = true;
+            bool updating_intros = false;
 
             std::chrono::milliseconds last_cc_update = 0s;
+            std::optional<ClientContact> current_cc{std::nullopt};
+            bool cc_ok = false;
 
             // Chooses the next router id to pivot to, based on introset and current paths.  Returns
             // nullopt if no pivot is available right now, otherwise the router id and the lifetime
@@ -377,6 +383,8 @@ namespace llarp
             void update_intros(const ClientContact& cc);
 
             void update_paths(std::chrono::milliseconds now) override;
+
+            void recv_close() override;
 
             nlohmann::json ExtractStatus() const;
 

--- a/llarp/session/session.hpp
+++ b/llarp/session/session.hpp
@@ -8,6 +8,7 @@
 #include <llarp/path/path.hpp>
 #include <llarp/path/path_handler.hpp>
 #include <llarp/path/transit_hop.hpp>
+#include <llarp/util/bspan.hpp>
 
 #include <oxen/quic/btstream.hpp>
 #include <oxen/quic/connection.hpp>
@@ -47,6 +48,11 @@ namespace llarp
 
         struct TCPTunnel;
 
+        // We must not use the same nonce for path switch and session init, as they can be in the
+        // same message using the same shared secret.  As such, the path switch message will use
+        // dh_nonce ^ this xor factor.
+        inline const SymmNonce switch_xor_factor = SymmNonce::filled<SymmNonce>(0x42);
+
         class Session
         {
             // TODO FIXME: how long since last use should is_expired() return true?
@@ -67,6 +73,8 @@ namespace llarp
 
             NetworkAddress _remote;
 
+            PubKey dh_pk;
+            SymmNonce dh_nonce;
             SharedSecret _shared_secret;
 
             // used for bridging data messages across aligned paths
@@ -162,11 +170,18 @@ namespace llarp
             virtual void handle_session_accept(std::span<const std::byte> params);
 
             void send_session_data_message(std::span<const std::byte> data, net::IPProtocol proto);
+            std::optional<std::pair<std::vector<std::byte>, SymmNonce>> make_session_data_message(
+                std::span<const std::byte> data,
+                uint8_t type,
+                bool control = false,
+                bool init = false,
+                SymmNonce nonce = SymmNonce::make_random());
             void send_session_data_message(
                 std::span<const std::byte> data, uint8_t type, bool control = false, bool init = false);
 
             virtual void send_path_data_message(std::vector<std::byte>&& data, SymmNonce&& nonce) = 0;
-            virtual void send_path_control_message(std::vector<std::byte>&& data, SymmNonce&& nonce) = 0;
+            virtual void send_path_control_message(
+                std::vector<std::byte>&& data, SymmNonce&& nonce, bool path_switch) = 0;
 
             // Called by send_session_data_message if trying to send a data message on a
             // not-yet-established connection (which, by definition, can only be an outbound
@@ -233,10 +248,6 @@ namespace llarp
                 std::vector<std::pair<path::Path*, HopID>>&& good,
                 std::vector<std::pair<path::Path*, HopID>>&& fallback);
 
-            // Switches (or starts using) the given path.  If there currently is no path, this will
-            // call any waiting on-established callbacks.
-            void switch_path(path::Path& p, const HopID& new_pivot_txid);
-
             void tick(std::chrono::milliseconds now) override;
 
             virtual void select_new_current() = 0;
@@ -246,7 +257,7 @@ namespace llarp
             void close_old_paths(std::chrono::milliseconds now);
 
             void send_path_data_message(std::vector<std::byte>&& data, SymmNonce&& nonce) override;
-            void send_path_control_message(std::vector<std::byte>&& data, SymmNonce&& nonce) override;
+            void send_path_control_message(std::vector<std::byte>&& data, SymmNonce&& nonce, bool path_switch) override;
 
             void queue_data_message(std::span<const std::byte>, uint8_t type) override;
 
@@ -254,7 +265,10 @@ namespace llarp
             std::optional<std::deque<std::vector<std::byte>>> pre_establish_data_queue;
 
           private:
-            void session_init(path::Path& path);
+            // Switches to (or starts using) the given path.
+            void switch_path(path::Path& p, const HopID& new_pivot_txid);
+
+            std::string make_session_init(path::Path& path);
 
             void fire_waiting(std::chrono::milliseconds now);
 
@@ -379,7 +393,7 @@ namespace llarp
             std::shared_ptr<path::Path> _current_path;
 
             void send_path_data_message(std::vector<std::byte>&& data, SymmNonce&& nonce) override;
-            void send_path_control_message(std::vector<std::byte>&& data, SymmNonce&& nonce) override;
+            void send_path_control_message(std::vector<std::byte>&& data, SymmNonce&& nonce, bool path_switch) override;
 
           public:
             InboundClientSession(
@@ -399,7 +413,7 @@ namespace llarp
 
             void send_path_data_message(std::vector<std::byte>&& data, SymmNonce&& nonce) override;
 
-            void send_path_control_message(std::vector<std::byte>&& data, SymmNonce&& nonce) override;
+            void send_path_control_message(std::vector<std::byte>&& data, SymmNonce&& nonce, bool path_switch) override;
 
           public:
             InboundRelaySession(

--- a/llarp/util/aligned.hpp
+++ b/llarp/util/aligned.hpp
@@ -190,6 +190,15 @@ namespace llarp
         // Used in log statements to log the value as its first 8 base32z characters:
         short_log_printer short_string() const { return {*this}; }
 
+        template <typename T>
+            requires(std::derived_from<T, AlignedBuffer<T::SIZE>>)
+        static T filled(uint8_t f)
+        {
+            T ret;
+            ret.Fill(f);
+            return ret;
+        }
+
       private:
         std::array<uint8_t, SIZE> _data;
     };


### PR DESCRIPTION
builds on top of #2274

In cases where the inbound side of a session closes (e.g. the process restarts), it is useful for the outbound side of that session to carry on as if this never happened.  Now path switch messages are bundled with the original session init so that the inbound side can accept a new session if it doesn't recognize it.  The outbound side *does* need to update the outbound session tag when it receives the new session accept message, but otherwise this is transparent.

Note: this will break TCP tunneling once that is implemented, but I don't think there's much we can do about that.